### PR TITLE
feat(ledger): serialize api money amounts as decimal strings

### DIFF
--- a/services/ledger/src/main/kotlin/com/fincore/ledger/api/dto/response/BalanceResponse.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/api/dto/response/BalanceResponse.kt
@@ -3,12 +3,17 @@
 
 package com.fincore.ledger.api.dto.response
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import com.fincore.ledger.api.serialization.MoneyAmountSerializer
+import io.swagger.v3.oas.annotations.media.Schema
 import java.math.BigDecimal
 import java.time.Instant
 
 data class BalanceResponse(
     val accountId: String,
     val currency: String,
+    @JsonSerialize(using = MoneyAmountSerializer::class)
+    @Schema(type = "string", format = "decimal", example = "100.00")
     val amount: BigDecimal,
     val lastPostedAt: Instant?,
 )

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/api/serialization/MoneyAmountSerializer.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/api/serialization/MoneyAmountSerializer.kt
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.api.serialization
+
+import com.fasterxml.jackson.core.JsonGenerator
+import com.fasterxml.jackson.databind.JsonSerializer
+import com.fasterxml.jackson.databind.SerializerProvider
+import java.math.BigDecimal
+
+class MoneyAmountSerializer : JsonSerializer<BigDecimal>() {
+    override fun serialize(
+        value: BigDecimal,
+        gen: JsonGenerator,
+        serializers: SerializerProvider,
+    ) {
+        gen.writeString(value.toPlainString())
+    }
+}

--- a/services/ledger/src/test/kotlin/com/fincore/ledger/api/AccountControllerTest.kt
+++ b/services/ledger/src/test/kotlin/com/fincore/ledger/api/AccountControllerTest.kt
@@ -131,7 +131,7 @@ class AccountControllerTest(
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.accountId").value(id.toString()))
             .andExpect(jsonPath("$.currency").value("EUR"))
-            .andExpect(jsonPath("$.amount").value(100.00))
+            .andExpect(jsonPath("$.amount").value("100.00"))
     }
 
     @Test

--- a/services/ledger/src/test/kotlin/com/fincore/ledger/api/serialization/MoneyAmountSerializerTest.kt
+++ b/services/ledger/src/test/kotlin/com/fincore/ledger/api/serialization/MoneyAmountSerializerTest.kt
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.api.serialization
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+class MoneyAmountSerializerTest {
+    private data class Holder(
+        @JsonSerialize(using = MoneyAmountSerializer::class) val amount: BigDecimal,
+    )
+
+    private val mapper = jacksonObjectMapper()
+
+    @Test
+    fun `should serialize amount as a json string preserving trailing zeros`() {
+        mapper.writeValueAsString(Holder(BigDecimal("100.00"))) shouldBe """{"amount":"100.00"}"""
+    }
+
+    @Test
+    fun `should serialize a high scale amount losslessly without scientific notation`() {
+        val value = "12345678901234567890.123456789012345678"
+        mapper.writeValueAsString(Holder(BigDecimal(value))) shouldBe """{"amount":"$value"}"""
+    }
+}


### PR DESCRIPTION
## What
Money amounts were serialized over the API as JSON numbers. JSON has one numeric type and JS clients parse it into float64, truncating large or high-scale `NUMERIC(38,18)` values before any client code runs - a ledger correctness hazard.

This serializes money amounts as JSON decimal strings via `BigDecimal.toPlainString()` (exact digits, preserved scale, never scientific notation):

```
before  {"amount": 100.00}
after   {"amount": "100.00"}
```

## Scope
- `MoneyAmountSerializer (JsonSerializer<BigDecimal>)`
- applied to `BalanceResponse.amount` (the only money output field today) + `@Schema(type=string, format=decimal)` so generated OpenAPI is accurate
- per-field annotation, not a global Jackson module: outbox/event/idempotency serialization stays byte-stable
- input unchanged: default `BigDecimal` deserialization already accepts string and number

## Tests
- `MoneyAmountSerializerTest`: trailing zeros preserved (`100.00` -> `"100.00"`); high-scale value `12345678901234567890.123456789012345678` round-trips losslessly with no exponent
- `AccountControllerTest` balance assertion updated to the string form (validates the real Spring ObjectMapper path)

Unblocks Sandbox UI Screen 2 (Account Detail + Balance) on a lossless string amount. ADR: Money over JSON (prepared for Wiki).

Closes #113