### PR TITLE
feat(ledger): add paginated transaction listing endpoint

### DIFF
--- a/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/api/TransactionListingIT.kt
+++ b/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/api/TransactionListingIT.kt
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.api
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fincore.core.TransactionId
+import com.fincore.ledger.domain.enum.TransactionStatus
+import com.fincore.ledger.infrastructure.persistence.TransactionEntity
+import com.fincore.ledger.infrastructure.persistence.TransactionRepository
+import com.fincore.test.containers.PostgresContainerExtension
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import java.time.Instant
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ExtendWith(PostgresContainerExtension::class)
+@Import(TransactionListingIT.TestSecurity::class)
+class TransactionListingIT(
+    @Autowired private val rest: TestRestTemplate,
+    @Autowired private val objectMapper: ObjectMapper,
+    @Autowired private val transactionRepository: TransactionRepository,
+) {
+    @TestConfiguration
+    class TestSecurity {
+        @Bean
+        fun jwtDecoder(): JwtDecoder =
+            JwtDecoder { token ->
+                Jwt
+                    .withTokenValue(token)
+                    .header("alg", "none")
+                    .subject("tx-list-it")
+                    .issuedAt(Instant.now())
+                    .expiresAt(Instant.now().plusSeconds(EXPIRY_SECONDS))
+                    .build()
+            }
+    }
+
+    private fun persist(
+        reference: String,
+        postedAt: Instant,
+    ) {
+        transactionRepository.saveAndFlush(
+            TransactionEntity(
+                id = TransactionId.generate().value,
+                reference = reference,
+                description = null,
+                status = TransactionStatus.POSTED,
+                reversesId = null,
+                metadata = "{}",
+                postedAt = postedAt,
+                createdAt = postedAt,
+                createdBy = "tx-list-it",
+            ),
+        )
+    }
+
+    @Test
+    fun `should return transactions newest first across the page`() {
+        val base = Instant.parse("2026-06-13T00:00:00Z")
+        val references = listOf("tx-list-it-a", "tx-list-it-b", "tx-list-it-c")
+        references.forEachIndexed { i, reference -> persist(reference, base.plusSeconds(i.toLong())) }
+
+        val headers = HttpHeaders().apply { setBearerAuth("list-token") }
+        val response = rest.exchange("/v1/transactions?page=0&size=100", HttpMethod.GET, HttpEntity<Void>(headers), String::class.java)
+
+        response.statusCode.value() shouldBe 200
+        val tree = objectMapper.readTree(response.body)
+        (tree.get("totalElements").asLong() >= 3) shouldBe true
+        val ordered = tree.get("items").map { it.get("reference").asText() }.filter { it in references }
+        ordered shouldBe listOf("tx-list-it-c", "tx-list-it-b", "tx-list-it-a")
+        tree
+            .get("items")
+            .first()
+            .get("id")
+            .asText()
+            .startsWith("tx_") shouldBe true
+        tree
+            .get("items")
+            .first()
+            .get("status")
+            .asText() shouldBe "POSTED"
+    }
+
+    @Test
+    fun `should return disjoint slices across successive pages`() {
+        val base = Instant.parse("2026-06-14T00:00:00Z")
+        (0 until 5).forEach { i -> persist("tx-list-it-page-$i", base.plusSeconds(i.toLong())) }
+
+        val headers = HttpHeaders().apply { setBearerAuth("list-token") }
+        val first = idsAndTimes("/v1/transactions?page=0&size=2", headers)
+        val second = idsAndTimes("/v1/transactions?page=1&size=2", headers)
+
+        (first.map { it.first }.intersect(second.map { it.first }.toSet())).isEmpty() shouldBe true
+        val times = (first + second).map { it.second }
+        times shouldBe times.sortedDescending()
+    }
+
+    private fun idsAndTimes(
+        path: String,
+        headers: HttpHeaders,
+    ): List<Pair<String, String>> {
+        val response = rest.exchange(path, HttpMethod.GET, HttpEntity<Void>(headers), String::class.java)
+        response.statusCode.value() shouldBe 200
+        return objectMapper.readTree(response.body).get("items").map { it.get("id").asText() to it.get("postedAt").asText() }
+    }
+
+    companion object {
+        private const val EXPIRY_SECONDS = 300L
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun datasourceProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { PostgresContainerExtension.jdbcUrl }
+            registry.add("spring.datasource.username") { PostgresContainerExtension.username }
+            registry.add("spring.datasource.password") { PostgresContainerExtension.password }
+            registry.add("spring.jpa.hibernate.ddl-auto") { "none" }
+        }
+    }
+}

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/api/TransactionController.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/api/TransactionController.kt
@@ -6,6 +6,8 @@ package com.fincore.ledger.api
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fincore.core.IdempotencyKey
 import com.fincore.ledger.api.dto.request.PostTransactionRequest
+import com.fincore.ledger.api.dto.response.PageResponse
+import com.fincore.ledger.api.dto.response.TransactionResponse
 import com.fincore.ledger.api.idempotency.IdempotencyAttributes
 import com.fincore.ledger.api.mapper.LedgerApiMapper
 import com.fincore.ledger.application.IdempotencyService
@@ -18,11 +20,13 @@ import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestAttribute
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.net.URI
 
@@ -52,6 +56,16 @@ class TransactionController(
         return respond(result, location)
     }
 
+    @GetMapping
+    fun list(
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "20") size: Int,
+    ): PageResponse<TransactionResponse> {
+        require(page >= 0) { "page must be >= 0" }
+        require(size in 1..MAX_PAGE_SIZE) { "size must be 1..$MAX_PAGE_SIZE" }
+        return mapper.toPageResponse(transactionService.list(page, size))
+    }
+
     private fun respond(
         result: IdempotentResult,
         location: URI?,
@@ -65,5 +79,6 @@ class TransactionController(
 
     private companion object {
         const val CORRELATION_HEADER = "X-Correlation-Id"
+        const val MAX_PAGE_SIZE = 100
     }
 }

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/api/dto/response/TransactionResponse.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/api/dto/response/TransactionResponse.kt
@@ -3,10 +3,12 @@
 
 package com.fincore.ledger.api.dto.response
 
+import com.fincore.ledger.domain.enum.TransactionStatus
 import java.time.Instant
 
 data class TransactionResponse(
     val id: String,
     val reference: String,
+    val status: TransactionStatus,
     val postedAt: Instant,
 )

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/api/mapper/LedgerApiMapper.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/api/mapper/LedgerApiMapper.kt
@@ -17,6 +17,8 @@ import com.fincore.ledger.application.CreateAccountCommand
 import com.fincore.ledger.application.EntryLine
 import com.fincore.ledger.application.PostTransactionCommand
 import com.fincore.ledger.application.PostedTransaction
+import com.fincore.ledger.application.TransactionPage
+import com.fincore.ledger.application.TransactionSummary
 import com.fincore.ledger.domain.Account
 import org.springframework.stereotype.Component
 
@@ -86,6 +88,24 @@ class LedgerApiMapper {
         TransactionResponse(
             id = posted.id.toString(),
             reference = posted.reference,
+            status = posted.status,
             postedAt = posted.postedAt,
+        )
+
+    fun toResponse(summary: TransactionSummary): TransactionResponse =
+        TransactionResponse(
+            id = summary.id.toString(),
+            reference = summary.reference,
+            status = summary.status,
+            postedAt = summary.postedAt,
+        )
+
+    fun toPageResponse(page: TransactionPage): PageResponse<TransactionResponse> =
+        PageResponse(
+            items = page.items.map { toResponse(it) },
+            page = page.page,
+            size = page.size,
+            totalElements = page.totalElements,
+            totalPages = page.totalPages,
         )
 }

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/application/TransactionPage.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/application/TransactionPage.kt
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.application
+
+data class TransactionPage(
+    val items: List<TransactionSummary>,
+    val page: Int,
+    val size: Int,
+    val totalElements: Long,
+    val totalPages: Int,
+)

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/application/TransactionPoster.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/application/TransactionPoster.kt
@@ -54,7 +54,7 @@ class TransactionPoster(
         persist(transaction, command, postedAt)
         applyBalances(transaction, command, postedAt)
         emit(transaction, command, postedAt)
-        return PostedTransaction(transaction.id, transaction.reference, postedAt)
+        return PostedTransaction(transaction.id, transaction.reference, transaction.status, postedAt)
     }
 
     private fun buildDomain(command: PostTransactionCommand): Transaction {

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/application/TransactionService.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/application/TransactionService.kt
@@ -5,4 +5,9 @@ package com.fincore.ledger.application
 
 interface TransactionService {
     fun post(command: PostTransactionCommand): PostedTransaction
+
+    fun list(
+        page: Int,
+        size: Int,
+    ): TransactionPage
 }

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/application/TransactionServiceImpl.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/application/TransactionServiceImpl.kt
@@ -3,13 +3,20 @@
 
 package com.fincore.ledger.application
 
+import com.fincore.core.TransactionId
 import com.fincore.ledger.domain.exception.ConcurrencyConflictException
+import com.fincore.ledger.infrastructure.persistence.TransactionEntity
+import com.fincore.ledger.infrastructure.persistence.TransactionRepository
 import org.springframework.dao.OptimisticLockingFailureException
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
 
 @Service
 class TransactionServiceImpl(
     private val poster: TransactionPoster,
+    private val transactionRepository: TransactionRepository,
 ) : TransactionService {
     override fun post(command: PostTransactionCommand): PostedTransaction {
         var attempt = 0
@@ -24,6 +31,25 @@ class TransactionServiceImpl(
             }
         }
     }
+
+    @Transactional(readOnly = true)
+    override fun list(
+        page: Int,
+        size: Int,
+    ): TransactionPage {
+        val pageable = PageRequest.of(page, size, Sort.by(Sort.Order.desc("postedAt"), Sort.Order.desc("id")))
+        val result = transactionRepository.findAll(pageable)
+        return TransactionPage(
+            items = result.content.map(::toSummary),
+            page = page,
+            size = size,
+            totalElements = result.totalElements,
+            totalPages = result.totalPages,
+        )
+    }
+
+    private fun toSummary(entity: TransactionEntity): TransactionSummary =
+        TransactionSummary(TransactionId(entity.id), entity.reference, entity.status, entity.postedAt)
 
     private companion object {
         const val MAX_ATTEMPTS = 3

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/application/TransactionSummary.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/application/TransactionSummary.kt
@@ -7,7 +7,7 @@ import com.fincore.core.TransactionId
 import com.fincore.ledger.domain.enum.TransactionStatus
 import java.time.Instant
 
-data class PostedTransaction(
+data class TransactionSummary(
     val id: TransactionId,
     val reference: String,
     val status: TransactionStatus,

--- a/services/ledger/src/test/kotlin/com/fincore/ledger/api/TransactionControllerTest.kt
+++ b/services/ledger/src/test/kotlin/com/fincore/ledger/api/TransactionControllerTest.kt
@@ -10,9 +10,12 @@ import com.fincore.ledger.api.idempotency.IdempotencyFilter
 import com.fincore.ledger.api.mapper.LedgerApiMapper
 import com.fincore.ledger.application.PostTransactionCommand
 import com.fincore.ledger.application.PostedTransaction
+import com.fincore.ledger.application.TransactionPage
 import com.fincore.ledger.application.TransactionService
+import com.fincore.ledger.application.TransactionSummary
 import com.fincore.ledger.config.SecurityConfig
 import com.fincore.ledger.domain.enum.EntryDirection
+import com.fincore.ledger.domain.enum.TransactionStatus
 import com.fincore.ledger.domain.exception.AccountNotFoundException
 import com.fincore.ledger.domain.exception.ConcurrencyConflictException
 import com.fincore.ledger.domain.exception.CurrencyConsistencyViolationException
@@ -23,6 +26,8 @@ import io.mockk.clearMocks
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.slot
+import io.mockk.verify
+import org.hamcrest.Matchers.matchesPattern
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -34,8 +39,10 @@ import org.springframework.http.MediaType
 import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.math.BigDecimal
 import java.time.Instant
@@ -87,10 +94,11 @@ class TransactionControllerTest(
     fun `should post a balanced transaction and pass through signed amounts and actor`() {
         val commandSlot = slot<PostTransactionCommand>()
         every { transactionService.post(capture(commandSlot)) } returns
-            PostedTransaction(TransactionId.generate(), "tx-ref-1", Instant.parse("2026-06-13T10:00:00Z"))
+            PostedTransaction(TransactionId.generate(), "tx-ref-1", TransactionStatus.POSTED, Instant.parse("2026-06-13T10:00:00Z"))
 
         postBalanced(correlationId = "corr-1")
             .andExpect(status().isCreated)
+            .andExpect(jsonPath("$.status").value("POSTED"))
             .andExpect(header().string("Location", org.hamcrest.Matchers.startsWith("/v1/transactions/tx_")))
 
         val command = commandSlot.captured
@@ -145,5 +153,75 @@ class TransactionControllerTest(
                     .contentType(MediaType.APPLICATION_JSON)
                     .content("""{"reference":"r","currency":"EUR","entries":[{"accountId":"$accountA","direction":"DEBIT","amount":1}]}"""),
             ).andExpect(status().isBadRequest)
+    }
+
+    private fun summary(
+        reference: String,
+        status: TransactionStatus,
+    ) = TransactionSummary(TransactionId.generate(), reference, status, Instant.parse("2026-06-13T10:00:00Z"))
+
+    @Test
+    fun `should list transactions as a page with prefixed ids and status`() {
+        every { transactionService.list(0, 20) } returns
+            TransactionPage(
+                items = listOf(summary("tx-ref-2", TransactionStatus.POSTED), summary("tx-ref-1", TransactionStatus.REVERSED)),
+                page = 0,
+                size = 20,
+                totalElements = 2,
+                totalPages = 1,
+            )
+
+        mockMvc
+            .perform(get("/v1/transactions?page=0&size=20").with(jwt()))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.items[0].id").value(matchesPattern("^tx_[0-9A-HJKMNP-TV-Z]{26}$")))
+            .andExpect(jsonPath("$.items[0].status").value("POSTED"))
+            .andExpect(jsonPath("$.items[1].status").value("REVERSED"))
+            .andExpect(jsonPath("$.page").value(0))
+            .andExpect(jsonPath("$.totalElements").value(2))
+    }
+
+    @Test
+    fun `should return an empty page when no transactions exist`() {
+        every { transactionService.list(0, 20) } returns TransactionPage(emptyList(), 0, 20, 0, 0)
+
+        mockMvc
+            .perform(get("/v1/transactions").with(jwt()))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.items").isEmpty)
+            .andExpect(jsonPath("$.totalElements").value(0))
+            .andExpect(jsonPath("$.totalPages").value(0))
+    }
+
+    @Test
+    fun `should reject an oversized page request with 400`() {
+        mockMvc
+            .perform(get("/v1/transactions?size=101").with(jwt()))
+            .andExpect(status().isBadRequest)
+
+        verify(exactly = 0) { transactionService.list(any(), any()) }
+    }
+
+    @Test
+    fun `should reject a zero page size with 400`() {
+        mockMvc
+            .perform(get("/v1/transactions?size=0").with(jwt()))
+            .andExpect(status().isBadRequest)
+
+        verify(exactly = 0) { transactionService.list(any(), any()) }
+    }
+
+    @Test
+    fun `should reject a negative page index with 400`() {
+        mockMvc
+            .perform(get("/v1/transactions?page=-1").with(jwt()))
+            .andExpect(status().isBadRequest)
+
+        verify(exactly = 0) { transactionService.list(any(), any()) }
+    }
+
+    @Test
+    fun `should reject an unauthenticated list request with 401`() {
+        mockMvc.perform(get("/v1/transactions")).andExpect(status().isUnauthorized)
     }
 }

--- a/services/ledger/src/test/kotlin/com/fincore/ledger/api/mapper/LedgerApiMapperTest.kt
+++ b/services/ledger/src/test/kotlin/com/fincore/ledger/api/mapper/LedgerApiMapperTest.kt
@@ -16,6 +16,7 @@ import com.fincore.ledger.domain.Account
 import com.fincore.ledger.domain.enum.AccountStatus
 import com.fincore.ledger.domain.enum.AccountType
 import com.fincore.ledger.domain.enum.EntryDirection
+import com.fincore.ledger.domain.enum.TransactionStatus
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldStartWith
 import org.junit.jupiter.api.Test
@@ -86,7 +87,7 @@ class LedgerApiMapperTest {
 
     @Test
     fun `should serialize transaction id as prefixed ulid`() {
-        val posted = PostedTransaction(TransactionId.generate(), "ref-1", java.time.Instant.now())
+        val posted = PostedTransaction(TransactionId.generate(), "ref-1", TransactionStatus.POSTED, java.time.Instant.now())
         mapper.toResponse(posted).id shouldStartWith "tx_"
     }
 }

--- a/services/ledger/src/test/kotlin/com/fincore/ledger/application/TransactionServiceImplTest.kt
+++ b/services/ledger/src/test/kotlin/com/fincore/ledger/application/TransactionServiceImplTest.kt
@@ -7,20 +7,30 @@ import com.fincore.core.AccountId
 import com.fincore.core.Currency
 import com.fincore.core.TransactionId
 import com.fincore.ledger.domain.enum.EntryDirection
+import com.fincore.ledger.domain.enum.TransactionStatus
 import com.fincore.ledger.domain.exception.ConcurrencyConflictException
+import com.fincore.ledger.infrastructure.persistence.TransactionEntity
+import com.fincore.ledger.infrastructure.persistence.TransactionRepository
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.every
 import io.mockk.mockk
+import io.mockk.slot
 import io.mockk.verify
 import org.junit.jupiter.api.Test
 import org.springframework.dao.OptimisticLockingFailureException
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Pageable
+import org.springframework.data.domain.Sort
 import java.math.BigDecimal
 import java.time.Instant
+import java.util.UUID
 
 class TransactionServiceImplTest {
     private val poster = mockk<TransactionPoster>()
-    private val service = TransactionServiceImpl(poster)
+    private val transactionRepository = mockk<TransactionRepository>()
+    private val service = TransactionServiceImpl(poster, transactionRepository)
 
     private val command =
         PostTransactionCommand(
@@ -38,7 +48,7 @@ class TransactionServiceImplTest {
 
     @Test
     fun `should post through the poster`() {
-        every { poster.post(command) } returns PostedTransaction(TransactionId.generate(), "ref-1", Instant.now())
+        every { poster.post(command) } returns PostedTransaction(TransactionId.generate(), "ref-1", TransactionStatus.POSTED, Instant.now())
 
         service.post(command).reference shouldBe "ref-1"
     }
@@ -49,7 +59,7 @@ class TransactionServiceImplTest {
         every { poster.post(command) } answers {
             calls++
             if (calls < 2) throw OptimisticLockingFailureException("version conflict")
-            PostedTransaction(TransactionId.generate(), "ref-1", Instant.now())
+            PostedTransaction(TransactionId.generate(), "ref-1", TransactionStatus.POSTED, Instant.now())
         }
 
         service.post(command)
@@ -64,5 +74,36 @@ class TransactionServiceImplTest {
         shouldThrow<ConcurrencyConflictException> { service.post(command) }
 
         verify(exactly = 3) { poster.post(command) }
+    }
+
+    @Test
+    fun `should list transactions mapped to summaries ordered by posted_at desc then id desc`() {
+        val id = UUID.randomUUID()
+        val postedAt = Instant.parse("2026-06-10T09:00:00Z")
+        val entity =
+            TransactionEntity(
+                id = id,
+                reference = "ref-9",
+                description = null,
+                status = TransactionStatus.POSTED,
+                reversesId = null,
+                metadata = "{}",
+                postedAt = postedAt,
+                createdAt = postedAt,
+                createdBy = "op",
+            )
+        val pageableSlot = slot<Pageable>()
+        every { transactionRepository.findAll(capture(pageableSlot)) } returns PageImpl(listOf(entity), PageRequest.of(0, 20), 1)
+
+        val page = service.list(0, 20)
+
+        page.totalElements shouldBe 1
+        page.items.single().let {
+            it.id shouldBe TransactionId(id)
+            it.reference shouldBe "ref-9"
+            it.status shouldBe TransactionStatus.POSTED
+            it.postedAt shouldBe postedAt
+        }
+        pageableSlot.captured.sort shouldBe Sort.by(Sort.Order.desc("postedAt"), Sort.Order.desc("id"))
     }
 }


### PR DESCRIPTION
## What

Adds `GET /v1/transactions?page=&size=` returning a generic `PageResponse<TransactionResponse>`, the Sandbox Transaction Explorer (Screen 3) feed. Mirrors the merged `GET /v1/accounts` (PR #110) one-to-one.

## How

- Read-only global listing over `ledger.transactions` only (no entry join, no money on the wire). `@Transactional(readOnly = true)`.
- New application read-model `TransactionSummary` (id/reference/status/postedAt) + `TransactionPage`; the JPA entity does not cross the application boundary.
- `status` added to the shared `TransactionResponse` and to `PostedTransaction`, read from the domain `Transaction.status` (not hardcoded). Additive: the POST response now also carries `status: "POSTED"`, otherwise unchanged.
- Ordering `posted_at` desc, `id` desc (ULID tiebreaker), deterministic across pages.
- Thin controller: `page >= 0`, `size in 1..100`, out-of-range -> 400 via the existing handler; JWT-secured. No schema change.

## Tests

- `TransactionControllerTest`: list 200 (tx_-prefixed ids + status), empty page, 400 on `size=0|101` and `page=-1` (service not invoked), 401 unauthenticated, POST returns `status: "POSTED"`.
- `TransactionServiceImplTest`: list maps entity -> summary and requests sort `postedAt desc, id desc`.
- `TransactionListingIT` (Testcontainers): newest-first ordering and disjoint successive pages.

Closes #117