### PR TITLE
feat(web): add account detail screen with current balance

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -4,6 +4,7 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { BrowserRouter, Route, Routes } from 'react-router-dom'
 import { ThemeProvider } from '@/components/ThemeProvider'
+import { AccountDetail } from '@/routes/AccountDetail'
 import { Accounts } from '@/routes/Accounts'
 import { Overview } from '@/routes/Overview'
 
@@ -17,6 +18,7 @@ export function App() {
                     <Routes>
                         <Route path="/" element={<Overview />} />
                         <Route path="/accounts" element={<Accounts />} />
+                        <Route path="/accounts/:id" element={<AccountDetail />} />
                     </Routes>
                 </BrowserRouter>
             </ThemeProvider>

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -29,3 +29,10 @@ export interface PageResponse<T> {
     totalElements: number
     totalPages: number
 }
+
+export interface BalanceResponse {
+    accountId: string
+    currency: string
+    amount: string
+    lastPostedAt: string | null
+}

--- a/web/src/components/StateMessage.tsx
+++ b/web/src/components/StateMessage.tsx
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+import type { ReactNode } from 'react'
+import { Icon, type IconName } from './Icon'
+
+interface StateMessageProps {
+    icon: IconName
+    text: string
+    children?: ReactNode
+}
+
+export function StateMessage({ icon, text, children }: StateMessageProps) {
+    return (
+        <div
+            style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                justifyContent: 'center',
+                gap: 10,
+                padding: '64px 24px',
+                color: 'var(--text-3)',
+                fontSize: 13,
+            }}
+        >
+            <Icon name={icon} size={20} />
+            <span>{text}</span>
+            {children}
+        </div>
+    )
+}

--- a/web/src/features/accounts/AccountsTable.tsx
+++ b/web/src/features/accounts/AccountsTable.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 FinCore Engine Authors
 
+import { Link } from 'react-router-dom'
 import type { AccountResponse } from '@/api/types'
 import { StatusPill, TypePill } from './Pills'
 
@@ -20,13 +21,14 @@ export function AccountsTable({ accounts }: { accounts: AccountResponse[] }) {
                 {accounts.map((account) => (
                     <tr key={account.id}>
                         <td>
-                            <span
+                            <Link
+                                to={`/accounts/${account.id}`}
                                 className="mono"
                                 title={account.id}
-                                style={{ color: 'var(--text)' }}
+                                style={{ color: 'var(--text-accent)', textDecoration: 'none' }}
                             >
                                 {account.id}
-                            </span>
+                            </Link>
                         </td>
                         <td>{account.name}</td>
                         <td>

--- a/web/src/features/accounts/useAccount.ts
+++ b/web/src/features/accounts/useAccount.ts
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+import { useQuery } from '@tanstack/react-query'
+import { apiFetch } from '@/api/client'
+import type { AccountResponse, BalanceResponse } from '@/api/types'
+
+export function useAccount(id: string) {
+    return useQuery({
+        queryKey: ['account', id],
+        queryFn: () => apiFetch<AccountResponse>(`/v1/accounts/${id}`),
+    })
+}
+
+export function useBalance(id: string) {
+    return useQuery({
+        queryKey: ['account', id, 'balance'],
+        queryFn: () => apiFetch<BalanceResponse>(`/v1/accounts/${id}/balance`),
+    })
+}

--- a/web/src/lib/money.ts
+++ b/web/src/lib/money.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+// Group the integer part with thousands separators while preserving the
+// fractional digits verbatim. Pure string work - never parse money to a number.
+export function formatAmount(amount: string): string {
+    const negative = amount.startsWith('-')
+    const unsigned = negative ? amount.slice(1) : amount
+    const [integer, fraction] = unsigned.split('.')
+    const grouped = integer.replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+    return (negative ? '-' : '') + grouped + (fraction ? `.${fraction}` : '')
+}
+
+export function formatInstant(iso: string): string {
+    return `${iso
+        .replace('T', ' ')
+        .replace(/\.\d+Z$/, 'Z')
+        .replace('Z', ' UTC')}`
+}

--- a/web/src/routes/AccountDetail.tsx
+++ b/web/src/routes/AccountDetail.tsx
@@ -1,0 +1,155 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+import { Link, useParams } from 'react-router-dom'
+import { ApiError } from '@/api/client'
+import { Icon } from '@/components/Icon'
+import { Shell } from '@/components/Shell'
+import { StateMessage } from '@/components/StateMessage'
+import { StatusPill, TypePill } from '@/features/accounts/Pills'
+import { useAccount, useBalance } from '@/features/accounts/useAccount'
+import { formatAmount, formatInstant } from '@/lib/money'
+
+export function AccountDetail() {
+    const { id = '' } = useParams()
+    const { data: account, isPending, isError, error, refetch } = useAccount(id)
+
+    return (
+        <Shell activeNav="Accounts">
+            <div
+                style={{
+                    padding: '20px 24px',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 16,
+                    flex: 1,
+                    minHeight: 0,
+                }}
+            >
+                <Link
+                    to="/accounts"
+                    style={{
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        gap: 6,
+                        fontSize: 12,
+                        color: 'var(--text-2)',
+                        textDecoration: 'none',
+                    }}
+                >
+                    <Icon name="chevLeft" size={12} />
+                    Accounts
+                </Link>
+
+                {isPending ? (
+                    <StateMessage icon="activity" text="Loading account..." />
+                ) : isError ? (
+                    error instanceof ApiError && error.status === 404 ? (
+                        <StateMessage icon="inbox" text="Account not found." />
+                    ) : (
+                        <StateMessage icon="alert" text="Could not load account.">
+                            <button type="button" className="btn" onClick={() => refetch()}>
+                                Retry
+                            </button>
+                        </StateMessage>
+                    )
+                ) : (
+                    <>
+                        <div
+                            className="card"
+                            style={{
+                                padding: 18,
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: 12,
+                                flexWrap: 'wrap',
+                            }}
+                        >
+                            <span
+                                style={{ fontSize: 19, fontWeight: 500, letterSpacing: '-0.01em' }}
+                            >
+                                {account.name}
+                            </span>
+                            <StatusPill status={account.status} />
+                            <TypePill type={account.type} />
+                            <span
+                                className="mono"
+                                style={{ fontSize: 11.5, color: 'var(--text-3)' }}
+                            >
+                                {account.id} · {account.currency}
+                            </span>
+                        </div>
+                        <BalanceCard id={id} />
+                    </>
+                )}
+            </div>
+        </Shell>
+    )
+}
+
+function BalanceCard({ id }: { id: string }) {
+    const { data: balance, isPending, isError, refetch } = useBalance(id)
+
+    return (
+        <div className="card" style={{ padding: 18, maxWidth: 360 }}>
+            <div
+                style={{
+                    fontSize: 11,
+                    color: 'var(--text-3)',
+                    textTransform: 'uppercase',
+                    letterSpacing: '0.06em',
+                }}
+            >
+                Current balance
+            </div>
+            {isPending ? (
+                <div style={{ marginTop: 8, fontSize: 13, color: 'var(--text-3)' }}>
+                    Loading balance...
+                </div>
+            ) : isError ? (
+                <div
+                    style={{
+                        marginTop: 8,
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 10,
+                        fontSize: 13,
+                        color: 'var(--text-3)',
+                    }}
+                >
+                    <span>Could not load balance.</span>
+                    <button type="button" className="btn btn-sm" onClick={() => refetch()}>
+                        Retry
+                    </button>
+                </div>
+            ) : (
+                <>
+                    <div
+                        className="mono tnum"
+                        style={{
+                            fontSize: 32,
+                            fontWeight: 500,
+                            letterSpacing: '-0.02em',
+                            marginTop: 8,
+                        }}
+                    >
+                        <span>{formatAmount(balance.amount)}</span>{' '}
+                        <span style={{ fontSize: 14, color: 'var(--text-3)', fontWeight: 400 }}>
+                            {balance.currency}
+                        </span>
+                    </div>
+                    <div style={{ fontSize: 11.5, color: 'var(--text-2)', marginTop: 6 }}>
+                        {balance.lastPostedAt ? (
+                            <>
+                                last posted{' '}
+                                <span className="mono">{formatInstant(balance.lastPostedAt)}</span>
+                            </>
+                        ) : (
+                            'No postings yet.'
+                        )}
+                    </div>
+                </>
+            )}
+        </div>
+    )
+}

--- a/web/src/routes/Accounts.tsx
+++ b/web/src/routes/Accounts.tsx
@@ -2,8 +2,8 @@
 // SPDX-FileCopyrightText: 2026 FinCore Engine Authors
 
 import { useState } from 'react'
-import { Icon } from '@/components/Icon'
 import { Shell } from '@/components/Shell'
+import { StateMessage } from '@/components/StateMessage'
 import { AccountsTable } from '@/features/accounts/AccountsTable'
 import { Pagination } from '@/features/accounts/Pagination'
 import { useAccounts } from '@/features/accounts/useAccounts'
@@ -63,34 +63,5 @@ export function Accounts() {
                 </div>
             </div>
         </Shell>
-    )
-}
-
-function StateMessage({
-    icon,
-    text,
-    children,
-}: {
-    icon: 'activity' | 'alert' | 'inbox'
-    text: string
-    children?: React.ReactNode
-}) {
-    return (
-        <div
-            style={{
-                display: 'flex',
-                flexDirection: 'column',
-                alignItems: 'center',
-                justifyContent: 'center',
-                gap: 10,
-                padding: '64px 24px',
-                color: 'var(--text-3)',
-                fontSize: 13,
-            }}
-        >
-            <Icon name={icon} size={20} />
-            <span>{text}</span>
-            {children}
-        </div>
     )
 }

--- a/web/src/test/AccountDetail.test.tsx
+++ b/web/src/test/AccountDetail.test.tsx
@@ -1,0 +1,100 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { AccountResponse, BalanceResponse } from '@/api/types'
+import { ThemeProvider } from '@/components/ThemeProvider'
+import { AccountDetail } from '@/routes/AccountDetail'
+
+const ACCOUNT: AccountResponse = {
+    id: 'acc_0001',
+    name: 'Operating Cash',
+    type: 'ASSET',
+    currency: 'EUR',
+    status: 'ACTIVE',
+}
+const BALANCE: BalanceResponse = {
+    accountId: 'acc_0001',
+    currency: 'EUR',
+    amount: '1234567.89',
+    lastPostedAt: '2026-06-13T10:00:00Z',
+}
+
+function ok(body: unknown) {
+    return { ok: true, status: 200, json: async () => body } as Response
+}
+function fail(status: number) {
+    return { ok: false, status, json: async () => ({}) } as Response
+}
+
+function mockFetch(opts: { account?: () => Response; balance?: () => Response } = {}) {
+    return vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+        const url = String(input)
+        if (url.endsWith('/balance'))
+            return Promise.resolve((opts.balance ?? (() => ok(BALANCE)))())
+        return Promise.resolve((opts.account ?? (() => ok(ACCOUNT)))())
+    })
+}
+
+function renderDetail(id = 'acc_0001') {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    return render(
+        <QueryClientProvider client={client}>
+            <MemoryRouter initialEntries={[`/accounts/${id}`]}>
+                <ThemeProvider>
+                    <Routes>
+                        <Route path="/accounts/:id" element={<AccountDetail />} />
+                    </Routes>
+                </ThemeProvider>
+            </MemoryRouter>
+        </QueryClientProvider>,
+    )
+}
+
+afterEach(() => {
+    vi.restoreAllMocks()
+})
+
+describe('AccountDetail', () => {
+    it('renders the account header and a losslessly formatted balance', async () => {
+        mockFetch()
+        renderDetail()
+        expect(await screen.findByText('Operating Cash')).toBeInTheDocument()
+        expect(screen.getByText('ACTIVE')).toBeInTheDocument()
+        expect(screen.getByText('ASSET')).toBeInTheDocument()
+        expect(await screen.findByText('1,234,567.89')).toBeInTheDocument()
+        expect(screen.getByText(/last posted/)).toBeInTheDocument()
+        expect(screen.getByText('2026-06-13 10:00:00 UTC')).toBeInTheDocument()
+    })
+
+    it('shows a not-found state on 404', async () => {
+        mockFetch({ account: () => fail(404) })
+        renderDetail()
+        expect(await screen.findByText('Account not found.')).toBeInTheDocument()
+    })
+
+    it('shows an error state with Retry on a server error', async () => {
+        const fetchMock = mockFetch({ account: () => fail(500) })
+        renderDetail()
+        expect(await screen.findByText('Could not load account.')).toBeInTheDocument()
+        const before = fetchMock.mock.calls.length
+        fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+        await waitFor(() => expect(fetchMock.mock.calls.length).toBeGreaterThan(before))
+    })
+
+    it('shows a balance error independently when the account loads', async () => {
+        mockFetch({ balance: () => fail(500) })
+        renderDetail()
+        expect(await screen.findByText('Operating Cash')).toBeInTheDocument()
+        expect(await screen.findByText('Could not load balance.')).toBeInTheDocument()
+    })
+
+    it('shows a no-postings hint when lastPostedAt is null', async () => {
+        mockFetch({ balance: () => ok({ ...BALANCE, lastPostedAt: null }) })
+        renderDetail()
+        expect(await screen.findByText('No postings yet.')).toBeInTheDocument()
+    })
+})

--- a/web/src/test/money.test.ts
+++ b/web/src/test/money.test.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+import { describe, expect, it } from 'vitest'
+import { formatAmount, formatInstant } from '@/lib/money'
+
+describe('formatAmount', () => {
+    it('groups thousands and keeps the fraction verbatim', () => {
+        expect(formatAmount('1234567.89')).toBe('1,234,567.89')
+    })
+
+    it('preserves a high-scale fraction without rounding', () => {
+        expect(formatAmount('100.123456789012345678')).toBe('100.123456789012345678')
+    })
+
+    it('keeps trailing zeros', () => {
+        expect(formatAmount('100.00')).toBe('100.00')
+    })
+
+    it('handles negative amounts', () => {
+        expect(formatAmount('-12345.6')).toBe('-12,345.6')
+    })
+
+    it('handles integers without a fraction', () => {
+        expect(formatAmount('1000')).toBe('1,000')
+    })
+})
+
+describe('formatInstant', () => {
+    it('renders an instant as a UTC timestamp', () => {
+        expect(formatInstant('2026-06-13T10:00:00Z')).toBe('2026-06-13 10:00:00 UTC')
+    })
+
+    it('drops sub-second precision', () => {
+        expect(formatInstant('2026-06-13T10:00:00.123456Z')).toBe('2026-06-13 10:00:00 UTC')
+    })
+})


### PR DESCRIPTION
Second Sandbox UI screen on the live backend (Screen 2).

## What
- `/accounts/:id` route, reached from the Account Browser (id cell is a link)
- header from `GET /v1/accounts/{id}`: name, id (mono), type pill, status pill, currency
- current balance from `GET /v1/accounts/{id}/balance`: amount, currency, last posted at
- amount is the lossless decimal string (#114) formatted with pure string grouping - no float math on money
- states: loading, 404 -> not found, error + retry; the balance card has its own loading/error
- extracts a shared `StateMessage` component (deduped from the account browser)

## Out of scope (no backing API)
entries table, audit trail, holds/available, 30d delta, time-travel, lifecycle actions, linked entities.

## Tests
`money.test.ts` (grouping, high-scale fraction preserved, trailing zeros, negative, instant formatting) and `AccountDetail.test.tsx` (header + lossless balance, 404, error+retry, independent balance error, no-postings). 22 web tests pass.

Closes #115