### PR TITLE
feat(web): add transaction explorer screen on live transactions api

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,6 +7,7 @@ import { ThemeProvider } from '@/components/ThemeProvider'
 import { AccountDetail } from '@/routes/AccountDetail'
 import { Accounts } from '@/routes/Accounts'
 import { Overview } from '@/routes/Overview'
+import { Transactions } from '@/routes/Transactions'
 
 const queryClient = new QueryClient()
 
@@ -19,6 +20,7 @@ export function App() {
                         <Route path="/" element={<Overview />} />
                         <Route path="/accounts" element={<Accounts />} />
                         <Route path="/accounts/:id" element={<AccountDetail />} />
+                        <Route path="/transactions" element={<Transactions />} />
                     </Routes>
                 </BrowserRouter>
             </ThemeProvider>

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -30,6 +30,15 @@ export interface PageResponse<T> {
     totalPages: number
 }
 
+export type TransactionStatus = 'POSTED' | 'REVERSED'
+
+export interface TransactionResponse {
+    id: string
+    reference: string
+    status: TransactionStatus
+    postedAt: string
+}
+
 export interface BalanceResponse {
     accountId: string
     currency: string

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -13,7 +13,7 @@ interface NavItem {
 const NAV: NavItem[] = [
     { name: 'Overview', icon: 'home', path: '/' },
     { name: 'Accounts', icon: 'wallet', path: '/accounts' },
-    { name: 'Transactions', icon: 'arrows' },
+    { name: 'Transactions', icon: 'arrows', path: '/transactions' },
     { name: 'Payments', icon: 'send' },
     { name: 'Decisions', icon: 'scale' },
     { name: 'Compliance', icon: 'shield' },

--- a/web/src/features/accounts/Pagination.tsx
+++ b/web/src/features/accounts/Pagination.tsx
@@ -9,9 +9,17 @@ interface PaginationProps {
     totalElements: number
     onPrev: () => void
     onNext: () => void
+    noun?: string
 }
 
-export function Pagination({ page, totalPages, totalElements, onPrev, onNext }: PaginationProps) {
+export function Pagination({
+    page,
+    totalPages,
+    totalElements,
+    onPrev,
+    onNext,
+    noun = 'accounts',
+}: PaginationProps) {
     const prevDisabled = page <= 0
     const nextDisabled = totalPages === 0 || page >= totalPages - 1
     return (
@@ -30,7 +38,7 @@ export function Pagination({ page, totalPages, totalElements, onPrev, onNext }: 
                 <span className="mono" style={{ color: 'var(--text)' }}>
                     {totalElements}
                 </span>{' '}
-                accounts
+                {noun}
             </span>
             <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
                 <button

--- a/web/src/features/transactions/Pills.tsx
+++ b/web/src/features/transactions/Pills.tsx
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+import type { TransactionStatus } from '@/api/types'
+
+const STATUS_CLASS: Record<TransactionStatus, string> = {
+    POSTED: 'pill-teal',
+    REVERSED: 'pill-grey',
+}
+
+export function TxStatusPill({ status }: { status: TransactionStatus }) {
+    return (
+        <span className={`pill ${STATUS_CLASS[status] ?? 'pill-grey'}`}>
+            <span className="dot" />
+            {status}
+        </span>
+    )
+}

--- a/web/src/features/transactions/TransactionsTable.tsx
+++ b/web/src/features/transactions/TransactionsTable.tsx
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+import type { TransactionResponse } from '@/api/types'
+import { formatInstant } from '@/lib/money'
+import { TxStatusPill } from './Pills'
+
+export function TransactionsTable({ transactions }: { transactions: TransactionResponse[] }) {
+    return (
+        <table className="tbl">
+            <thead>
+                <tr>
+                    <th>Transaction ID</th>
+                    <th>Reference</th>
+                    <th>Status</th>
+                    <th>Posted At</th>
+                </tr>
+            </thead>
+            <tbody>
+                {transactions.map((transaction) => (
+                    <tr key={transaction.id}>
+                        <td
+                            className="mono"
+                            title={transaction.id}
+                            style={{ color: 'var(--text-2)' }}
+                        >
+                            {transaction.id}
+                        </td>
+                        <td>{transaction.reference}</td>
+                        <td>
+                            <TxStatusPill status={transaction.status} />
+                        </td>
+                        <td className="mono" style={{ color: 'var(--text-2)' }}>
+                            {formatInstant(transaction.postedAt)}
+                        </td>
+                    </tr>
+                ))}
+            </tbody>
+        </table>
+    )
+}

--- a/web/src/features/transactions/useTransactions.ts
+++ b/web/src/features/transactions/useTransactions.ts
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+import { useQuery } from '@tanstack/react-query'
+import { apiFetch } from '@/api/client'
+import type { PageResponse, TransactionResponse } from '@/api/types'
+
+export function useTransactions(page: number, size: number) {
+    return useQuery({
+        queryKey: ['transactions', page, size],
+        queryFn: () =>
+            apiFetch<PageResponse<TransactionResponse>>(
+                `/v1/transactions?page=${page}&size=${size}`,
+            ),
+    })
+}

--- a/web/src/routes/Transactions.tsx
+++ b/web/src/routes/Transactions.tsx
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+import { useState } from 'react'
+import { Shell } from '@/components/Shell'
+import { StateMessage } from '@/components/StateMessage'
+import { Pagination } from '@/features/accounts/Pagination'
+import { TransactionsTable } from '@/features/transactions/TransactionsTable'
+import { useTransactions } from '@/features/transactions/useTransactions'
+
+const PAGE_SIZE = 20
+
+export function Transactions() {
+    const [page, setPage] = useState(0)
+    const { data, isPending, isError, refetch } = useTransactions(page, PAGE_SIZE)
+
+    return (
+        <Shell activeNav="Transactions">
+            <div
+                style={{
+                    padding: '20px 24px',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 16,
+                    flex: 1,
+                    minHeight: 0,
+                }}
+            >
+                <div
+                    className="card"
+                    style={{
+                        flex: 1,
+                        minHeight: 0,
+                        display: 'flex',
+                        flexDirection: 'column',
+                        overflow: 'hidden',
+                    }}
+                >
+                    <div style={{ flex: 1, overflow: 'auto' }} className="fc-scroll">
+                        {isPending ? (
+                            <StateMessage icon="activity" text="Loading transactions..." />
+                        ) : isError ? (
+                            <StateMessage icon="alert" text="Could not load transactions.">
+                                <button type="button" className="btn" onClick={() => refetch()}>
+                                    Retry
+                                </button>
+                            </StateMessage>
+                        ) : data.totalElements === 0 ? (
+                            <StateMessage icon="inbox" text="No transactions yet." />
+                        ) : (
+                            <TransactionsTable transactions={data.items} />
+                        )}
+                    </div>
+                    {!isPending && !isError && (
+                        <Pagination
+                            page={data.page}
+                            totalPages={data.totalPages}
+                            totalElements={data.totalElements}
+                            onPrev={() => setPage((p) => Math.max(0, p - 1))}
+                            onNext={() => setPage((p) => p + 1)}
+                            noun="transactions"
+                        />
+                    )}
+                </div>
+            </div>
+        </Shell>
+    )
+}

--- a/web/src/test/Transactions.test.tsx
+++ b/web/src/test/Transactions.test.tsx
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { PageResponse, TransactionResponse } from '@/api/types'
+import { ThemeProvider } from '@/components/ThemeProvider'
+import { Transactions } from '@/routes/Transactions'
+
+function page(
+    items: TransactionResponse[],
+    over: Partial<PageResponse<TransactionResponse>> = {},
+): PageResponse<TransactionResponse> {
+    return { items, page: 0, size: 20, totalElements: items.length, totalPages: 1, ...over }
+}
+
+const SAMPLE: TransactionResponse[] = [
+    {
+        id: 'tx_0001',
+        reference: 'payroll-0425',
+        status: 'POSTED',
+        postedAt: '2026-06-13T10:00:00Z',
+    },
+    {
+        id: 'tx_0002',
+        reference: 'refund-0188',
+        status: 'REVERSED',
+        postedAt: '2026-06-13T09:30:00Z',
+    },
+]
+
+function ok(body: unknown) {
+    return { ok: true, status: 200, json: async () => body } as Response
+}
+
+function renderTransactions() {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const ui: ReactElement = (
+        <QueryClientProvider client={client}>
+            <MemoryRouter initialEntries={['/transactions']}>
+                <ThemeProvider>
+                    <Transactions />
+                </ThemeProvider>
+            </MemoryRouter>
+        </QueryClientProvider>
+    )
+    return render(ui)
+}
+
+afterEach(() => {
+    vi.restoreAllMocks()
+})
+
+describe('Transactions', () => {
+    it('shows a loading state while the request is in flight', () => {
+        vi.spyOn(globalThis, 'fetch').mockReturnValue(new Promise<Response>(() => {}))
+        renderTransactions()
+        expect(screen.getByText('Loading transactions...')).toBeInTheDocument()
+        expect(screen.queryByRole('table')).not.toBeInTheDocument()
+    })
+
+    it('renders a row per transaction with only the real contract fields', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(ok(page(SAMPLE, { totalElements: 2 })))
+        renderTransactions()
+        expect(await screen.findByText('payroll-0425')).toBeInTheDocument()
+        expect(screen.getAllByRole('row')).toHaveLength(SAMPLE.length + 1)
+        expect(screen.getByText('tx_0001')).toBeInTheDocument()
+        expect(screen.getByText('POSTED')).toBeInTheDocument()
+        expect(screen.getByText('REVERSED')).toBeInTheDocument()
+        expect(screen.queryByText('Amount')).not.toBeInTheDocument()
+        expect(screen.queryByText('Currency')).not.toBeInTheDocument()
+    })
+
+    it('shows an empty state and disables Next when there are no transactions', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+            ok(page([], { totalElements: 0, totalPages: 0 })),
+        )
+        renderTransactions()
+        expect(await screen.findByText('No transactions yet.')).toBeInTheDocument()
+        expect(screen.getByRole('button', { name: 'Next page' })).toBeDisabled()
+    })
+
+    it('shows an error state with a working Retry', async () => {
+        const fetchMock = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network down'))
+        renderTransactions()
+        expect(await screen.findByText('Could not load transactions.')).toBeInTheDocument()
+        const before = fetchMock.mock.calls.length
+        fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+        await waitFor(() => expect(fetchMock.mock.calls.length).toBeGreaterThan(before))
+    })
+
+    it('paginates: Prev disabled on first page, Next refetches with the next page', async () => {
+        const fetchMock = vi
+            .spyOn(globalThis, 'fetch')
+            .mockResolvedValue(ok(page(SAMPLE, { totalElements: 45, totalPages: 3 })))
+        renderTransactions()
+        await screen.findByText('payroll-0425')
+        expect(screen.getByRole('button', { name: 'Previous page' })).toBeDisabled()
+
+        fireEvent.click(screen.getByRole('button', { name: 'Next page' }))
+        await waitFor(() => expect(String(fetchMock.mock.calls.at(-1)?.[0])).toContain('page=1'))
+    })
+
+    it('marks the Transactions sidebar item as the current page', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(ok(page(SAMPLE, { totalElements: 2 })))
+        renderTransactions()
+        await screen.findByText('payroll-0425')
+        expect(screen.getByRole('link', { name: 'Transactions' })).toHaveAttribute(
+            'aria-current',
+            'page',
+        )
+    })
+})


### PR DESCRIPTION
## What

Implements Screen 3 (Transaction Explorer) of the Sandbox UI: a `/transactions` route listing posted transactions from the live `GET /v1/transactions` (PR #118). Mirrors the merged Account Browser one-to-one.

## How

- Typed `useTransactions(page, size)` TanStack hook over the real endpoint.
- `TransactionsTable` renders only the real `TransactionResponse` fields: id (mono, prefixed ULID), reference, status pill (`TxStatusPill`), posted at (`formatInstant`). No amount/currency/counterparty columns: those are not in the listing payload (they belong to the detail endpoint #105).
- Server-authoritative pagination (reuses `Pagination` with a new additive `noun` prop; the Account Browser behaviour is unchanged), with loading / error+retry / empty states via the shared `StateMessage`.
- Sidebar Transactions item becomes a react-router `Link` to `/transactions`.

## Tests

`Transactions.test.tsx` (6 Vitest+RTL, `fetch` mocked, no msw): loading, real-fields-only row rendering, empty + disabled Next, error+retry, pagination requests `page=1`, sidebar active state. Full suite 28 passing; typecheck, lint (exit 0), and build green.

Closes #119