### PR TITLE
feat(ledger): add transaction posting and balance services

### DIFF
--- a/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/application/TransactionBalanceServiceIT.kt
+++ b/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/application/TransactionBalanceServiceIT.kt
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.application
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fincore.core.Currency
+import com.fincore.ledger.domain.enum.AccountStatus
+import com.fincore.ledger.domain.enum.AccountType
+import com.fincore.ledger.domain.enum.EntryDirection
+import com.fincore.ledger.domain.exception.DomainException
+import com.fincore.ledger.domain.exception.DoubleEntryViolationException
+import com.fincore.ledger.domain.exception.DuplicateTransactionException
+import com.fincore.ledger.infrastructure.persistence.AccountPersistenceAdapter
+import com.fincore.ledger.infrastructure.persistence.OutboxEventRepository
+import com.fincore.ledger.infrastructure.persistence.TransactionPersistenceAdapter
+import com.fincore.test.containers.PostgresContainerExtension
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import java.math.BigDecimal
+import java.time.Instant
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ExtendWith(PostgresContainerExtension::class)
+@Import(
+    TransactionServiceImpl::class,
+    TransactionPoster::class,
+    TransactionPersistenceAdapter::class,
+    BalanceServiceImpl::class,
+    AccountServiceImpl::class,
+    AccountPersistenceAdapter::class,
+    TransactionBalanceServiceIT.JacksonConfig::class,
+)
+class TransactionBalanceServiceIT(
+    @Autowired private val transactionService: TransactionService,
+    @Autowired private val balanceService: BalanceService,
+    @Autowired private val accountService: AccountService,
+    @Autowired private val outboxRepository: OutboxEventRepository,
+) {
+    @TestConfiguration
+    class JacksonConfig {
+        @Bean
+        fun objectMapper(): ObjectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+    }
+
+    private fun newAccount(currency: Currency = Currency.USD) =
+        accountService.create(CreateAccountCommand("Account", AccountType.USER_WALLET, currency, "op"))
+
+    private fun command(
+        reference: String,
+        debitAccount: com.fincore.core.AccountId,
+        creditAccount: com.fincore.core.AccountId,
+        currency: Currency = Currency.USD,
+        debit: BigDecimal = BigDecimal("100.00"),
+        credit: BigDecimal = BigDecimal("-100.00"),
+    ) = PostTransactionCommand(
+        reference = reference,
+        description = null,
+        currency = currency,
+        entries =
+            listOf(
+                EntryLine(debitAccount, EntryDirection.DEBIT, debit),
+                EntryLine(creditAccount, EntryDirection.CREDIT, credit),
+            ),
+        actor = "op",
+        correlationId = "corr-1",
+    )
+
+    @Test
+    fun `should post a balanced transaction and update both balances and the outbox`() {
+        val debit = newAccount()
+        val credit = newAccount()
+
+        transactionService.post(command("ref-1", debit.id, credit.id))
+
+        balanceService
+            .current(debit.id, Currency.USD)
+            .amount.amount
+            .compareTo(BigDecimal("100.00")) shouldBe 0
+        balanceService
+            .current(credit.id, Currency.USD)
+            .amount.amount
+            .compareTo(BigDecimal("-100.00")) shouldBe 0
+        val events = outboxRepository.findAll()
+        events.size shouldBe 1
+        events.first().eventType shouldBe "com.fincore.ledger.transaction.posted.v1"
+    }
+
+    @Test
+    fun `should reject an unbalanced transaction`() {
+        val debit = newAccount()
+        val credit = newAccount()
+
+        shouldThrow<DoubleEntryViolationException> {
+            transactionService.post(command("ref-2", debit.id, credit.id, credit = BigDecimal("-90.00")))
+        }
+        outboxRepository.findAll().size shouldBe 0
+    }
+
+    @Test
+    fun `should reject posting to a frozen account`() {
+        val debit = newAccount()
+        val credit = newAccount()
+        accountService.changeStatus(debit.id, AccountStatus.FROZEN, "op")
+
+        shouldThrow<DomainException> { transactionService.post(command("ref-3", debit.id, credit.id)) }
+    }
+
+    @Test
+    fun `should reject a currency mismatch`() {
+        val debit = newAccount(Currency.USD)
+        val credit = newAccount(Currency.USD)
+
+        shouldThrow<DomainException> {
+            transactionService.post(command("ref-4", debit.id, credit.id, currency = Currency.EUR))
+        }
+    }
+
+    @Test
+    fun `should reject a duplicate reference`() {
+        val debit = newAccount()
+        val credit = newAccount()
+        transactionService.post(command("ref-5", debit.id, credit.id))
+
+        shouldThrow<DuplicateTransactionException> {
+            transactionService.post(command("ref-5", debit.id, credit.id))
+        }
+    }
+
+    @Test
+    fun `should time-travel the balance with asOf`() {
+        val debit = newAccount()
+        val credit = newAccount()
+        transactionService.post(command("ref-6", debit.id, credit.id))
+
+        balanceService
+            .asOf(debit.id, Currency.USD, Instant.now().plusSeconds(3600))
+            .amount.amount
+            .compareTo(BigDecimal("100.00")) shouldBe 0
+        balanceService
+            .asOf(debit.id, Currency.USD, Instant.parse("2020-01-01T00:00:00Z"))
+            .amount
+            .isZero() shouldBe true
+    }
+
+    companion object {
+        @JvmStatic
+        @DynamicPropertySource
+        fun datasourceProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { PostgresContainerExtension.jdbcUrl }
+            registry.add("spring.datasource.username") { PostgresContainerExtension.username }
+            registry.add("spring.datasource.password") { PostgresContainerExtension.password }
+            registry.add("spring.jpa.hibernate.ddl-auto") { "none" }
+        }
+    }
+}

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/application/AccountBalance.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/application/AccountBalance.kt
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.application
+
+import com.fincore.core.AccountId
+import com.fincore.core.Money
+import java.time.Instant
+
+data class AccountBalance(
+    val accountId: AccountId,
+    val amount: Money,
+    val lastPostedAt: Instant?,
+)

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/application/BalanceService.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/application/BalanceService.kt
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.application
+
+import com.fincore.core.AccountId
+import com.fincore.core.Currency
+import java.time.Instant
+
+interface BalanceService {
+    fun current(
+        accountId: AccountId,
+        currency: Currency,
+    ): AccountBalance
+
+    fun asOf(
+        accountId: AccountId,
+        currency: Currency,
+        instant: Instant,
+    ): AccountBalance
+}

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/application/BalanceServiceImpl.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/application/BalanceServiceImpl.kt
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.application
+
+import com.fincore.core.AccountId
+import com.fincore.core.Currency
+import com.fincore.core.Money
+import com.fincore.ledger.infrastructure.persistence.AccountBalanceKey
+import com.fincore.ledger.infrastructure.persistence.AccountBalanceRepository
+import com.fincore.ledger.infrastructure.persistence.EntryRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+@Service
+class BalanceServiceImpl(
+    private val balanceRepository: AccountBalanceRepository,
+    private val entryRepository: EntryRepository,
+) : BalanceService {
+    @Transactional(readOnly = true)
+    override fun current(
+        accountId: AccountId,
+        currency: Currency,
+    ): AccountBalance {
+        val row = balanceRepository.findById(AccountBalanceKey(accountId.value, currency.code)).orElse(null)
+        return if (row == null) {
+            AccountBalance(accountId, Money.zero(currency), null)
+        } else {
+            AccountBalance(accountId, Money.of(row.balance, currency), row.lastPostedAt)
+        }
+    }
+
+    @Transactional(readOnly = true)
+    override fun asOf(
+        accountId: AccountId,
+        currency: Currency,
+        instant: Instant,
+    ): AccountBalance {
+        val sum = entryRepository.sumAmount(accountId.value, currency.code, instant)
+        return AccountBalance(accountId, Money.of(sum, currency), null)
+    }
+}

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/application/PostTransactionCommand.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/application/PostTransactionCommand.kt
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.application
+
+import com.fincore.core.AccountId
+import com.fincore.core.Currency
+import com.fincore.ledger.domain.enum.EntryDirection
+import java.math.BigDecimal
+
+data class EntryLine(
+    val accountId: AccountId,
+    val direction: EntryDirection,
+    val amount: BigDecimal,
+)
+
+data class PostTransactionCommand(
+    val reference: String,
+    val description: String?,
+    val currency: Currency,
+    val entries: List<EntryLine>,
+    val actor: String,
+    val correlationId: String?,
+)

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/application/PostedTransaction.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/application/PostedTransaction.kt
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.application
+
+import com.fincore.core.TransactionId
+import java.time.Instant
+
+data class PostedTransaction(
+    val id: TransactionId,
+    val reference: String,
+    val postedAt: Instant,
+)

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/application/TransactionPoster.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/application/TransactionPoster.kt
@@ -1,0 +1,166 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.application
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fincore.core.EntryId
+import com.fincore.core.Money
+import com.fincore.core.TransactionId
+import com.fincore.events.EventEnvelope
+import com.fincore.events.LedgerEvents
+import com.fincore.events.OutboxStatus
+import com.fincore.ledger.application.event.EntryLinePayload
+import com.fincore.ledger.application.event.TransactionPostedPayload
+import com.fincore.ledger.domain.Entry
+import com.fincore.ledger.domain.Transaction
+import com.fincore.ledger.domain.enum.AccountStatus
+import com.fincore.ledger.domain.exception.AccountNotFoundException
+import com.fincore.ledger.domain.exception.DomainException
+import com.fincore.ledger.domain.exception.DuplicateTransactionException
+import com.fincore.ledger.infrastructure.persistence.AccountBalanceEntity
+import com.fincore.ledger.infrastructure.persistence.AccountBalanceKey
+import com.fincore.ledger.infrastructure.persistence.AccountBalanceRepository
+import com.fincore.ledger.infrastructure.persistence.AccountRepository
+import com.fincore.ledger.infrastructure.persistence.EntryRepository
+import com.fincore.ledger.infrastructure.persistence.OutboxEventEntity
+import com.fincore.ledger.infrastructure.persistence.OutboxEventRepository
+import com.fincore.ledger.infrastructure.persistence.TransactionPersistenceAdapter
+import com.fincore.ledger.infrastructure.persistence.TransactionRepository
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import java.util.UUID
+
+@Component
+class TransactionPoster(
+    private val accountRepository: AccountRepository,
+    private val transactionRepository: TransactionRepository,
+    private val entryRepository: EntryRepository,
+    private val balanceRepository: AccountBalanceRepository,
+    private val outboxRepository: OutboxEventRepository,
+    private val adapter: TransactionPersistenceAdapter,
+    private val objectMapper: ObjectMapper,
+) {
+    @Transactional
+    fun post(command: PostTransactionCommand): PostedTransaction {
+        val transaction = buildDomain(command)
+        guardAccounts(transaction, command)
+        if (transactionRepository.existsByReference(command.reference)) {
+            throw DuplicateTransactionException(command.reference)
+        }
+        val postedAt = Instant.now()
+        persist(transaction, command, postedAt)
+        applyBalances(transaction, command, postedAt)
+        emit(transaction, command, postedAt)
+        return PostedTransaction(transaction.id, transaction.reference, postedAt)
+    }
+
+    private fun buildDomain(command: PostTransactionCommand): Transaction {
+        val entries =
+            command.entries.map { line ->
+                Entry(EntryId.generate(), line.accountId, line.direction, Money.of(line.amount, command.currency))
+            }
+        return Transaction(TransactionId.generate(), command.reference, command.description, entries, command.currency)
+    }
+
+    private fun guardAccounts(
+        transaction: Transaction,
+        command: PostTransactionCommand,
+    ) {
+        transaction.entries.map { it.accountId }.distinct().forEach { accountId ->
+            val account =
+                accountRepository.findById(accountId.value).orElseThrow { AccountNotFoundException(accountId) }
+            if (account.status != AccountStatus.ACTIVE) {
+                throw DomainException("Cannot post to non-active account $accountId with status ${account.status}")
+            }
+            if (account.currency != command.currency.code) {
+                throw DomainException(
+                    "Account $accountId currency ${account.currency} does not match transaction currency ${command.currency}",
+                )
+            }
+        }
+    }
+
+    private fun persist(
+        transaction: Transaction,
+        command: PostTransactionCommand,
+        postedAt: Instant,
+    ) {
+        try {
+            transactionRepository.saveAndFlush(adapter.toTransactionEntity(transaction, command.actor, postedAt))
+        } catch (duplicate: DataIntegrityViolationException) {
+            throw DuplicateTransactionException(command.reference, duplicate)
+        }
+        adapter.toEntryEntities(transaction, postedAt).forEach { entryRepository.saveAndFlush(it) }
+    }
+
+    private fun applyBalances(
+        transaction: Transaction,
+        command: PostTransactionCommand,
+        postedAt: Instant,
+    ) {
+        transaction.entries.forEach { entry ->
+            val key = AccountBalanceKey(entry.accountId.value, command.currency.code)
+            val existing = balanceRepository.findById(key).orElse(null)
+            if (existing == null) {
+                balanceRepository.saveAndFlush(AccountBalanceEntity(key, entry.amount.amount, postedAt, 0))
+            } else {
+                existing.balance = existing.balance.add(entry.amount.amount)
+                existing.lastPostedAt = postedAt
+                balanceRepository.saveAndFlush(existing)
+            }
+        }
+    }
+
+    private fun emit(
+        transaction: Transaction,
+        command: PostTransactionCommand,
+        postedAt: Instant,
+    ) {
+        val envelope =
+            EventEnvelope.of(
+                source = SOURCE,
+                type = LedgerEvents.TransactionPosted,
+                data = buildPayload(transaction, command, postedAt),
+                subject = transaction.id.toString(),
+                correlationId = command.correlationId,
+            )
+        outboxRepository.saveAndFlush(
+            OutboxEventEntity(
+                id = UUID.randomUUID(),
+                aggregateType = AGGREGATE_TYPE,
+                aggregateId = transaction.id.toString(),
+                eventType = LedgerEvents.TransactionPosted.fullType,
+                payload = objectMapper.writeValueAsString(envelope),
+                status = OutboxStatus.PENDING,
+                createdAt = postedAt,
+                publishedAt = null,
+                attempts = 0,
+                lastError = null,
+            ),
+        )
+    }
+
+    private fun buildPayload(
+        transaction: Transaction,
+        command: PostTransactionCommand,
+        postedAt: Instant,
+    ): TransactionPostedPayload =
+        TransactionPostedPayload(
+            transactionId = transaction.id.toString(),
+            reference = transaction.reference,
+            currency = command.currency.code,
+            postedAt = postedAt,
+            entries =
+                transaction.entries.map {
+                    EntryLinePayload(it.accountId.toString(), it.direction.name, it.amount.amount.toPlainString())
+                },
+        )
+
+    private companion object {
+        const val SOURCE = "ledger-service"
+        const val AGGREGATE_TYPE = "Transaction"
+    }
+}

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/application/TransactionService.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/application/TransactionService.kt
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.application
+
+interface TransactionService {
+    fun post(command: PostTransactionCommand): PostedTransaction
+}

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/application/TransactionServiceImpl.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/application/TransactionServiceImpl.kt
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.application
+
+import com.fincore.ledger.domain.exception.ConcurrencyConflictException
+import org.springframework.dao.OptimisticLockingFailureException
+import org.springframework.stereotype.Service
+
+@Service
+class TransactionServiceImpl(
+    private val poster: TransactionPoster,
+) : TransactionService {
+    override fun post(command: PostTransactionCommand): PostedTransaction {
+        var attempt = 0
+        while (true) {
+            try {
+                return poster.post(command)
+            } catch (lock: OptimisticLockingFailureException) {
+                attempt++
+                if (attempt >= MAX_ATTEMPTS) {
+                    throw ConcurrencyConflictException(lock)
+                }
+            }
+        }
+    }
+
+    private companion object {
+        const val MAX_ATTEMPTS = 3
+    }
+}

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/application/event/TransactionPostedPayload.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/application/event/TransactionPostedPayload.kt
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.application.event
+
+import java.time.Instant
+
+data class EntryLinePayload(
+    val accountId: String,
+    val direction: String,
+    val amount: String,
+)
+
+data class TransactionPostedPayload(
+    val transactionId: String,
+    val reference: String,
+    val currency: String,
+    val postedAt: Instant,
+    val entries: List<EntryLinePayload>,
+)

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/domain/exception/ConcurrencyConflictException.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/domain/exception/ConcurrencyConflictException.kt
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.domain.exception
+
+class ConcurrencyConflictException(
+    cause: Throwable,
+) : RuntimeException("Posting failed after retries due to concurrent balance updates", cause)

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/domain/exception/DomainException.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/domain/exception/DomainException.kt
@@ -5,7 +5,8 @@ package com.fincore.ledger.domain.exception
 
 open class DomainException(
     message: String,
-) : RuntimeException(message) {
+    cause: Throwable? = null,
+) : RuntimeException(message, cause) {
     init {
         require(message.isNotBlank()) { "DomainException message must not be blank" }
     }

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/domain/exception/DuplicateTransactionException.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/domain/exception/DuplicateTransactionException.kt
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.domain.exception
+
+class DuplicateTransactionException(
+    reference: String,
+    cause: Throwable? = null,
+) : DomainException("Transaction reference already posted: $reference", cause)

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/EntryRepository.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/EntryRepository.kt
@@ -4,5 +4,20 @@
 package com.fincore.ledger.infrastructure.persistence
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.UUID
 
-interface EntryRepository : JpaRepository<EntryEntity, EntryKey>
+interface EntryRepository : JpaRepository<EntryEntity, EntryKey> {
+    @Query(
+        "select coalesce(sum(e.amount), 0) from EntryEntity e " +
+            "where e.accountId = :accountId and e.currency = :currency and e.postedAt <= :asOf",
+    )
+    fun sumAmount(
+        @Param("accountId") accountId: UUID,
+        @Param("currency") currency: String,
+        @Param("asOf") asOf: Instant,
+    ): BigDecimal
+}

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/TransactionPersistenceAdapter.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/TransactionPersistenceAdapter.kt
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.infrastructure.persistence
+
+import com.fincore.ledger.domain.Transaction
+import com.fincore.ledger.domain.enum.TransactionStatus
+import org.springframework.stereotype.Component
+import java.time.Instant
+
+// Hand-written domain aggregate -> rows (issue #33 deferral): a Transaction maps to one
+// transactions row plus N entries rows that share the post instant.
+@Component
+class TransactionPersistenceAdapter {
+    fun toTransactionEntity(
+        transaction: Transaction,
+        actor: String,
+        postedAt: Instant,
+    ): TransactionEntity =
+        TransactionEntity(
+            id = transaction.id.value,
+            reference = transaction.reference,
+            description = transaction.description,
+            status = TransactionStatus.POSTED,
+            reversesId = null,
+            metadata = EMPTY_JSON,
+            postedAt = postedAt,
+            createdAt = postedAt,
+            createdBy = actor,
+        )
+
+    fun toEntryEntities(
+        transaction: Transaction,
+        postedAt: Instant,
+    ): List<EntryEntity> =
+        transaction.entries.map { entry ->
+            EntryEntity(
+                key = EntryKey(entry.id.value, postedAt),
+                transactionId = transaction.id.value,
+                accountId = entry.accountId.value,
+                amount = entry.amount.amount,
+                currency = entry.amount.currency.code,
+                direction = entry.direction,
+                postedAt = postedAt,
+            )
+        }
+
+    companion object {
+        private const val EMPTY_JSON = "{}"
+    }
+}

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/TransactionRepository.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/TransactionRepository.kt
@@ -6,4 +6,6 @@ package com.fincore.ledger.infrastructure.persistence
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.UUID
 
-interface TransactionRepository : JpaRepository<TransactionEntity, UUID>
+interface TransactionRepository : JpaRepository<TransactionEntity, UUID> {
+    fun existsByReference(reference: String): Boolean
+}

--- a/services/ledger/src/test/kotlin/com/fincore/ledger/application/BalanceServiceImplTest.kt
+++ b/services/ledger/src/test/kotlin/com/fincore/ledger/application/BalanceServiceImplTest.kt
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.application
+
+import com.fincore.core.AccountId
+import com.fincore.core.Currency
+import com.fincore.ledger.infrastructure.persistence.AccountBalanceEntity
+import com.fincore.ledger.infrastructure.persistence.AccountBalanceKey
+import com.fincore.ledger.infrastructure.persistence.AccountBalanceRepository
+import com.fincore.ledger.infrastructure.persistence.EntryRepository
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.Optional
+
+class BalanceServiceImplTest {
+    private val balanceRepository = mockk<AccountBalanceRepository>()
+    private val entryRepository = mockk<EntryRepository>()
+    private val service = BalanceServiceImpl(balanceRepository, entryRepository)
+    private val accountId = AccountId.generate()
+
+    @Test
+    fun `should return zero when no balance row exists`() {
+        every { balanceRepository.findById(any()) } returns Optional.empty()
+
+        val balance = service.current(accountId, Currency.USD)
+
+        balance.amount.isZero() shouldBe true
+        balance.lastPostedAt shouldBe null
+    }
+
+    @Test
+    fun `should return the stored balance`() {
+        val key = AccountBalanceKey(accountId.value, "USD")
+        val postedAt = Instant.parse("2026-06-05T12:00:00Z")
+        every { balanceRepository.findById(key) } returns
+            Optional.of(AccountBalanceEntity(key, BigDecimal("250.50"), postedAt, 2))
+
+        val balance = service.current(accountId, Currency.USD)
+
+        balance.amount.amount.compareTo(BigDecimal("250.50")) shouldBe 0
+        balance.lastPostedAt shouldBe postedAt
+    }
+
+    @Test
+    fun `should sum entries up to the asOf instant`() {
+        val asOf = Instant.parse("2026-06-05T12:00:00Z")
+        every { entryRepository.sumAmount(accountId.value, "USD", asOf) } returns BigDecimal("75.00")
+
+        val balance = service.asOf(accountId, Currency.USD, asOf)
+
+        balance.amount.amount.compareTo(BigDecimal("75.00")) shouldBe 0
+    }
+}

--- a/services/ledger/src/test/kotlin/com/fincore/ledger/application/TransactionPosterTest.kt
+++ b/services/ledger/src/test/kotlin/com/fincore/ledger/application/TransactionPosterTest.kt
@@ -1,0 +1,148 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.application
+
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fincore.core.AccountId
+import com.fincore.core.Currency
+import com.fincore.ledger.domain.enum.AccountStatus
+import com.fincore.ledger.domain.enum.AccountType
+import com.fincore.ledger.domain.enum.EntryDirection
+import com.fincore.ledger.domain.exception.AccountNotFoundException
+import com.fincore.ledger.domain.exception.DomainException
+import com.fincore.ledger.domain.exception.DoubleEntryViolationException
+import com.fincore.ledger.domain.exception.DuplicateTransactionException
+import com.fincore.ledger.infrastructure.persistence.AccountBalanceRepository
+import com.fincore.ledger.infrastructure.persistence.AccountEntity
+import com.fincore.ledger.infrastructure.persistence.AccountRepository
+import com.fincore.ledger.infrastructure.persistence.EntryRepository
+import com.fincore.ledger.infrastructure.persistence.OutboxEventRepository
+import com.fincore.ledger.infrastructure.persistence.TransactionPersistenceAdapter
+import com.fincore.ledger.infrastructure.persistence.TransactionRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.Optional
+import java.util.UUID
+
+class TransactionPosterTest {
+    private val accountRepository = mockk<AccountRepository>()
+    private val transactionRepository = mockk<TransactionRepository>()
+    private val entryRepository = mockk<EntryRepository>()
+    private val balanceRepository = mockk<AccountBalanceRepository>()
+    private val outboxRepository = mockk<OutboxEventRepository>()
+    private val objectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+    private val poster =
+        TransactionPoster(
+            accountRepository,
+            transactionRepository,
+            entryRepository,
+            balanceRepository,
+            outboxRepository,
+            TransactionPersistenceAdapter(),
+            objectMapper,
+        )
+
+    private val now = Instant.parse("2026-06-05T12:00:00Z")
+    private val accountA = UUID.randomUUID()
+    private val accountB = UUID.randomUUID()
+
+    private fun account(
+        id: UUID,
+        status: AccountStatus = AccountStatus.ACTIVE,
+        currency: String = "USD",
+    ) = AccountEntity(id, "Account", AccountType.USER_WALLET, currency, status, "{}", 0, now, "a", now, "a")
+
+    private fun command(
+        reference: String = "ref-1",
+        currency: Currency = Currency.USD,
+        debit: BigDecimal = BigDecimal("100.00"),
+        credit: BigDecimal = BigDecimal("-100.00"),
+    ) = PostTransactionCommand(
+        reference = reference,
+        description = null,
+        currency = currency,
+        entries =
+            listOf(
+                EntryLine(AccountId(accountA), EntryDirection.DEBIT, debit),
+                EntryLine(AccountId(accountB), EntryDirection.CREDIT, credit),
+            ),
+        actor = "op",
+        correlationId = "corr-1",
+    )
+
+    private fun stubActiveAccounts() {
+        every { accountRepository.findById(accountA) } returns Optional.of(account(accountA))
+        every { accountRepository.findById(accountB) } returns Optional.of(account(accountB))
+    }
+
+    @Test
+    fun `should persist transaction entries balances and a single outbox event`() {
+        stubActiveAccounts()
+        every { transactionRepository.existsByReference("ref-1") } returns false
+        every { transactionRepository.saveAndFlush(any()) } answers { firstArg() }
+        every { entryRepository.saveAndFlush(any()) } answers { firstArg() }
+        every { balanceRepository.findById(any()) } returns Optional.empty()
+        every { balanceRepository.saveAndFlush(any()) } answers { firstArg() }
+        every { outboxRepository.saveAndFlush(any()) } answers { firstArg() }
+
+        val result = poster.post(command())
+
+        result.reference shouldBe "ref-1"
+        verify(exactly = 2) { entryRepository.saveAndFlush(any()) }
+        verify(exactly = 2) { balanceRepository.saveAndFlush(any()) }
+        verify(exactly = 1) { outboxRepository.saveAndFlush(any()) }
+    }
+
+    @Test
+    fun `should reject an unbalanced transaction before touching the database`() {
+        shouldThrow<DoubleEntryViolationException> {
+            poster.post(command(debit = BigDecimal("100.00"), credit = BigDecimal("-90.00")))
+        }
+
+        verify(exactly = 0) { transactionRepository.saveAndFlush(any()) }
+    }
+
+    @Test
+    fun `should reject posting to a frozen account`() {
+        every { accountRepository.findById(accountA) } returns Optional.of(account(accountA, AccountStatus.FROZEN))
+        every { accountRepository.findById(accountB) } returns Optional.of(account(accountB))
+
+        shouldThrow<DomainException> { poster.post(command()) }
+
+        verify(exactly = 0) { transactionRepository.saveAndFlush(any()) }
+    }
+
+    @Test
+    fun `should reject posting to a missing account`() {
+        every { accountRepository.findById(accountA) } returns Optional.empty()
+        every { accountRepository.findById(accountB) } returns Optional.of(account(accountB))
+
+        shouldThrow<AccountNotFoundException> { poster.post(command()) }
+    }
+
+    @Test
+    fun `should reject a currency mismatch between account and transaction`() {
+        every { accountRepository.findById(accountA) } returns Optional.of(account(accountA, currency = "EUR"))
+        every { accountRepository.findById(accountB) } returns Optional.of(account(accountB))
+
+        shouldThrow<DomainException> { poster.post(command()) }
+    }
+
+    @Test
+    fun `should reject a duplicate reference`() {
+        stubActiveAccounts()
+        every { transactionRepository.existsByReference("ref-1") } returns true
+
+        shouldThrow<DuplicateTransactionException> { poster.post(command()) }
+
+        verify(exactly = 0) { transactionRepository.saveAndFlush(any()) }
+    }
+}

--- a/services/ledger/src/test/kotlin/com/fincore/ledger/application/TransactionServiceImplTest.kt
+++ b/services/ledger/src/test/kotlin/com/fincore/ledger/application/TransactionServiceImplTest.kt
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.application
+
+import com.fincore.core.AccountId
+import com.fincore.core.Currency
+import com.fincore.core.TransactionId
+import com.fincore.ledger.domain.enum.EntryDirection
+import com.fincore.ledger.domain.exception.ConcurrencyConflictException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import org.springframework.dao.OptimisticLockingFailureException
+import java.math.BigDecimal
+import java.time.Instant
+
+class TransactionServiceImplTest {
+    private val poster = mockk<TransactionPoster>()
+    private val service = TransactionServiceImpl(poster)
+
+    private val command =
+        PostTransactionCommand(
+            reference = "ref-1",
+            description = null,
+            currency = Currency.USD,
+            entries =
+                listOf(
+                    EntryLine(AccountId.generate(), EntryDirection.DEBIT, BigDecimal("100.00")),
+                    EntryLine(AccountId.generate(), EntryDirection.CREDIT, BigDecimal("-100.00")),
+                ),
+            actor = "op",
+            correlationId = null,
+        )
+
+    @Test
+    fun `should post through the poster`() {
+        every { poster.post(command) } returns PostedTransaction(TransactionId.generate(), "ref-1", Instant.now())
+
+        service.post(command).reference shouldBe "ref-1"
+    }
+
+    @Test
+    fun `should retry on an optimistic lock failure then succeed`() {
+        var calls = 0
+        every { poster.post(command) } answers {
+            calls++
+            if (calls < 2) throw OptimisticLockingFailureException("version conflict")
+            PostedTransaction(TransactionId.generate(), "ref-1", Instant.now())
+        }
+
+        service.post(command)
+
+        verify(exactly = 2) { poster.post(command) }
+    }
+
+    @Test
+    fun `should fail with a concurrency conflict after three attempts`() {
+        every { poster.post(command) } throws OptimisticLockingFailureException("version conflict")
+
+        shouldThrow<ConcurrencyConflictException> { service.post(command) }
+
+        verify(exactly = 3) { poster.post(command) }
+    }
+}


### PR DESCRIPTION
## What

F-01.3 PR 2b of 2: the core ledger use case - posting a balanced double-entry transaction and reading balances.

**TransactionService.post** (one transaction, atomic):
- Builds the domain `Transaction` (enforces 2..1000 entries, no duplicate `(account, direction)`, single currency, signed amounts net to zero).
- Guards (#23): every referenced account exists, is `ACTIVE`, and its currency equals the transaction currency.
- Persists the `transactions` row + `entries` rows; applies `balance += signed amount` per `(account, currency)` to `account_balances`.
- Emits exactly one `com.fincore.ledger.transaction.posted.v1` PENDING row to the outbox in the same transaction (#22).
- Retries up to 3 times on an `account_balances` optimistic-lock conflict, then `ConcurrencyConflictException` (#24); a repeated `reference` -> `DuplicateTransactionException`.

**BalanceService** (#27/#29): `current` reads the authoritative `account_balances` table (always fresh - updated in the posting transaction, so no stale flag); `asOf` reconstructs a historical balance by summing `entries` with `posted_at <= instant`.

Sign convention (DEBIT positive / CREDIT negative, net zero) and balance math were verified against the existing domain code and tests, not assumed.

## Tests

Unit (MockK, 12 green): poster guards (missing/frozen/currency-mismatch), unbalanced rejection, single-event emission, duplicate reference, retry-then-succeed, retry-exhaustion, balance current/zero/asOf. Integration (`@DataJpaTest` + `@Import`, pg17): post updates both balances + writes one outbox row, net-zero rejection, frozen/currency guards, duplicate reference, asOf time-travel.

## Verification

Local: `:test` (12/12 new unit green), `:spotlessCheck`, `:detekt`, `:compileIntegrationTestKotlin`, `:assemble` all BUILD SUCCESSFUL. Integration tests run on CI (Testcontainers); env-blocked under local WSL Docker. No migration touched.

Closes #19
Closes #22
Closes #23
Closes #24
Closes #27
Closes #29