### PR TITLE
feat(web): wire account browser screen to live accounts api

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,20 +4,22 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { BrowserRouter, Route, Routes } from 'react-router-dom'
 import { ThemeProvider } from '@/components/ThemeProvider'
+import { Accounts } from '@/routes/Accounts'
 import { Overview } from '@/routes/Overview'
 
 const queryClient = new QueryClient()
 
 export function App() {
-  return (
-    <QueryClientProvider client={queryClient}>
-      <ThemeProvider>
-        <BrowserRouter>
-          <Routes>
-            <Route path="/" element={<Overview />} />
-          </Routes>
-        </BrowserRouter>
-      </ThemeProvider>
-    </QueryClientProvider>
-  )
+    return (
+        <QueryClientProvider client={queryClient}>
+            <ThemeProvider>
+                <BrowserRouter>
+                    <Routes>
+                        <Route path="/" element={<Overview />} />
+                        <Route path="/accounts" element={<Accounts />} />
+                    </Routes>
+                </BrowserRouter>
+            </ThemeProvider>
+        </QueryClientProvider>
+    )
 }

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+const BASE_URL = import.meta.env.VITE_API_BASE_URL ?? ''
+const DEV_BEARER = import.meta.env.VITE_DEV_BEARER_TOKEN
+
+export class ApiError extends Error {
+    constructor(readonly status: number) {
+        super(`request failed with status ${status}`)
+        this.name = 'ApiError'
+    }
+}
+
+export async function apiFetch<T>(path: string): Promise<T> {
+    const headers: Record<string, string> = { Accept: 'application/json' }
+    if (DEV_BEARER) headers.Authorization = `Bearer ${DEV_BEARER}`
+    const response = await fetch(`${BASE_URL}${path}`, { headers })
+    if (!response.ok) throw new ApiError(response.status)
+    return (await response.json()) as T
+}

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+export type AccountType =
+    | 'ASSET'
+    | 'LIABILITY'
+    | 'EQUITY'
+    | 'REVENUE'
+    | 'EXPENSE'
+    | 'USER_WALLET'
+    | 'FEE'
+    | 'RESERVE'
+    | 'SUSPENSE'
+
+export type AccountStatus = 'ACTIVE' | 'FROZEN' | 'CLOSED'
+
+export interface AccountResponse {
+    id: string
+    name: string
+    type: AccountType
+    currency: string
+    status: AccountStatus
+}
+
+export interface PageResponse<T> {
+    items: T[]
+    page: number
+    size: number
+    totalElements: number
+    totalPages: number
+}

--- a/web/src/components/Icon.tsx
+++ b/web/src/components/Icon.tsx
@@ -2,54 +2,60 @@
 // SPDX-FileCopyrightText: 2026 FinCore Engine Authors
 
 import {
-  Activity,
-  ArrowDownUp,
-  BookOpen,
-  Check,
-  ChevronDown,
-  ChevronRight,
-  Code,
-  Copy,
-  Home,
-  Key,
-  Play,
-  Scale,
-  Search,
-  Send,
-  Shield,
-  Wallet,
-  type LucideIcon,
+    Activity,
+    AlertTriangle,
+    ArrowDownUp,
+    BookOpen,
+    Check,
+    ChevronDown,
+    ChevronLeft,
+    ChevronRight,
+    Code,
+    Copy,
+    Home,
+    Inbox,
+    Key,
+    Play,
+    Scale,
+    Search,
+    Send,
+    Shield,
+    Wallet,
+    type LucideIcon,
 } from 'lucide-react'
 
 const ICONS = {
-  home: Home,
-  wallet: Wallet,
-  arrows: ArrowDownUp,
-  send: Send,
-  scale: Scale,
-  shield: Shield,
-  book: BookOpen,
-  search: Search,
-  chevDown: ChevronDown,
-  chevRight: ChevronRight,
-  check: Check,
-  key: Key,
-  code: Code,
-  activity: Activity,
-  copy: Copy,
-  play: Play,
+    home: Home,
+    wallet: Wallet,
+    arrows: ArrowDownUp,
+    send: Send,
+    scale: Scale,
+    shield: Shield,
+    book: BookOpen,
+    search: Search,
+    chevDown: ChevronDown,
+    chevLeft: ChevronLeft,
+    chevRight: ChevronRight,
+    check: Check,
+    key: Key,
+    code: Code,
+    activity: Activity,
+    copy: Copy,
+    play: Play,
+    alert: AlertTriangle,
+    inbox: Inbox,
 } satisfies Record<string, LucideIcon>
 
 export type IconName = keyof typeof ICONS
 
 interface IconProps {
-  name: IconName
-  size?: number
-  className?: string
-  style?: React.CSSProperties
+    name: IconName
+    size?: number
+    className?: string
+    style?: React.CSSProperties
 }
 
 export function Icon({ name, size = 14, className, style }: IconProps) {
-  const Glyph = ICONS[name]
-  return <Glyph size={size} strokeWidth={1.6} className={className} style={style} aria-hidden />
+    const Glyph = ICONS[name]
+    return <Glyph size={size} strokeWidth={1.6} className={className} style={style} aria-hidden />
 }

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -1,156 +1,233 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 FinCore Engine Authors
 
+import { Link } from 'react-router-dom'
 import { Icon, type IconName } from './Icon'
 
 interface NavItem {
-  name: string
-  icon: IconName
+    name: string
+    icon: IconName
+    path?: string
 }
 
 const NAV: NavItem[] = [
-  { name: 'Overview', icon: 'home' },
-  { name: 'Accounts', icon: 'wallet' },
-  { name: 'Transactions', icon: 'arrows' },
-  { name: 'Payments', icon: 'send' },
-  { name: 'Decisions', icon: 'scale' },
-  { name: 'Compliance', icon: 'shield' },
-  { name: 'Audit', icon: 'book' },
+    { name: 'Overview', icon: 'home', path: '/' },
+    { name: 'Accounts', icon: 'wallet', path: '/accounts' },
+    { name: 'Transactions', icon: 'arrows' },
+    { name: 'Payments', icon: 'send' },
+    { name: 'Decisions', icon: 'scale' },
+    { name: 'Compliance', icon: 'shield' },
+    { name: 'Audit', icon: 'book' },
 ]
 
 const SERVICES = ['postgres', 'redpanda', 'keycloak', 'redis']
 
 export function Sidebar({ active = 'Overview' }: { active?: string }) {
-  return (
-    <div
-      style={{
-        width: 240,
-        height: '100%',
-        background: 'var(--bg-2)',
-        borderRight: '1px solid var(--border)',
-        display: 'flex',
-        flexDirection: 'column',
-        flex: '0 0 auto',
-      }}
-    >
-      <div style={{ padding: '18px 18px 16px', borderBottom: '1px solid var(--border)', display: 'flex', alignItems: 'center', gap: 10 }}>
+    return (
         <div
-          style={{
-            width: 26,
-            height: 26,
-            borderRadius: 6,
-            background: 'linear-gradient(135deg, var(--accent), var(--text-accent))',
-            display: 'flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            color: '#03201D',
-            fontWeight: 700,
-            fontSize: 13,
-            fontFamily: 'var(--mono)',
-          }}
-        >
-          F
-        </div>
-        <div style={{ display: 'flex', flexDirection: 'column', lineHeight: 1.15 }}>
-          <span style={{ fontWeight: 600, fontSize: 13 }}>FinCore</span>
-          <span className="mono" style={{ fontSize: 10, color: 'var(--text-3)' }}>v0.4.0 · sandbox</span>
-        </div>
-      </div>
-
-      <div style={{ padding: '12px 12px 8px' }}>
-        <div
-          style={{
-            display: 'flex',
-            alignItems: 'center',
-            gap: 8,
-            height: 28,
-            padding: '0 10px',
-            background: 'var(--bg)',
-            border: '1px solid var(--border)',
-            borderRadius: 4,
-            color: 'var(--text-3)',
-            fontSize: 12,
-          }}
-        >
-          <Icon name="search" size={13} />
-          <span style={{ flex: 1 }}>Jump to...</span>
-          <span className="kbd">Cmd K</span>
-        </div>
-      </div>
-
-      <nav style={{ padding: '4px 8px', flex: 1, display: 'flex', flexDirection: 'column', gap: 1 }}>
-        {NAV.map((item) => {
-          const isActive = item.name === active
-          return (
-            <div
-              key={item.name}
-              aria-current={isActive ? 'page' : undefined}
-              style={{
+            style={{
+                width: 240,
+                height: '100%',
+                background: 'var(--bg-2)',
+                borderRight: '1px solid var(--border)',
                 display: 'flex',
-                alignItems: 'center',
-                gap: 10,
-                height: 30,
-                padding: '0 10px',
-                borderRadius: 4,
-                background: isActive ? 'var(--accent-bg)' : 'transparent',
-                color: isActive ? 'var(--text-accent)' : 'var(--text-2)',
-                fontWeight: isActive ? 500 : 400,
-                fontSize: 12.5,
-                borderLeft: isActive ? '2px solid var(--accent)' : '2px solid transparent',
-                paddingLeft: 8,
-              }}
-            >
-              <Icon name={item.icon} size={14} />
-              <span>{item.name}</span>
-            </div>
-          )
-        })}
-      </nav>
-
-      <div style={{ padding: '10px 14px', borderTop: '1px solid var(--border)' }}>
-        <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', fontSize: 11, color: 'var(--text-3)', marginBottom: 8 }}>
-          <span>System</span>
-          <span className="mono cr" style={{ fontSize: 10 }}>operational</span>
-        </div>
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 4, fontSize: 10.5, color: 'var(--text-2)', fontFamily: 'var(--mono)' }}>
-          {SERVICES.map((s) => (
-            <div key={s} style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
-              <span style={{ width: 6, height: 6, borderRadius: '50%', background: 'var(--accent)' }} />
-              <span>{s}</span>
-            </div>
-          ))}
-        </div>
-      </div>
-
-      <div style={{ padding: '10px 14px', borderTop: '1px solid var(--border)', display: 'flex', alignItems: 'center', gap: 10 }}>
-        <span
-          style={{
-            width: 26,
-            height: 26,
-            borderRadius: '50%',
-            background: 'oklch(0.42 0.06 170)',
-            color: 'oklch(0.86 0.07 170)',
-            display: 'inline-flex',
-            alignItems: 'center',
-            justifyContent: 'center',
-            fontSize: 11,
-            fontWeight: 600,
-            flex: '0 0 auto',
-          }}
+                flexDirection: 'column',
+                flex: '0 0 auto',
+            }}
         >
-          LP
-        </span>
-        <div style={{ flex: 1, minWidth: 0, lineHeight: 1.2 }}>
-          <div style={{ fontSize: 12, fontWeight: 500 }}>Lena Park</div>
-          <div
-            className="mono"
-            style={{ fontSize: 10, color: 'var(--text-3)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
-          >
-            mercator-eu-prod
-          </div>
+            <div
+                style={{
+                    padding: '18px 18px 16px',
+                    borderBottom: '1px solid var(--border)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 10,
+                }}
+            >
+                <div
+                    style={{
+                        width: 26,
+                        height: 26,
+                        borderRadius: 6,
+                        background: 'linear-gradient(135deg, var(--accent), var(--text-accent))',
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        color: '#03201D',
+                        fontWeight: 700,
+                        fontSize: 13,
+                        fontFamily: 'var(--mono)',
+                    }}
+                >
+                    F
+                </div>
+                <div style={{ display: 'flex', flexDirection: 'column', lineHeight: 1.15 }}>
+                    <span style={{ fontWeight: 600, fontSize: 13 }}>FinCore</span>
+                    <span className="mono" style={{ fontSize: 10, color: 'var(--text-3)' }}>
+                        v0.4.0 · sandbox
+                    </span>
+                </div>
+            </div>
+
+            <div style={{ padding: '12px 12px 8px' }}>
+                <div
+                    style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 8,
+                        height: 28,
+                        padding: '0 10px',
+                        background: 'var(--bg)',
+                        border: '1px solid var(--border)',
+                        borderRadius: 4,
+                        color: 'var(--text-3)',
+                        fontSize: 12,
+                    }}
+                >
+                    <Icon name="search" size={13} />
+                    <span style={{ flex: 1 }}>Jump to...</span>
+                    <span className="kbd">Cmd K</span>
+                </div>
+            </div>
+
+            <nav
+                style={{
+                    padding: '4px 8px',
+                    flex: 1,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 1,
+                }}
+            >
+                {NAV.map((item) => {
+                    const isActive = item.name === active
+                    const style: React.CSSProperties = {
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 10,
+                        height: 30,
+                        padding: '0 10px',
+                        borderRadius: 4,
+                        background: isActive ? 'var(--accent-bg)' : 'transparent',
+                        color: isActive ? 'var(--text-accent)' : 'var(--text-2)',
+                        fontWeight: isActive ? 500 : 400,
+                        fontSize: 12.5,
+                        borderLeft: isActive ? '2px solid var(--accent)' : '2px solid transparent',
+                        paddingLeft: 8,
+                        textDecoration: 'none',
+                    }
+                    const content = (
+                        <>
+                            <Icon name={item.icon} size={14} />
+                            <span>{item.name}</span>
+                        </>
+                    )
+                    return item.path ? (
+                        <Link
+                            key={item.name}
+                            to={item.path}
+                            aria-current={isActive ? 'page' : undefined}
+                            style={style}
+                        >
+                            {content}
+                        </Link>
+                    ) : (
+                        <div
+                            key={item.name}
+                            aria-current={isActive ? 'page' : undefined}
+                            style={style}
+                        >
+                            {content}
+                        </div>
+                    )
+                })}
+            </nav>
+
+            <div style={{ padding: '10px 14px', borderTop: '1px solid var(--border)' }}>
+                <div
+                    style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        justifyContent: 'space-between',
+                        fontSize: 11,
+                        color: 'var(--text-3)',
+                        marginBottom: 8,
+                    }}
+                >
+                    <span>System</span>
+                    <span className="mono cr" style={{ fontSize: 10 }}>
+                        operational
+                    </span>
+                </div>
+                <div
+                    style={{
+                        display: 'grid',
+                        gridTemplateColumns: '1fr 1fr',
+                        gap: 4,
+                        fontSize: 10.5,
+                        color: 'var(--text-2)',
+                        fontFamily: 'var(--mono)',
+                    }}
+                >
+                    {SERVICES.map((s) => (
+                        <div key={s} style={{ display: 'flex', alignItems: 'center', gap: 5 }}>
+                            <span
+                                style={{
+                                    width: 6,
+                                    height: 6,
+                                    borderRadius: '50%',
+                                    background: 'var(--accent)',
+                                }}
+                            />
+                            <span>{s}</span>
+                        </div>
+                    ))}
+                </div>
+            </div>
+
+            <div
+                style={{
+                    padding: '10px 14px',
+                    borderTop: '1px solid var(--border)',
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 10,
+                }}
+            >
+                <span
+                    style={{
+                        width: 26,
+                        height: 26,
+                        borderRadius: '50%',
+                        background: 'oklch(0.42 0.06 170)',
+                        color: 'oklch(0.86 0.07 170)',
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        justifyContent: 'center',
+                        fontSize: 11,
+                        fontWeight: 600,
+                        flex: '0 0 auto',
+                    }}
+                >
+                    LP
+                </span>
+                <div style={{ flex: 1, minWidth: 0, lineHeight: 1.2 }}>
+                    <div style={{ fontSize: 12, fontWeight: 500 }}>Lena Park</div>
+                    <div
+                        className="mono"
+                        style={{
+                            fontSize: 10,
+                            color: 'var(--text-3)',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                            whiteSpace: 'nowrap',
+                        }}
+                    >
+                        mercator-eu-prod
+                    </div>
+                </div>
+                <Icon name="chevDown" size={12} />
+            </div>
         </div>
-        <Icon name="chevDown" size={12} />
-      </div>
-    </div>
-  )
+    )
 }

--- a/web/src/features/accounts/AccountsTable.tsx
+++ b/web/src/features/accounts/AccountsTable.tsx
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+import type { AccountResponse } from '@/api/types'
+import { StatusPill, TypePill } from './Pills'
+
+export function AccountsTable({ accounts }: { accounts: AccountResponse[] }) {
+    return (
+        <table className="tbl">
+            <thead>
+                <tr>
+                    <th>Account ID</th>
+                    <th>Name</th>
+                    <th>Type</th>
+                    <th>Currency</th>
+                    <th>Status</th>
+                </tr>
+            </thead>
+            <tbody>
+                {accounts.map((account) => (
+                    <tr key={account.id}>
+                        <td>
+                            <span
+                                className="mono"
+                                title={account.id}
+                                style={{ color: 'var(--text)' }}
+                            >
+                                {account.id}
+                            </span>
+                        </td>
+                        <td>{account.name}</td>
+                        <td>
+                            <TypePill type={account.type} />
+                        </td>
+                        <td className="mono" style={{ color: 'var(--text-2)' }}>
+                            {account.currency}
+                        </td>
+                        <td>
+                            <StatusPill status={account.status} />
+                        </td>
+                    </tr>
+                ))}
+            </tbody>
+        </table>
+    )
+}

--- a/web/src/features/accounts/Pagination.tsx
+++ b/web/src/features/accounts/Pagination.tsx
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+import { Icon } from '@/components/Icon'
+
+interface PaginationProps {
+    page: number
+    totalPages: number
+    totalElements: number
+    onPrev: () => void
+    onNext: () => void
+}
+
+export function Pagination({ page, totalPages, totalElements, onPrev, onNext }: PaginationProps) {
+    const prevDisabled = page <= 0
+    const nextDisabled = totalPages === 0 || page >= totalPages - 1
+    return (
+        <div
+            style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'space-between',
+                padding: '10px 16px',
+                borderTop: '1px solid var(--border)',
+                fontSize: 11.5,
+                color: 'var(--text-2)',
+            }}
+        >
+            <span>
+                <span className="mono" style={{ color: 'var(--text)' }}>
+                    {totalElements}
+                </span>{' '}
+                accounts
+            </span>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                <button
+                    type="button"
+                    className="btn btn-sm"
+                    onClick={onPrev}
+                    disabled={prevDisabled}
+                    aria-label="Previous page"
+                >
+                    <Icon name="chevLeft" size={11} />
+                </button>
+                <span className="mono">
+                    page {page + 1} of {Math.max(totalPages, 1)}
+                </span>
+                <button
+                    type="button"
+                    className="btn btn-sm"
+                    onClick={onNext}
+                    disabled={nextDisabled}
+                    aria-label="Next page"
+                >
+                    <Icon name="chevRight" size={11} />
+                </button>
+            </div>
+        </div>
+    )
+}

--- a/web/src/features/accounts/Pills.tsx
+++ b/web/src/features/accounts/Pills.tsx
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+import type { AccountStatus, AccountType } from '@/api/types'
+
+const STATUS_CLASS: Record<AccountStatus, string> = {
+    ACTIVE: 'pill-teal',
+    FROZEN: 'pill-amber',
+    CLOSED: 'pill-grey',
+}
+
+export function StatusPill({ status }: { status: AccountStatus }) {
+    return (
+        <span className={`pill ${STATUS_CLASS[status] ?? 'pill-grey'}`}>
+            <span className="dot" />
+            {status}
+        </span>
+    )
+}
+
+export function TypePill({ type }: { type: AccountType }) {
+    return (
+        <span className="pill pill-grey mono" style={{ fontSize: 10 }}>
+            {type}
+        </span>
+    )
+}

--- a/web/src/features/accounts/useAccounts.ts
+++ b/web/src/features/accounts/useAccounts.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+import { useQuery } from '@tanstack/react-query'
+import { apiFetch } from '@/api/client'
+import type { AccountResponse, PageResponse } from '@/api/types'
+
+export function useAccounts(page: number, size: number) {
+    return useQuery({
+        queryKey: ['accounts', page, size],
+        queryFn: () =>
+            apiFetch<PageResponse<AccountResponse>>(`/v1/accounts?page=${page}&size=${size}`),
+    })
+}

--- a/web/src/routes/Accounts.tsx
+++ b/web/src/routes/Accounts.tsx
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+import { useState } from 'react'
+import { Icon } from '@/components/Icon'
+import { Shell } from '@/components/Shell'
+import { AccountsTable } from '@/features/accounts/AccountsTable'
+import { Pagination } from '@/features/accounts/Pagination'
+import { useAccounts } from '@/features/accounts/useAccounts'
+
+const PAGE_SIZE = 20
+
+export function Accounts() {
+    const [page, setPage] = useState(0)
+    const { data, isPending, isError, refetch } = useAccounts(page, PAGE_SIZE)
+
+    return (
+        <Shell activeNav="Accounts">
+            <div
+                style={{
+                    padding: '20px 24px',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 16,
+                    flex: 1,
+                    minHeight: 0,
+                }}
+            >
+                <div
+                    className="card"
+                    style={{
+                        flex: 1,
+                        minHeight: 0,
+                        display: 'flex',
+                        flexDirection: 'column',
+                        overflow: 'hidden',
+                    }}
+                >
+                    <div style={{ flex: 1, overflow: 'auto' }} className="fc-scroll">
+                        {isPending ? (
+                            <StateMessage icon="activity" text="Loading accounts..." />
+                        ) : isError ? (
+                            <StateMessage icon="alert" text="Could not load accounts.">
+                                <button type="button" className="btn" onClick={() => refetch()}>
+                                    Retry
+                                </button>
+                            </StateMessage>
+                        ) : data.totalElements === 0 ? (
+                            <StateMessage icon="inbox" text="No accounts yet." />
+                        ) : (
+                            <AccountsTable accounts={data.items} />
+                        )}
+                    </div>
+                    {!isPending && !isError && (
+                        <Pagination
+                            page={data.page}
+                            totalPages={data.totalPages}
+                            totalElements={data.totalElements}
+                            onPrev={() => setPage((p) => Math.max(0, p - 1))}
+                            onNext={() => setPage((p) => p + 1)}
+                        />
+                    )}
+                </div>
+            </div>
+        </Shell>
+    )
+}
+
+function StateMessage({
+    icon,
+    text,
+    children,
+}: {
+    icon: 'activity' | 'alert' | 'inbox'
+    text: string
+    children?: React.ReactNode
+}) {
+    return (
+        <div
+            style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: 10,
+                padding: '64px 24px',
+                color: 'var(--text-3)',
+                fontSize: 13,
+            }}
+        >
+            <Icon name={icon} size={20} />
+            <span>{text}</span>
+            {children}
+        </div>
+    )
+}

--- a/web/src/test/Accounts.test.tsx
+++ b/web/src/test/Accounts.test.tsx
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { AccountResponse, PageResponse } from '@/api/types'
+import { ThemeProvider } from '@/components/ThemeProvider'
+import { Accounts } from '@/routes/Accounts'
+
+function page(
+    items: AccountResponse[],
+    over: Partial<PageResponse<AccountResponse>> = {},
+): PageResponse<AccountResponse> {
+    return { items, page: 0, size: 20, totalElements: items.length, totalPages: 1, ...over }
+}
+
+const SAMPLE: AccountResponse[] = [
+    { id: 'acc_0001', name: 'Operating Cash', type: 'ASSET', currency: 'USD', status: 'ACTIVE' },
+    {
+        id: 'acc_0002',
+        name: 'Customer Wallet',
+        type: 'USER_WALLET',
+        currency: 'EUR',
+        status: 'FROZEN',
+    },
+    { id: 'acc_0003', name: 'Fee Income', type: 'REVENUE', currency: 'GBP', status: 'CLOSED' },
+]
+
+function ok(body: unknown) {
+    return { ok: true, status: 200, json: async () => body } as Response
+}
+
+function renderAccounts() {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const ui: ReactElement = (
+        <QueryClientProvider client={client}>
+            <MemoryRouter initialEntries={['/accounts']}>
+                <ThemeProvider>
+                    <Accounts />
+                </ThemeProvider>
+            </MemoryRouter>
+        </QueryClientProvider>
+    )
+    return render(ui)
+}
+
+afterEach(() => {
+    vi.restoreAllMocks()
+})
+
+describe('Accounts', () => {
+    it('shows a loading state while the request is in flight', () => {
+        vi.spyOn(globalThis, 'fetch').mockReturnValue(new Promise<Response>(() => {}))
+        renderAccounts()
+        expect(screen.getByText('Loading accounts...')).toBeInTheDocument()
+        expect(screen.queryByRole('table')).not.toBeInTheDocument()
+    })
+
+    it('renders a row per account with only the real contract fields', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(ok(page(SAMPLE, { totalElements: 3 })))
+        renderAccounts()
+        expect(await screen.findByText('Operating Cash')).toBeInTheDocument()
+        expect(screen.getAllByRole('row')).toHaveLength(SAMPLE.length + 1)
+        expect(screen.getByText('acc_0001')).toBeInTheDocument()
+        expect(screen.getByText('ACTIVE')).toBeInTheDocument()
+        expect(screen.getByText('USER_WALLET')).toBeInTheDocument()
+        expect(screen.queryByText('Balance')).not.toBeInTheDocument()
+        expect(screen.queryByText('Owner')).not.toBeInTheDocument()
+        expect(screen.queryByText('Created')).not.toBeInTheDocument()
+    })
+
+    it('shows an empty state and disables Next when there are no accounts', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+            ok(page([], { totalElements: 0, totalPages: 0 })),
+        )
+        renderAccounts()
+        expect(await screen.findByText('No accounts yet.')).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Next page' })).toBeDisabled()
+    })
+
+    it('shows an error state with a working Retry', async () => {
+        const fetchMock = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network down'))
+        renderAccounts()
+        expect(await screen.findByText('Could not load accounts.')).toBeInTheDocument()
+        const before = fetchMock.mock.calls.length
+        fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+        await waitFor(() => expect(fetchMock.mock.calls.length).toBeGreaterThan(before))
+    })
+
+    it('paginates: Prev disabled on first page, Next refetches with the next page', async () => {
+        const fetchMock = vi
+            .spyOn(globalThis, 'fetch')
+            .mockResolvedValue(ok(page(SAMPLE, { totalElements: 45, totalPages: 3 })))
+        renderAccounts()
+        await screen.findByText('Operating Cash')
+        expect(screen.getByRole('button', { name: 'Previous page' })).toBeDisabled()
+
+        fireEvent.click(screen.getByRole('button', { name: 'Next page' }))
+        await waitFor(() => expect(String(fetchMock.mock.calls.at(-1)?.[0])).toContain('page=1'))
+    })
+
+    it('marks the Accounts sidebar item as the current page', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(ok(page(SAMPLE, { totalElements: 3 })))
+        renderAccounts()
+        await screen.findByText('Operating Cash')
+        expect(screen.getByRole('link', { name: 'Accounts' })).toHaveAttribute(
+            'aria-current',
+            'page',
+        )
+    })
+})

--- a/web/src/test/Overview.test.tsx
+++ b/web/src/test/Overview.test.tsx
@@ -2,31 +2,65 @@
 // SPDX-FileCopyrightText: 2026 FinCore Engine Authors
 
 import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import { describe, expect, it, vi } from 'vitest'
 import { ThemeProvider } from '@/components/ThemeProvider'
 import type { OverviewData } from '@/mock/types'
 import { Overview } from '@/routes/Overview'
 
 vi.mock('@/mock/overview', () => ({
-  getOverview: (): OverviewData => ({
-    status: { title: 'Sandbox running locally', version: 'v9', build: 'abc123', uptime: '1m', user: 'Tester', tenant: 'demo-tenant' },
-    services: [{ name: 'postgres', version: '17', ok: true }],
-    kpis: [{ label: 'Transactions · today', value: '42', sub: [{ text: '+1%', tone: 'credit' }], spark: [1, 2, 3] }],
-    activity: [{ type: 'transaction.posted', detail: 'tx_demo', ts: '2s ago', icon: 'arrows', tone: 'neutral' }],
-    apiExamples: [{ title: 'Create a transaction', endpoint: 'POST /v1/transactions', icon: 'arrows', curl: 'curl ...' }],
-    systemLinks: [{ title: 'Swagger UI', sub: 'docs', url: 'localhost:8080/swagger', icon: 'code' }],
-  }),
+    getOverview: (): OverviewData => ({
+        status: {
+            title: 'Sandbox running locally',
+            version: 'v9',
+            build: 'abc123',
+            uptime: '1m',
+            user: 'Tester',
+            tenant: 'demo-tenant',
+        },
+        services: [{ name: 'postgres', version: '17', ok: true }],
+        kpis: [
+            {
+                label: 'Transactions · today',
+                value: '42',
+                sub: [{ text: '+1%', tone: 'credit' }],
+                spark: [1, 2, 3],
+            },
+        ],
+        activity: [
+            {
+                type: 'transaction.posted',
+                detail: 'tx_demo',
+                ts: '2s ago',
+                icon: 'arrows',
+                tone: 'neutral',
+            },
+        ],
+        apiExamples: [
+            {
+                title: 'Create a transaction',
+                endpoint: 'POST /v1/transactions',
+                icon: 'arrows',
+                curl: 'curl ...',
+            },
+        ],
+        systemLinks: [
+            { title: 'Swagger UI', sub: 'docs', url: 'localhost:8080/swagger', icon: 'code' },
+        ],
+    }),
 }))
 
 describe('Overview', () => {
-  it('renders the stubbed landing data without crashing', () => {
-    render(
-      <ThemeProvider>
-        <Overview />
-      </ThemeProvider>,
-    )
-    expect(screen.getByText('Transactions · today')).toBeInTheDocument()
-    expect(screen.getByText('transaction.posted')).toBeInTheDocument()
-    expect(screen.getByText('Create a transaction')).toBeInTheDocument()
-  })
+    it('renders the stubbed landing data without crashing', () => {
+        render(
+            <MemoryRouter>
+                <ThemeProvider>
+                    <Overview />
+                </ThemeProvider>
+            </MemoryRouter>,
+        )
+        expect(screen.getByText('Transactions · today')).toBeInTheDocument()
+        expect(screen.getByText('transaction.posted')).toBeInTheDocument()
+        expect(screen.getByText('Create a transaction')).toBeInTheDocument()
+    })
 })

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,1 +1,10 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+    readonly VITE_API_BASE_URL?: string
+    readonly VITE_DEV_BEARER_TOKEN?: string
+}
+
+interface ImportMeta {
+    readonly env: ImportMetaEnv
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -2,11 +2,18 @@ import { fileURLToPath, URL } from 'node:url'
 import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vitest/config'
 
+const API_TARGET = process.env.VITE_API_BASE_URL ?? 'http://localhost:8080'
+
 export default defineConfig({
     plugins: [react()],
     resolve: {
         alias: {
             '@': fileURLToPath(new URL('./src', import.meta.url)),
+        },
+    },
+    server: {
+        proxy: {
+            '/v1': { target: API_TARGET, changeOrigin: true },
         },
     },
     test: {


### PR DESCRIPTION
First Sandbox UI screen wired to the live ledger backend.

## What
- `/accounts` route rendering inside the existing `Shell`, sidebar `Accounts` active + navigable
- Typed `useAccounts(page, size)` TanStack Query hook over `GET /v1/accounts`, replacing the mock-direct-read pattern
- API client (`apiFetch`) with `VITE_API_BASE_URL` base + optional dev bearer token; Vite dev proxy `/v1` -> `localhost:8080`
- Accounts table rendering only the five real `AccountResponse` fields: id (mono), name, type pill, currency, status pill
- Server-authoritative pagination (page/size/totalPages/totalElements), Prev/Next with bounds
- loading / error+retry / empty states
- Vitest + RTL: 6 tests covering all states, pagination, and nav active

## Out of scope (no backing API)
Balance column, owner/avatar, created column, KPI strip, search, filters, page-size selector, real Keycloak login.

## Contract fidelity
Fields verified against `AccountResponse`/`PageResponse` DTOs and `AccountController`. No invented fields (no balance/owner/created; prototype's `SETTLEMENT` type is not real and was dropped).

Closes #111