### PR TITLE
feat(ledger): add jpa entities and repositories for ledger aggregates

### DIFF
--- a/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/infrastructure/persistence/LedgerAggregatePersistenceIT.kt
+++ b/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/infrastructure/persistence/LedgerAggregatePersistenceIT.kt
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.infrastructure.persistence
+
+import com.fincore.ledger.domain.enum.AccountStatus
+import com.fincore.ledger.domain.enum.AccountType
+import com.fincore.ledger.domain.enum.EntryDirection
+import com.fincore.ledger.domain.enum.TransactionStatus
+import com.fincore.test.containers.PostgresContainerExtension
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager
+import org.springframework.orm.ObjectOptimisticLockingFailureException
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.UUID
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ExtendWith(PostgresContainerExtension::class)
+class LedgerAggregatePersistenceIT(
+    @Autowired private val accountRepository: AccountRepository,
+    @Autowired private val transactionRepository: TransactionRepository,
+    @Autowired private val entryRepository: EntryRepository,
+    @Autowired private val balanceRepository: AccountBalanceRepository,
+    @Autowired private val entityManager: TestEntityManager,
+) {
+    private val instant = Instant.parse("2026-06-05T12:00:00Z")
+
+    private fun newAccount(id: UUID = UUID.randomUUID()) =
+        AccountEntity(
+            id = id,
+            name = "Operating wallet",
+            type = AccountType.USER_WALLET,
+            currency = "USD",
+            status = AccountStatus.ACTIVE,
+            metadata = "{\"tier\": \"gold\"}",
+            version = 0,
+            createdAt = instant,
+            createdBy = "auth0|operator",
+            updatedAt = instant,
+            updatedBy = "auth0|operator",
+        )
+
+    @Test
+    fun `should round trip an account with enum metadata and version`() {
+        val id = UUID.randomUUID()
+        accountRepository.saveAndFlush(newAccount(id))
+        entityManager.clear()
+
+        val loaded = accountRepository.findById(id).orElseThrow()
+        loaded.name shouldBe "Operating wallet"
+        loaded.type shouldBe AccountType.USER_WALLET
+        loaded.status shouldBe AccountStatus.ACTIVE
+        loaded.currency shouldBe "USD"
+        loaded.metadata.contains("gold") shouldBe true
+        loaded.version shouldBe 0
+    }
+
+    @Test
+    fun `should increment account version on update`() {
+        val id = UUID.randomUUID()
+        accountRepository.saveAndFlush(newAccount(id))
+        entityManager.clear()
+
+        val loaded = accountRepository.findById(id).orElseThrow()
+        loaded.status = AccountStatus.FROZEN
+        accountRepository.saveAndFlush(loaded)
+
+        accountRepository.findById(id).orElseThrow().version shouldBe 1
+    }
+
+    @Test
+    fun `should reject a stale account write with optimistic lock failure`() {
+        val id = UUID.randomUUID()
+        accountRepository.saveAndFlush(newAccount(id))
+        entityManager.clear()
+
+        val current = accountRepository.findById(id).orElseThrow()
+        current.status = AccountStatus.FROZEN
+        accountRepository.saveAndFlush(current)
+        entityManager.clear()
+
+        val stale = newAccount(id).apply { version = 0 }
+        shouldThrow<ObjectOptimisticLockingFailureException> {
+            accountRepository.saveAndFlush(stale)
+        }
+    }
+
+    @Test
+    fun `should round trip an insert only transaction`() {
+        val id = UUID.randomUUID()
+        transactionRepository.saveAndFlush(
+            TransactionEntity(
+                id = id,
+                reference = "ref-$id",
+                description = null,
+                status = TransactionStatus.POSTED,
+                reversesId = null,
+                metadata = "{}",
+                postedAt = instant,
+                createdAt = instant,
+                createdBy = "auth0|operator",
+            ),
+        )
+        entityManager.clear()
+
+        val loaded = transactionRepository.findById(id).orElseThrow()
+        loaded.reference shouldBe "ref-$id"
+        loaded.status shouldBe TransactionStatus.POSTED
+        loaded.description shouldBe null
+        loaded.reversesId shouldBe null
+    }
+
+    @Test
+    fun `should round trip an entry preserving 18 digit money scale and composite key`() {
+        val accountId = UUID.randomUUID()
+        accountRepository.saveAndFlush(newAccount(accountId))
+        val txId = UUID.randomUUID()
+        transactionRepository.saveAndFlush(
+            TransactionEntity(
+                id = txId,
+                reference = "ref-$txId",
+                description = null,
+                status = TransactionStatus.POSTED,
+                reversesId = null,
+                metadata = "{}",
+                postedAt = instant,
+                createdAt = instant,
+                createdBy = "auth0|operator",
+            ),
+        )
+        val amount = BigDecimal("12345.123456789012345678")
+        val key = EntryKey(id = UUID.randomUUID(), createdAt = instant)
+        entryRepository.saveAndFlush(
+            EntryEntity(
+                key = key,
+                transactionId = txId,
+                accountId = accountId,
+                amount = amount,
+                currency = "EUR",
+                direction = EntryDirection.DEBIT,
+                postedAt = instant,
+            ),
+        )
+        entityManager.clear()
+
+        val loaded = entryRepository.findById(key).orElseThrow()
+        loaded.amount.scale() shouldBe 18
+        (loaded.amount.compareTo(amount) == 0) shouldBe true
+        loaded.direction shouldBe EntryDirection.DEBIT
+        loaded.currency shouldBe "EUR"
+    }
+
+    @Test
+    fun `should round trip an account balance with precision and version`() {
+        val accountId = UUID.randomUUID()
+        accountRepository.saveAndFlush(newAccount(accountId))
+        val key = AccountBalanceKey(accountId = accountId, currency = "USD")
+        val balance = BigDecimal("999.000000000000000001")
+        balanceRepository.saveAndFlush(
+            AccountBalanceEntity(
+                key = key,
+                balance = balance,
+                lastPostedAt = instant,
+                version = 0,
+            ),
+        )
+        entityManager.clear()
+
+        val loaded = balanceRepository.findById(key).orElseThrow()
+        loaded.balance.scale() shouldBe 18
+        (loaded.balance.compareTo(balance) == 0) shouldBe true
+        loaded.version shouldBe 0
+    }
+
+    companion object {
+        @JvmStatic
+        @DynamicPropertySource
+        fun datasourceProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { PostgresContainerExtension.jdbcUrl }
+            registry.add("spring.datasource.username") { PostgresContainerExtension.username }
+            registry.add("spring.datasource.password") { PostgresContainerExtension.password }
+            registry.add("spring.jpa.hibernate.ddl-auto") { "none" }
+        }
+    }
+}

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/AccountBalanceEntity.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/AccountBalanceEntity.kt
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.infrastructure.persistence
+
+import jakarta.persistence.Column
+import jakarta.persistence.EmbeddedId
+import jakarta.persistence.Entity
+import jakarta.persistence.Table
+import jakarta.persistence.Version
+import java.math.BigDecimal
+import java.time.Instant
+
+@Entity
+@Table(name = "account_balances", schema = "ledger")
+class AccountBalanceEntity(
+    @EmbeddedId
+    var key: AccountBalanceKey,
+    @Column(name = "balance", nullable = false, precision = 38, scale = 18)
+    var balance: BigDecimal,
+    @Column(name = "last_posted_at", nullable = false)
+    var lastPostedAt: Instant,
+    @Version
+    @Column(name = "version", nullable = false)
+    var version: Long,
+)

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/AccountBalanceKey.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/AccountBalanceKey.kt
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.infrastructure.persistence
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import java.io.Serializable
+import java.util.UUID
+
+// Composite key mirrors the PK (account_id, currency) on ledger.account_balances.
+@Embeddable
+data class AccountBalanceKey(
+    @Column(name = "account_id", nullable = false, updatable = false)
+    var accountId: UUID,
+    @Column(name = "currency", nullable = false, updatable = false)
+    var currency: String,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/AccountBalanceRepository.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/AccountBalanceRepository.kt
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.infrastructure.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface AccountBalanceRepository : JpaRepository<AccountBalanceEntity, AccountBalanceKey>

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/AccountEntity.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/AccountEntity.kt
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.infrastructure.persistence
+
+import com.fincore.ledger.domain.enum.AccountStatus
+import com.fincore.ledger.domain.enum.AccountType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import jakarta.persistence.Version
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(name = "accounts", schema = "ledger")
+@Suppress("LongParameterList")
+class AccountEntity(
+    @Id
+    @Column(name = "id", nullable = false, updatable = false)
+    var id: UUID,
+    @Column(name = "name", nullable = false)
+    var name: String,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "type", nullable = false, updatable = false)
+    var type: AccountType,
+    @Column(name = "currency", nullable = false, updatable = false)
+    var currency: String,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    var status: AccountStatus,
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "metadata", nullable = false)
+    var metadata: String,
+    @Version
+    @Column(name = "version", nullable = false)
+    var version: Long,
+    @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: Instant,
+    @Column(name = "created_by", nullable = false, updatable = false)
+    var createdBy: String,
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: Instant,
+    @Column(name = "updated_by", nullable = false)
+    var updatedBy: String,
+)

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/AccountRepository.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/AccountRepository.kt
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.infrastructure.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface AccountRepository : JpaRepository<AccountEntity, UUID>

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/EntryEntity.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/EntryEntity.kt
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.infrastructure.persistence
+
+import com.fincore.ledger.domain.enum.EntryDirection
+import jakarta.persistence.Column
+import jakarta.persistence.EmbeddedId
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Table
+import org.hibernate.annotations.Immutable
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Immutable
+@Table(name = "entries", schema = "ledger")
+@Suppress("LongParameterList")
+class EntryEntity(
+    @EmbeddedId
+    var key: EntryKey,
+    @Column(name = "transaction_id", nullable = false, updatable = false)
+    var transactionId: UUID,
+    @Column(name = "account_id", nullable = false, updatable = false)
+    var accountId: UUID,
+    @Column(name = "amount", nullable = false, updatable = false, precision = 38, scale = 18)
+    var amount: BigDecimal,
+    @Column(name = "currency", nullable = false, updatable = false)
+    var currency: String,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "direction", nullable = false, updatable = false)
+    var direction: EntryDirection,
+    @Column(name = "posted_at", nullable = false, updatable = false)
+    var postedAt: Instant,
+)

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/EntryKey.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/EntryKey.kt
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.infrastructure.persistence
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import java.io.Serializable
+import java.time.Instant
+import java.util.UUID
+
+// Composite key mirrors the partitioned PK (id, created_at) on ledger.entries.
+@Embeddable
+data class EntryKey(
+    @Column(name = "id", nullable = false, updatable = false)
+    var id: UUID,
+    @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: Instant,
+) : Serializable {
+    companion object {
+        private const val serialVersionUID: Long = 1L
+    }
+}

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/EntryRepository.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/EntryRepository.kt
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.infrastructure.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface EntryRepository : JpaRepository<EntryEntity, EntryKey>

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/TransactionEntity.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/TransactionEntity.kt
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.infrastructure.persistence
+
+import com.fincore.ledger.domain.enum.TransactionStatus
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.Immutable
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Immutable
+@Table(name = "transactions", schema = "ledger")
+@Suppress("LongParameterList")
+class TransactionEntity(
+    @Id
+    @Column(name = "id", nullable = false, updatable = false)
+    var id: UUID,
+    @Column(name = "reference", nullable = false, updatable = false)
+    var reference: String,
+    @Column(name = "description", updatable = false)
+    var description: String?,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    var status: TransactionStatus,
+    @Column(name = "reverses_id", updatable = false)
+    var reversesId: UUID?,
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "metadata", nullable = false)
+    var metadata: String,
+    @Column(name = "posted_at", nullable = false, updatable = false)
+    var postedAt: Instant,
+    @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: Instant,
+    @Column(name = "created_by", nullable = false, updatable = false)
+    var createdBy: String,
+)

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/TransactionRepository.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/TransactionRepository.kt
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.infrastructure.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface TransactionRepository : JpaRepository<TransactionEntity, UUID>


### PR DESCRIPTION
## What

JPA persistence layer for the four ledger aggregate tables, completing the data layer before application services (F-01.3).

- `AccountEntity`, `TransactionEntity`, `EntryEntity`, `AccountBalanceEntity` (class, not data class per §8.5)
- Spring Data `JpaRepository` for each
- `@EmbeddedId` composite keys: `EntryKey(id, created_at)` and `AccountBalanceKey(account_id, currency)`
- `@Version` on the mutable `Account` and `AccountBalance` aggregates; `@Immutable` on insert-only `Transaction`/`Entry`
- Enums stored `EnumType.STRING`; money maps to `NUMERIC(38,18)` via `BigDecimal`
- `LedgerAggregatePersistenceIT`: 6 pg17 round-trip tests (money 18-digit precision, enum string storage, composite-key retrieval, `@Version` increment + stale-write optimistic-lock rejection)

## Scope note: #33 (mappers) deferred

`kaptKotlin` proved MapStruct 1.6.3 cannot construct the value-class domain aggregates (`Account does not have an accessible constructor` - `AccountId`/`Currency`/`Money` `@JvmInline value class` constructor params are inaccessible to MapStruct-generated Java). Also `Transaction` has no 1:1 table mapping (needs its entries from a separate table + `init` validation) and `account_balances` has no domain type. MapStruct stays mandated for entity<->DTO (REST slice F-01.5); domain reconstruction moves to the services slice (F-01.3) as aggregate assembly.

## Verification

Local: `:test`, `:spotlessCheck`, `:detekt`, `:compileIntegrationTestKotlin`, `:assemble` all BUILD SUCCESSFUL. The integration test runs on CI (Testcontainers/Docker); it is env-blocked under local WSL, same as the existing `PlatformPersistenceIT`. No migration touched.

Closes #31
Closes #32