### PR TITLE
feat(ledger): add transaction detail and reversal endpoints

### DIFF
--- a/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/application/TransactionReversalIT.kt
+++ b/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/application/TransactionReversalIT.kt
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.application
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fincore.core.AccountId
+import com.fincore.core.Currency
+import com.fincore.ledger.domain.enum.AccountType
+import com.fincore.ledger.domain.enum.EntryDirection
+import com.fincore.ledger.domain.enum.TransactionStatus
+import com.fincore.ledger.domain.exception.TransactionAlreadyReversedException
+import com.fincore.ledger.infrastructure.persistence.AccountPersistenceAdapter
+import com.fincore.ledger.infrastructure.persistence.OutboxEventRepository
+import com.fincore.ledger.infrastructure.persistence.TransactionPersistenceAdapter
+import com.fincore.test.containers.PostgresContainerExtension
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import java.math.BigDecimal
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ExtendWith(PostgresContainerExtension::class)
+@Import(
+    TransactionServiceImpl::class,
+    TransactionPoster::class,
+    TransactionPersistenceAdapter::class,
+    BalanceServiceImpl::class,
+    AccountServiceImpl::class,
+    AccountPersistenceAdapter::class,
+    TransactionReversalIT.JacksonConfig::class,
+)
+class TransactionReversalIT(
+    @Autowired private val transactionService: TransactionService,
+    @Autowired private val balanceService: BalanceService,
+    @Autowired private val accountService: AccountService,
+    @Autowired private val outboxRepository: OutboxEventRepository,
+) {
+    @TestConfiguration
+    class JacksonConfig {
+        @Bean
+        fun objectMapper(): ObjectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+    }
+
+    private fun newAccount() = accountService.create(CreateAccountCommand("Account", AccountType.USER_WALLET, Currency.USD, "op"))
+
+    private fun postBalanced(
+        reference: String,
+        debit: AccountId,
+        credit: AccountId,
+    ) = transactionService.post(
+        PostTransactionCommand(
+            reference = reference,
+            description = null,
+            currency = Currency.USD,
+            entries =
+                listOf(
+                    EntryLine(debit, EntryDirection.DEBIT, BigDecimal("100.00")),
+                    EntryLine(credit, EntryDirection.CREDIT, BigDecimal("-100.00")),
+                ),
+            actor = "op",
+            correlationId = "corr-1",
+        ),
+    )
+
+    @Test
+    fun `should reverse a posted transaction and return both balances to zero`() {
+        val debit = newAccount()
+        val credit = newAccount()
+        val original = postBalanced("ref-rev-1", debit.id, credit.id)
+
+        transactionService.reverse(original.id, "op", "corr-2")
+
+        balanceService.current(debit.id, Currency.USD).amount.isZero() shouldBe true
+        balanceService.current(credit.id, Currency.USD).amount.isZero() shouldBe true
+    }
+
+    @Test
+    fun `should mark the original reversed and link the compensating transaction`() {
+        val debit = newAccount()
+        val credit = newAccount()
+        val original = postBalanced("ref-rev-2", debit.id, credit.id)
+
+        val compensating = transactionService.reverse(original.id, "op", "corr-2")
+
+        transactionService.get(original.id).status shouldBe TransactionStatus.REVERSED
+        val detail = transactionService.get(compensating.id)
+        detail.reversesId shouldBe original.id
+        detail.status shouldBe TransactionStatus.POSTED
+        detail.entries.size shouldBe 2
+    }
+
+    @Test
+    fun `should reject reversing the same transaction twice`() {
+        val debit = newAccount()
+        val credit = newAccount()
+        val original = postBalanced("ref-rev-3", debit.id, credit.id)
+        transactionService.reverse(original.id, "op", "corr-2")
+
+        shouldThrow<TransactionAlreadyReversedException> {
+            transactionService.reverse(original.id, "op", "corr-3")
+        }
+    }
+
+    @Test
+    fun `should emit an outbox event for the compensating transaction`() {
+        val debit = newAccount()
+        val credit = newAccount()
+        val original = postBalanced("ref-rev-4", debit.id, credit.id)
+
+        transactionService.reverse(original.id, "op", "corr-2")
+
+        outboxRepository.findAll().size shouldBe 2
+    }
+
+    companion object {
+        @JvmStatic
+        @DynamicPropertySource
+        fun datasourceProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { PostgresContainerExtension.jdbcUrl }
+            registry.add("spring.datasource.username") { PostgresContainerExtension.username }
+            registry.add("spring.datasource.password") { PostgresContainerExtension.password }
+            registry.add("spring.jpa.hibernate.ddl-auto") { "none" }
+        }
+    }
+}

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/api/TransactionController.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/api/TransactionController.kt
@@ -5,8 +5,10 @@ package com.fincore.ledger.api
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fincore.core.IdempotencyKey
+import com.fincore.core.TransactionId
 import com.fincore.ledger.api.dto.request.PostTransactionRequest
 import com.fincore.ledger.api.dto.response.PageResponse
+import com.fincore.ledger.api.dto.response.TransactionDetailResponse
 import com.fincore.ledger.api.dto.response.TransactionResponse
 import com.fincore.ledger.api.idempotency.IdempotencyAttributes
 import com.fincore.ledger.api.mapper.LedgerApiMapper
@@ -21,6 +23,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.jwt.Jwt
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestAttribute
 import org.springframework.web.bind.annotation.RequestBody
@@ -64,6 +67,30 @@ class TransactionController(
         require(page >= 0) { "page must be >= 0" }
         require(size in 1..MAX_PAGE_SIZE) { "size must be 1..$MAX_PAGE_SIZE" }
         return mapper.toPageResponse(transactionService.list(page, size))
+    }
+
+    @GetMapping("/{id}")
+    fun get(
+        @PathVariable id: String,
+    ): TransactionDetailResponse = mapper.toDetailResponse(transactionService.get(TransactionId.fromString(id)))
+
+    @PostMapping("/{id}/reverse")
+    fun reverse(
+        @PathVariable id: String,
+        @AuthenticationPrincipal jwt: Jwt,
+        @RequestHeader(value = CORRELATION_HEADER, required = false) correlationId: String?,
+        @RequestAttribute(IdempotencyAttributes.KEY) key: String,
+        @RequestAttribute(IdempotencyAttributes.BODY) rawBody: String,
+    ): ResponseEntity<String> {
+        val transactionId = TransactionId.fromString(id)
+        var location: URI? = null
+        val result =
+            idempotencyService.execute(IdempotencyKey.of(key), rawBody) {
+                val response = mapper.toResponse(transactionService.reverse(transactionId, jwt.subject, correlationId))
+                location = URI.create("/v1/transactions/${response.id}")
+                StoredResponse(HttpStatus.CREATED.value(), objectMapper.writeValueAsString(response))
+            }
+        return respond(result, location)
     }
 
     private fun respond(

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/api/dto/response/TransactionDetailResponse.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/api/dto/response/TransactionDetailResponse.kt
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.api.dto.response
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import com.fincore.ledger.api.serialization.MoneyAmountSerializer
+import com.fincore.ledger.domain.enum.EntryDirection
+import com.fincore.ledger.domain.enum.TransactionStatus
+import io.swagger.v3.oas.annotations.media.Schema
+import java.math.BigDecimal
+import java.time.Instant
+
+data class EntryResponse(
+    val accountId: String,
+    val direction: EntryDirection,
+    @JsonSerialize(using = MoneyAmountSerializer::class)
+    @Schema(type = "string", format = "decimal", example = "100.00")
+    val amount: BigDecimal,
+    val currency: String,
+)
+
+data class TransactionDetailResponse(
+    val id: String,
+    val reference: String,
+    val description: String?,
+    val status: TransactionStatus,
+    val reversesId: String?,
+    val postedAt: Instant,
+    val entries: List<EntryResponse>,
+)

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/api/idempotency/IdempotencyFilter.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/api/idempotency/IdempotencyFilter.kt
@@ -21,7 +21,9 @@ class IdempotencyFilter(
     private val objectMapper: ObjectMapper,
 ) : OncePerRequestFilter() {
     override fun shouldNotFilter(request: HttpServletRequest): Boolean =
-        request.method != HttpMethod.POST.name() || request.requestURI !in GUARDED_PATHS
+        request.method != HttpMethod.POST.name() || !isGuarded(request.requestURI)
+
+    private fun isGuarded(uri: String): Boolean = uri in GUARDED_PATHS || REVERSE_PATH.matches(uri)
 
     override fun doFilterInternal(
         request: HttpServletRequest,
@@ -61,5 +63,6 @@ class IdempotencyFilter(
 
     private companion object {
         val GUARDED_PATHS = setOf("/v1/accounts", "/v1/transactions")
+        val REVERSE_PATH = Regex("/v1/transactions/[^/]+/reverse")
     }
 }

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/api/mapper/LedgerApiMapper.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/api/mapper/LedgerApiMapper.kt
@@ -9,14 +9,18 @@ import com.fincore.ledger.api.dto.request.CreateAccountRequest
 import com.fincore.ledger.api.dto.request.PostTransactionRequest
 import com.fincore.ledger.api.dto.response.AccountResponse
 import com.fincore.ledger.api.dto.response.BalanceResponse
+import com.fincore.ledger.api.dto.response.EntryResponse
 import com.fincore.ledger.api.dto.response.PageResponse
+import com.fincore.ledger.api.dto.response.TransactionDetailResponse
 import com.fincore.ledger.api.dto.response.TransactionResponse
 import com.fincore.ledger.application.AccountBalance
 import com.fincore.ledger.application.AccountPage
 import com.fincore.ledger.application.CreateAccountCommand
 import com.fincore.ledger.application.EntryLine
+import com.fincore.ledger.application.EntryView
 import com.fincore.ledger.application.PostTransactionCommand
 import com.fincore.ledger.application.PostedTransaction
+import com.fincore.ledger.application.TransactionDetail
 import com.fincore.ledger.application.TransactionPage
 import com.fincore.ledger.application.TransactionSummary
 import com.fincore.ledger.domain.Account
@@ -98,6 +102,25 @@ class LedgerApiMapper {
             reference = summary.reference,
             status = summary.status,
             postedAt = summary.postedAt,
+        )
+
+    fun toDetailResponse(detail: TransactionDetail): TransactionDetailResponse =
+        TransactionDetailResponse(
+            id = detail.id.toString(),
+            reference = detail.reference,
+            description = detail.description,
+            status = detail.status,
+            reversesId = detail.reversesId?.toString(),
+            postedAt = detail.postedAt,
+            entries = detail.entries.map(::toResponse),
+        )
+
+    fun toResponse(entry: EntryView): EntryResponse =
+        EntryResponse(
+            accountId = entry.accountId.toString(),
+            direction = entry.direction,
+            amount = entry.amount,
+            currency = entry.currency,
         )
 
     fun toPageResponse(page: TransactionPage): PageResponse<TransactionResponse> =

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/application/TransactionDetail.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/application/TransactionDetail.kt
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.application
+
+import com.fincore.core.AccountId
+import com.fincore.core.TransactionId
+import com.fincore.ledger.domain.enum.EntryDirection
+import com.fincore.ledger.domain.enum.TransactionStatus
+import java.math.BigDecimal
+import java.time.Instant
+
+data class EntryView(
+    val accountId: AccountId,
+    val direction: EntryDirection,
+    val amount: BigDecimal,
+    val currency: String,
+)
+
+data class TransactionDetail(
+    val id: TransactionId,
+    val reference: String,
+    val description: String?,
+    val status: TransactionStatus,
+    val reversesId: TransactionId?,
+    val postedAt: Instant,
+    val entries: List<EntryView>,
+)

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/application/TransactionPoster.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/application/TransactionPoster.kt
@@ -4,6 +4,8 @@
 package com.fincore.ledger.application
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import com.fincore.core.AccountId
+import com.fincore.core.Currency
 import com.fincore.core.EntryId
 import com.fincore.core.Money
 import com.fincore.core.TransactionId
@@ -15,13 +17,17 @@ import com.fincore.ledger.application.event.TransactionPostedPayload
 import com.fincore.ledger.domain.Entry
 import com.fincore.ledger.domain.Transaction
 import com.fincore.ledger.domain.enum.AccountStatus
+import com.fincore.ledger.domain.enum.TransactionStatus
 import com.fincore.ledger.domain.exception.AccountNotFoundException
 import com.fincore.ledger.domain.exception.DomainException
 import com.fincore.ledger.domain.exception.DuplicateTransactionException
+import com.fincore.ledger.domain.exception.TransactionAlreadyReversedException
+import com.fincore.ledger.domain.exception.TransactionNotFoundException
 import com.fincore.ledger.infrastructure.persistence.AccountBalanceEntity
 import com.fincore.ledger.infrastructure.persistence.AccountBalanceKey
 import com.fincore.ledger.infrastructure.persistence.AccountBalanceRepository
 import com.fincore.ledger.infrastructure.persistence.AccountRepository
+import com.fincore.ledger.infrastructure.persistence.EntryEntity
 import com.fincore.ledger.infrastructure.persistence.EntryRepository
 import com.fincore.ledger.infrastructure.persistence.OutboxEventEntity
 import com.fincore.ledger.infrastructure.persistence.OutboxEventRepository
@@ -46,15 +52,40 @@ class TransactionPoster(
     @Transactional
     fun post(command: PostTransactionCommand): PostedTransaction {
         val transaction = buildDomain(command)
-        guardAccounts(transaction, command)
+        guardAccounts(transaction, command.currency)
         if (transactionRepository.existsByReference(command.reference)) {
             throw DuplicateTransactionException(command.reference)
         }
         val postedAt = Instant.now()
-        persist(transaction, command, postedAt)
-        applyBalances(transaction, command, postedAt)
-        emit(transaction, command, postedAt)
+        try {
+            write(transaction, command.actor, postedAt, reversesId = null, correlationId = command.correlationId)
+        } catch (duplicate: DataIntegrityViolationException) {
+            throw DuplicateTransactionException(command.reference, duplicate)
+        }
         return PostedTransaction(transaction.id, transaction.reference, transaction.status, postedAt)
+    }
+
+    @Transactional
+    fun postReversal(
+        originalId: TransactionId,
+        actor: String,
+        correlationId: String?,
+    ): PostedTransaction {
+        val original =
+            transactionRepository.findById(originalId.value).orElseThrow { TransactionNotFoundException(originalId) }
+        if (original.status != TransactionStatus.POSTED) {
+            throw TransactionAlreadyReversedException(originalId)
+        }
+        val compensating = buildReversal(originalId, original.reference, entryRepository.findByTransactionId(originalId.value))
+        original.status = TransactionStatus.REVERSED
+        transactionRepository.saveAndFlush(original)
+        val postedAt = Instant.now()
+        try {
+            write(compensating, actor, postedAt, reversesId = originalId.value, correlationId = correlationId)
+        } catch (conflict: DataIntegrityViolationException) {
+            throw TransactionAlreadyReversedException(originalId, conflict)
+        }
+        return PostedTransaction(compensating.id, compensating.reference, compensating.status, postedAt)
     }
 
     private fun buildDomain(command: PostTransactionCommand): Transaction {
@@ -65,9 +96,33 @@ class TransactionPoster(
         return Transaction(TransactionId.generate(), command.reference, command.description, entries, command.currency)
     }
 
+    private fun buildReversal(
+        originalId: TransactionId,
+        originalReference: String,
+        originalEntries: List<EntryEntity>,
+    ): Transaction {
+        val currency = Currency.of(originalEntries.first().currency)
+        val inverted =
+            originalEntries.map { entry ->
+                Entry(
+                    EntryId.generate(),
+                    AccountId(entry.accountId),
+                    entry.direction.opposite(),
+                    Money(entry.amount.negate(), Currency.of(entry.currency)),
+                )
+            }
+        return Transaction(
+            TransactionId.generate(),
+            "reversal-of-$originalId",
+            "reversal of $originalReference",
+            inverted,
+            currency,
+        )
+    }
+
     private fun guardAccounts(
         transaction: Transaction,
-        command: PostTransactionCommand,
+        currency: Currency,
     ) {
         transaction.entries.map { it.accountId }.distinct().forEach { accountId ->
             val account =
@@ -75,34 +130,33 @@ class TransactionPoster(
             if (account.status != AccountStatus.ACTIVE) {
                 throw DomainException("Cannot post to non-active account $accountId with status ${account.status}")
             }
-            if (account.currency != command.currency.code) {
+            if (account.currency != currency.code) {
                 throw DomainException(
-                    "Account $accountId currency ${account.currency} does not match transaction currency ${command.currency}",
+                    "Account $accountId currency ${account.currency} does not match transaction currency $currency",
                 )
             }
         }
     }
 
-    private fun persist(
+    private fun write(
         transaction: Transaction,
-        command: PostTransactionCommand,
+        actor: String,
         postedAt: Instant,
+        reversesId: UUID?,
+        correlationId: String?,
     ) {
-        try {
-            transactionRepository.saveAndFlush(adapter.toTransactionEntity(transaction, command.actor, postedAt))
-        } catch (duplicate: DataIntegrityViolationException) {
-            throw DuplicateTransactionException(command.reference, duplicate)
-        }
+        transactionRepository.saveAndFlush(adapter.toTransactionEntity(transaction, actor, postedAt, reversesId))
         adapter.toEntryEntities(transaction, postedAt).forEach { entryRepository.saveAndFlush(it) }
+        applyBalances(transaction, postedAt)
+        emit(transaction, correlationId, postedAt)
     }
 
     private fun applyBalances(
         transaction: Transaction,
-        command: PostTransactionCommand,
         postedAt: Instant,
     ) {
         transaction.entries.forEach { entry ->
-            val key = AccountBalanceKey(entry.accountId.value, command.currency.code)
+            val key = AccountBalanceKey(entry.accountId.value, entry.amount.currency.code)
             val existing = balanceRepository.findById(key).orElse(null)
             if (existing == null) {
                 balanceRepository.saveAndFlush(AccountBalanceEntity(key, entry.amount.amount, postedAt, 0))
@@ -116,16 +170,16 @@ class TransactionPoster(
 
     private fun emit(
         transaction: Transaction,
-        command: PostTransactionCommand,
+        correlationId: String?,
         postedAt: Instant,
     ) {
         val envelope =
             EventEnvelope.of(
                 source = SOURCE,
                 type = LedgerEvents.TransactionPosted,
-                data = buildPayload(transaction, command, postedAt),
+                data = buildPayload(transaction, postedAt),
                 subject = transaction.id.toString(),
-                correlationId = command.correlationId,
+                correlationId = correlationId,
             )
         outboxRepository.saveAndFlush(
             OutboxEventEntity(
@@ -145,13 +199,12 @@ class TransactionPoster(
 
     private fun buildPayload(
         transaction: Transaction,
-        command: PostTransactionCommand,
         postedAt: Instant,
     ): TransactionPostedPayload =
         TransactionPostedPayload(
             transactionId = transaction.id.toString(),
             reference = transaction.reference,
-            currency = command.currency.code,
+            currency = transaction.currency.code,
             postedAt = postedAt,
             entries =
                 transaction.entries.map {

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/application/TransactionService.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/application/TransactionService.kt
@@ -3,8 +3,18 @@
 
 package com.fincore.ledger.application
 
+import com.fincore.core.TransactionId
+
 interface TransactionService {
     fun post(command: PostTransactionCommand): PostedTransaction
+
+    fun get(id: TransactionId): TransactionDetail
+
+    fun reverse(
+        id: TransactionId,
+        actor: String,
+        correlationId: String?,
+    ): PostedTransaction
 
     fun list(
         page: Int,

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/application/TransactionServiceImpl.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/application/TransactionServiceImpl.kt
@@ -3,8 +3,12 @@
 
 package com.fincore.ledger.application
 
+import com.fincore.core.AccountId
 import com.fincore.core.TransactionId
 import com.fincore.ledger.domain.exception.ConcurrencyConflictException
+import com.fincore.ledger.domain.exception.TransactionNotFoundException
+import com.fincore.ledger.infrastructure.persistence.EntryEntity
+import com.fincore.ledger.infrastructure.persistence.EntryRepository
 import com.fincore.ledger.infrastructure.persistence.TransactionEntity
 import com.fincore.ledger.infrastructure.persistence.TransactionRepository
 import org.springframework.dao.OptimisticLockingFailureException
@@ -17,19 +21,22 @@ import org.springframework.transaction.annotation.Transactional
 class TransactionServiceImpl(
     private val poster: TransactionPoster,
     private val transactionRepository: TransactionRepository,
+    private val entryRepository: EntryRepository,
 ) : TransactionService {
-    override fun post(command: PostTransactionCommand): PostedTransaction {
-        var attempt = 0
-        while (true) {
-            try {
-                return poster.post(command)
-            } catch (lock: OptimisticLockingFailureException) {
-                attempt++
-                if (attempt >= MAX_ATTEMPTS) {
-                    throw ConcurrencyConflictException(lock)
-                }
-            }
-        }
+    override fun post(command: PostTransactionCommand): PostedTransaction = withOptimisticRetry { poster.post(command) }
+
+    override fun reverse(
+        id: TransactionId,
+        actor: String,
+        correlationId: String?,
+    ): PostedTransaction = withOptimisticRetry { poster.postReversal(id, actor, correlationId) }
+
+    @Transactional(readOnly = true)
+    override fun get(id: TransactionId): TransactionDetail {
+        val transaction =
+            transactionRepository.findById(id.value).orElseThrow { TransactionNotFoundException(id) }
+        val entries = entryRepository.findByTransactionId(id.value).map(::toView)
+        return toDetail(transaction, entries)
     }
 
     @Transactional(readOnly = true)
@@ -48,8 +55,38 @@ class TransactionServiceImpl(
         )
     }
 
+    private fun <T> withOptimisticRetry(action: () -> T): T {
+        var attempt = 0
+        while (true) {
+            try {
+                return action()
+            } catch (lock: OptimisticLockingFailureException) {
+                attempt++
+                if (attempt >= MAX_ATTEMPTS) {
+                    throw ConcurrencyConflictException(lock)
+                }
+            }
+        }
+    }
+
     private fun toSummary(entity: TransactionEntity): TransactionSummary =
         TransactionSummary(TransactionId(entity.id), entity.reference, entity.status, entity.postedAt)
+
+    private fun toDetail(
+        entity: TransactionEntity,
+        entries: List<EntryView>,
+    ): TransactionDetail =
+        TransactionDetail(
+            id = TransactionId(entity.id),
+            reference = entity.reference,
+            description = entity.description,
+            status = entity.status,
+            reversesId = entity.reversesId?.let(::TransactionId),
+            postedAt = entity.postedAt,
+            entries = entries,
+        )
+
+    private fun toView(entry: EntryEntity): EntryView = EntryView(AccountId(entry.accountId), entry.direction, entry.amount, entry.currency)
 
     private companion object {
         const val MAX_ATTEMPTS = 3

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/domain/Transaction.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/domain/Transaction.kt
@@ -17,13 +17,12 @@ class Transaction(
     val description: String?,
     val entries: List<Entry>,
     val currency: Currency,
+    val status: TransactionStatus = TransactionStatus.POSTED,
 ) {
     companion object {
         private const val MIN_ENTRIES = 2
         private const val MAX_ENTRIES = 1000
     }
-
-    val status: TransactionStatus = TransactionStatus.POSTED
 
     init {
         validateEntryCount()

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/domain/enum/EntryDirection.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/domain/enum/EntryDirection.kt
@@ -6,4 +6,7 @@ package com.fincore.ledger.domain.enum
 enum class EntryDirection {
     DEBIT,
     CREDIT,
+    ;
+
+    fun opposite(): EntryDirection = if (this == DEBIT) CREDIT else DEBIT
 }

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/domain/exception/TransactionAlreadyReversedException.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/domain/exception/TransactionAlreadyReversedException.kt
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.domain.exception
+
+import com.fincore.core.TransactionId
+
+class TransactionAlreadyReversedException(
+    id: TransactionId,
+    cause: Throwable? = null,
+) : DomainException("Transaction already reversed: $id", cause)

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/domain/exception/TransactionNotFoundException.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/domain/exception/TransactionNotFoundException.kt
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.domain.exception
+
+import com.fincore.core.TransactionId
+
+class TransactionNotFoundException(
+    id: TransactionId,
+) : DomainException("Transaction not found: $id")

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/exception/GlobalExceptionHandler.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/exception/GlobalExceptionHandler.kt
@@ -10,6 +10,8 @@ import com.fincore.ledger.domain.exception.DomainException
 import com.fincore.ledger.domain.exception.DoubleEntryViolationException
 import com.fincore.ledger.domain.exception.DuplicateTransactionException
 import com.fincore.ledger.domain.exception.IdempotencyConflictException
+import com.fincore.ledger.domain.exception.TransactionAlreadyReversedException
+import com.fincore.ledger.domain.exception.TransactionNotFoundException
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
@@ -29,11 +31,23 @@ class GlobalExceptionHandler {
         request: HttpServletRequest,
     ): ProblemDetail = problem(HttpStatus.NOT_FOUND, "account not found", ex.message, request)
 
+    @ExceptionHandler(TransactionNotFoundException::class)
+    fun handleTransactionNotFound(
+        ex: TransactionNotFoundException,
+        request: HttpServletRequest,
+    ): ProblemDetail = problem(HttpStatus.NOT_FOUND, "transaction not found", ex.message, request)
+
     @ExceptionHandler(DuplicateTransactionException::class)
     fun handleDuplicateTransaction(
         ex: DuplicateTransactionException,
         request: HttpServletRequest,
     ): ProblemDetail = problem(HttpStatus.CONFLICT, "duplicate transaction reference", ex.message, request)
+
+    @ExceptionHandler(TransactionAlreadyReversedException::class)
+    fun handleTransactionAlreadyReversed(
+        ex: TransactionAlreadyReversedException,
+        request: HttpServletRequest,
+    ): ProblemDetail = problem(HttpStatus.CONFLICT, "transaction already reversed", ex.message, request)
 
     @ExceptionHandler(IdempotencyConflictException::class)
     fun handleIdempotencyConflict(

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/EntryRepository.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/EntryRepository.kt
@@ -20,4 +20,9 @@ interface EntryRepository : JpaRepository<EntryEntity, EntryKey> {
         @Param("currency") currency: String,
         @Param("asOf") asOf: Instant,
     ): BigDecimal
+
+    @Query("select e from EntryEntity e where e.transactionId = :transactionId order by e.key.id")
+    fun findByTransactionId(
+        @Param("transactionId") transactionId: UUID,
+    ): List<EntryEntity>
 }

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/TransactionEntity.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/TransactionEntity.kt
@@ -10,14 +10,14 @@ import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
 import jakarta.persistence.Id
 import jakarta.persistence.Table
-import org.hibernate.annotations.Immutable
 import org.hibernate.annotations.JdbcTypeCode
 import org.hibernate.type.SqlTypes
 import java.time.Instant
 import java.util.UUID
 
+// Not @Immutable: Model (A) reversal flips `status` POSTED->REVERSED via a guarded update. Every other
+// column stays updatable = false so only `status` can ever change.
 @Entity
-@Immutable
 @Table(name = "transactions", schema = "ledger")
 @Suppress("LongParameterList")
 class TransactionEntity(

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/TransactionPersistenceAdapter.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/TransactionPersistenceAdapter.kt
@@ -7,6 +7,7 @@ import com.fincore.ledger.domain.Transaction
 import com.fincore.ledger.domain.enum.TransactionStatus
 import org.springframework.stereotype.Component
 import java.time.Instant
+import java.util.UUID
 
 // Hand-written domain aggregate -> rows (issue #33 deferral): a Transaction maps to one
 // transactions row plus N entries rows that share the post instant.
@@ -16,13 +17,14 @@ class TransactionPersistenceAdapter {
         transaction: Transaction,
         actor: String,
         postedAt: Instant,
+        reversesId: UUID? = null,
     ): TransactionEntity =
         TransactionEntity(
             id = transaction.id.value,
             reference = transaction.reference,
             description = transaction.description,
             status = TransactionStatus.POSTED,
-            reversesId = null,
+            reversesId = reversesId,
             metadata = EMPTY_JSON,
             postedAt = postedAt,
             createdAt = postedAt,

--- a/services/ledger/src/test/kotlin/com/fincore/ledger/api/TransactionControllerTest.kt
+++ b/services/ledger/src/test/kotlin/com/fincore/ledger/api/TransactionControllerTest.kt
@@ -8,8 +8,10 @@ import com.fincore.core.TransactionId
 import com.fincore.ledger.api.idempotency.IdempotencyAttributes
 import com.fincore.ledger.api.idempotency.IdempotencyFilter
 import com.fincore.ledger.api.mapper.LedgerApiMapper
+import com.fincore.ledger.application.EntryView
 import com.fincore.ledger.application.PostTransactionCommand
 import com.fincore.ledger.application.PostedTransaction
+import com.fincore.ledger.application.TransactionDetail
 import com.fincore.ledger.application.TransactionPage
 import com.fincore.ledger.application.TransactionService
 import com.fincore.ledger.application.TransactionSummary
@@ -21,6 +23,8 @@ import com.fincore.ledger.domain.exception.ConcurrencyConflictException
 import com.fincore.ledger.domain.exception.CurrencyConsistencyViolationException
 import com.fincore.ledger.domain.exception.DoubleEntryViolationException
 import com.fincore.ledger.domain.exception.DuplicateTransactionException
+import com.fincore.ledger.domain.exception.TransactionAlreadyReversedException
+import com.fincore.ledger.domain.exception.TransactionNotFoundException
 import io.kotest.matchers.shouldBe
 import io.mockk.clearMocks
 import io.mockk.every
@@ -223,5 +227,106 @@ class TransactionControllerTest(
     @Test
     fun `should reject an unauthenticated list request with 401`() {
         mockMvc.perform(get("/v1/transactions")).andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    fun `should return a transaction detail with entries as decimal strings and prefixed ids`() {
+        val txId = TransactionId.generate()
+        every { transactionService.get(any()) } returns
+            TransactionDetail(
+                id = txId,
+                reference = "tx-ref-1",
+                description = "a tx",
+                status = TransactionStatus.POSTED,
+                reversesId = null,
+                postedAt = Instant.parse("2026-06-13T10:00:00Z"),
+                entries =
+                    listOf(
+                        EntryView(accountA, EntryDirection.DEBIT, BigDecimal("100.00"), "EUR"),
+                        EntryView(accountB, EntryDirection.CREDIT, BigDecimal("-100.00"), "EUR"),
+                    ),
+            )
+
+        mockMvc
+            .perform(get("/v1/transactions/$txId").with(jwt()))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value(txId.toString()))
+            .andExpect(jsonPath("$.id").value(matchesPattern("^tx_[0-9A-HJKMNP-TV-Z]{26}$")))
+            .andExpect(jsonPath("$.status").value("POSTED"))
+            .andExpect(jsonPath("$.entries.length()").value(2))
+            .andExpect(jsonPath("$.entries[0].accountId").value(accountA.toString()))
+            .andExpect(jsonPath("$.entries[0].accountId").value(matchesPattern("^acc_[0-9A-HJKMNP-TV-Z]{26}$")))
+            .andExpect(jsonPath("$.entries[0].amount").value("100.00"))
+            .andExpect(jsonPath("$.entries[1].amount").value("-100.00"))
+    }
+
+    @Test
+    fun `should return 404 when the transaction is not found`() {
+        every { transactionService.get(any()) } throws TransactionNotFoundException(TransactionId.generate())
+
+        mockMvc
+            .perform(get("/v1/transactions/${TransactionId.generate()}").with(jwt()))
+            .andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.status").value(404))
+    }
+
+    @Test
+    fun `should return 400 for a malformed transaction id without calling the service`() {
+        mockMvc
+            .perform(get("/v1/transactions/tx_zzz").with(jwt()))
+            .andExpect(status().isBadRequest)
+
+        verify(exactly = 0) { transactionService.get(any()) }
+    }
+
+    private fun reverse(
+        id: String,
+        withKey: Boolean = true,
+        authenticated: Boolean = true,
+    ) = mockMvc.perform(
+        post("/v1/transactions/$id/reverse")
+            .apply { if (authenticated) with(jwt().jwt { it.subject("user-123") }) }
+            .apply { if (withKey) header(IdempotencyAttributes.HEADER, key) }
+            .contentType(MediaType.APPLICATION_JSON),
+    )
+
+    @Test
+    fun `should reverse a transaction and return 201 with location and the compensating transaction`() {
+        val compensatingId = TransactionId.generate()
+        every { transactionService.reverse(any(), "user-123", any()) } returns
+            PostedTransaction(compensatingId, "reversal-of-tx", TransactionStatus.POSTED, Instant.parse("2026-06-13T10:00:00Z"))
+
+        reverse(TransactionId.generate().toString())
+            .andExpect(status().isCreated)
+            .andExpect(header().string("Location", "/v1/transactions/$compensatingId"))
+            .andExpect(jsonPath("$.id").value(compensatingId.toString()))
+            .andExpect(jsonPath("$.status").value("POSTED"))
+    }
+
+    @Test
+    fun `should return 404 when reversing an unknown transaction`() {
+        every { transactionService.reverse(any(), any(), any()) } throws TransactionNotFoundException(TransactionId.generate())
+
+        reverse(TransactionId.generate().toString()).andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun `should return 409 when reversing an already reversed transaction`() {
+        every { transactionService.reverse(any(), any(), any()) } throws
+            TransactionAlreadyReversedException(TransactionId.generate())
+
+        reverse(TransactionId.generate().toString()).andExpect(status().isConflict)
+    }
+
+    @Test
+    fun `should reject a reverse without an idempotency key with 400`() {
+        reverse(TransactionId.generate().toString(), withKey = false).andExpect(status().isBadRequest)
+
+        verify(exactly = 0) { transactionService.reverse(any(), any(), any()) }
+    }
+
+    @Test
+    fun `should reject an unauthenticated reverse with 401`() {
+        reverse(TransactionId.generate().toString(), authenticated = false).andExpect(status().isUnauthorized)
     }
 }

--- a/services/ledger/src/test/kotlin/com/fincore/ledger/api/mapper/LedgerApiMapperTest.kt
+++ b/services/ledger/src/test/kotlin/com/fincore/ledger/api/mapper/LedgerApiMapperTest.kt
@@ -11,7 +11,9 @@ import com.fincore.ledger.api.dto.request.CreateAccountRequest
 import com.fincore.ledger.api.dto.request.EntryLineRequest
 import com.fincore.ledger.api.dto.request.PostTransactionRequest
 import com.fincore.ledger.application.AccountBalance
+import com.fincore.ledger.application.EntryView
 import com.fincore.ledger.application.PostedTransaction
+import com.fincore.ledger.application.TransactionDetail
 import com.fincore.ledger.domain.Account
 import com.fincore.ledger.domain.enum.AccountStatus
 import com.fincore.ledger.domain.enum.AccountType
@@ -89,5 +91,36 @@ class LedgerApiMapperTest {
     fun `should serialize transaction id as prefixed ulid`() {
         val posted = PostedTransaction(TransactionId.generate(), "ref-1", TransactionStatus.POSTED, java.time.Instant.now())
         mapper.toResponse(posted).id shouldStartWith "tx_"
+    }
+
+    @Test
+    fun `should map transaction detail with prefixed ids and full-precision entry amounts`() {
+        val txId = TransactionId.generate()
+        val reverses = TransactionId.generate()
+        val account = AccountId.generate()
+        val amount = BigDecimal("100.000000000000000001")
+        val detail =
+            TransactionDetail(
+                id = txId,
+                reference = "ref-7",
+                description = "a tx",
+                status = TransactionStatus.REVERSED,
+                reversesId = reverses,
+                postedAt = java.time.Instant.parse("2026-06-12T08:00:00Z"),
+                entries = listOf(EntryView(account, EntryDirection.DEBIT, amount, "USD")),
+            )
+
+        val response = mapper.toDetailResponse(detail)
+
+        response.id shouldBe txId.toString()
+        response.reversesId shouldBe reverses.toString()
+        response.status shouldBe TransactionStatus.REVERSED
+        response.entries.single().let {
+            it.accountId shouldBe account.toString()
+            it.accountId shouldStartWith "acc_"
+            it.direction shouldBe EntryDirection.DEBIT
+            it.amount.compareTo(amount) shouldBe 0
+            it.currency shouldBe "USD"
+        }
     }
 }

--- a/services/ledger/src/test/kotlin/com/fincore/ledger/application/TransactionPosterTest.kt
+++ b/services/ledger/src/test/kotlin/com/fincore/ledger/application/TransactionPosterTest.kt
@@ -7,18 +7,25 @@ import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fincore.core.AccountId
 import com.fincore.core.Currency
+import com.fincore.core.TransactionId
 import com.fincore.ledger.domain.enum.AccountStatus
 import com.fincore.ledger.domain.enum.AccountType
 import com.fincore.ledger.domain.enum.EntryDirection
+import com.fincore.ledger.domain.enum.TransactionStatus
 import com.fincore.ledger.domain.exception.AccountNotFoundException
 import com.fincore.ledger.domain.exception.DomainException
 import com.fincore.ledger.domain.exception.DoubleEntryViolationException
 import com.fincore.ledger.domain.exception.DuplicateTransactionException
+import com.fincore.ledger.domain.exception.TransactionAlreadyReversedException
+import com.fincore.ledger.domain.exception.TransactionNotFoundException
 import com.fincore.ledger.infrastructure.persistence.AccountBalanceRepository
 import com.fincore.ledger.infrastructure.persistence.AccountEntity
 import com.fincore.ledger.infrastructure.persistence.AccountRepository
+import com.fincore.ledger.infrastructure.persistence.EntryEntity
+import com.fincore.ledger.infrastructure.persistence.EntryKey
 import com.fincore.ledger.infrastructure.persistence.EntryRepository
 import com.fincore.ledger.infrastructure.persistence.OutboxEventRepository
+import com.fincore.ledger.infrastructure.persistence.TransactionEntity
 import com.fincore.ledger.infrastructure.persistence.TransactionPersistenceAdapter
 import com.fincore.ledger.infrastructure.persistence.TransactionRepository
 import io.kotest.assertions.throwables.shouldThrow
@@ -144,5 +151,66 @@ class TransactionPosterTest {
         shouldThrow<DuplicateTransactionException> { poster.post(command()) }
 
         verify(exactly = 0) { transactionRepository.saveAndFlush(any()) }
+    }
+
+    private fun transactionEntity(
+        id: UUID,
+        status: TransactionStatus,
+    ) = TransactionEntity(id, "ref-orig", null, status, null, "{}", now, now, "op")
+
+    private fun entryEntity(
+        account: UUID,
+        amount: BigDecimal,
+        direction: EntryDirection,
+        transactionId: UUID,
+    ) = EntryEntity(EntryKey(UUID.randomUUID(), now), transactionId, account, amount, "USD", direction, now)
+
+    @Test
+    fun `should post a compensating reversal that inverts entries and links and reverses the original`() {
+        val originalId = TransactionId.generate()
+        val original = transactionEntity(originalId.value, TransactionStatus.POSTED)
+        every { transactionRepository.findById(originalId.value) } returns Optional.of(original)
+        every { entryRepository.findByTransactionId(originalId.value) } returns
+            listOf(
+                entryEntity(accountA, BigDecimal("100.00"), EntryDirection.DEBIT, originalId.value),
+                entryEntity(accountB, BigDecimal("-100.00"), EntryDirection.CREDIT, originalId.value),
+            )
+        val txSlots = mutableListOf<TransactionEntity>()
+        val entrySlots = mutableListOf<EntryEntity>()
+        every { transactionRepository.saveAndFlush(capture(txSlots)) } answers { firstArg() }
+        every { entryRepository.saveAndFlush(capture(entrySlots)) } answers { firstArg() }
+        every { balanceRepository.findById(any()) } returns Optional.empty()
+        every { balanceRepository.saveAndFlush(any()) } answers { firstArg() }
+        every { outboxRepository.saveAndFlush(any()) } answers { firstArg() }
+
+        val result = poster.postReversal(originalId, "op", "corr-1")
+
+        result.reference shouldBe "reversal-of-$originalId"
+        original.status shouldBe TransactionStatus.REVERSED
+        txSlots.any { it.reversesId == originalId.value } shouldBe true
+        entrySlots[0].direction shouldBe EntryDirection.CREDIT
+        entrySlots[0].amount.compareTo(BigDecimal("-100.00")) shouldBe 0
+        entrySlots[1].direction shouldBe EntryDirection.DEBIT
+        entrySlots[1].amount.compareTo(BigDecimal("100.00")) shouldBe 0
+        verify(exactly = 1) { outboxRepository.saveAndFlush(any()) }
+    }
+
+    @Test
+    fun `should reject reversing a transaction that is not posted`() {
+        val originalId = TransactionId.generate()
+        every { transactionRepository.findById(originalId.value) } returns
+            Optional.of(transactionEntity(originalId.value, TransactionStatus.REVERSED))
+
+        shouldThrow<TransactionAlreadyReversedException> { poster.postReversal(originalId, "op", null) }
+
+        verify(exactly = 0) { entryRepository.saveAndFlush(any()) }
+    }
+
+    @Test
+    fun `should reject reversing an unknown transaction`() {
+        val originalId = TransactionId.generate()
+        every { transactionRepository.findById(originalId.value) } returns Optional.empty()
+
+        shouldThrow<TransactionNotFoundException> { poster.postReversal(originalId, "op", null) }
     }
 }

--- a/services/ledger/src/test/kotlin/com/fincore/ledger/application/TransactionServiceImplTest.kt
+++ b/services/ledger/src/test/kotlin/com/fincore/ledger/application/TransactionServiceImplTest.kt
@@ -9,6 +9,10 @@ import com.fincore.core.TransactionId
 import com.fincore.ledger.domain.enum.EntryDirection
 import com.fincore.ledger.domain.enum.TransactionStatus
 import com.fincore.ledger.domain.exception.ConcurrencyConflictException
+import com.fincore.ledger.domain.exception.TransactionNotFoundException
+import com.fincore.ledger.infrastructure.persistence.EntryEntity
+import com.fincore.ledger.infrastructure.persistence.EntryKey
+import com.fincore.ledger.infrastructure.persistence.EntryRepository
 import com.fincore.ledger.infrastructure.persistence.TransactionEntity
 import com.fincore.ledger.infrastructure.persistence.TransactionRepository
 import io.kotest.assertions.throwables.shouldThrow
@@ -25,12 +29,14 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 import java.math.BigDecimal
 import java.time.Instant
+import java.util.Optional
 import java.util.UUID
 
 class TransactionServiceImplTest {
     private val poster = mockk<TransactionPoster>()
     private val transactionRepository = mockk<TransactionRepository>()
-    private val service = TransactionServiceImpl(poster, transactionRepository)
+    private val entryRepository = mockk<EntryRepository>()
+    private val service = TransactionServiceImpl(poster, transactionRepository, entryRepository)
 
     private val command =
         PostTransactionCommand(
@@ -74,6 +80,81 @@ class TransactionServiceImplTest {
         shouldThrow<ConcurrencyConflictException> { service.post(command) }
 
         verify(exactly = 3) { poster.post(command) }
+    }
+
+    @Test
+    fun `should reverse through the poster`() {
+        val id = TransactionId.generate()
+        val compensating = PostedTransaction(TransactionId.generate(), "reversal-of-$id", TransactionStatus.POSTED, Instant.now())
+        every { poster.postReversal(id, "op", "corr-1") } returns compensating
+
+        service.reverse(id, "op", "corr-1") shouldBe compensating
+
+        verify(exactly = 1) { poster.postReversal(id, "op", "corr-1") }
+    }
+
+    @Test
+    fun `should retry reverse on an optimistic lock failure then succeed`() {
+        val id = TransactionId.generate()
+        var calls = 0
+        every { poster.postReversal(id, "op", null) } answers {
+            calls++
+            if (calls < 2) throw OptimisticLockingFailureException("version conflict")
+            PostedTransaction(TransactionId.generate(), "reversal-of-$id", TransactionStatus.POSTED, Instant.now())
+        }
+
+        service.reverse(id, "op", null)
+
+        verify(exactly = 2) { poster.postReversal(id, "op", null) }
+    }
+
+    private val postedAt = Instant.parse("2026-06-12T08:00:00Z")
+
+    private fun transactionEntity(
+        id: UUID,
+        reversesId: UUID?,
+    ) = TransactionEntity(id, "ref-7", "a tx", TransactionStatus.REVERSED, reversesId, "{}", postedAt, postedAt, "op")
+
+    private fun entryEntity(
+        transactionId: UUID,
+        account: UUID,
+    ) = EntryEntity(
+        EntryKey(UUID.randomUUID(), postedAt),
+        transactionId,
+        account,
+        BigDecimal("100.00"),
+        "USD",
+        EntryDirection.DEBIT,
+        postedAt,
+    )
+
+    @Test
+    fun `should assemble a transaction detail with its entries`() {
+        val id = UUID.randomUUID()
+        val account = UUID.randomUUID()
+        val reverses = UUID.randomUUID()
+        every { transactionRepository.findById(id) } returns Optional.of(transactionEntity(id, reverses))
+        every { entryRepository.findByTransactionId(id) } returns listOf(entryEntity(id, account))
+
+        val detail = service.get(TransactionId(id))
+
+        detail.id shouldBe TransactionId(id)
+        detail.status shouldBe TransactionStatus.REVERSED
+        detail.reversesId shouldBe TransactionId(reverses)
+        detail.entries.single().let {
+            it.accountId shouldBe AccountId(account)
+            it.direction shouldBe EntryDirection.DEBIT
+            it.amount.compareTo(BigDecimal("100.00")) shouldBe 0
+            it.currency shouldBe "USD"
+        }
+    }
+
+    @Test
+    fun `should fail to get an unknown transaction`() {
+        val id = UUID.randomUUID()
+        every { transactionRepository.findById(id) } returns Optional.empty()
+
+        shouldThrow<TransactionNotFoundException> { service.get(TransactionId(id)) }
     }
 
     @Test


### PR DESCRIPTION
## What

Adds the two remaining `TransactionController` endpoints (issue #105):

- `GET /v1/transactions/{id}` -> `TransactionDetailResponse`: header
  (`id, reference, description, status, reversesId?, postedAt`) plus `entries[]`
  (`accountId`, `direction`, `amount` as a decimal string per ADR-0012, `currency`).
  Unknown id -> `404` (new `TransactionNotFoundException`); malformed id -> `400`.
- `POST /v1/transactions/{id}/reverse` -> `201` + `Location`: a balanced compensating
  transaction whose entries invert the original's (opposite direction, negated amount,
  net zero per currency), linked via `reverses_id = original.id`.

## Reversal semantics (Model A, owner-resolved OQ-1)

A reversal marks the original `POSTED -> REVERSED` and posts the compensating tx as
`POSTED`. A second reverse is `409`, guarded by the status check and the
`uq_transactions_reverses_id` unique partial index. `TransactionEntity` drops
`@Immutable` so only `status` is updatable (every other column stays `updatable=false`).
The reverse reuses the existing posting / outbox / optimistic-lock path
(`TransactionPoster.write`) and requires an `Idempotency-Key`.

## Tests

- `@WebMvcTest` controller: get 200 (entries, decimal-string amount, prefixed ids), 404,
  400 malformed; reverse 201 + Location, 404, 409, 401, 400 (no Idempotency-Key).
- service-unit (get assembly / 404, reverse delegate + retry), poster (invert/link/flip/409/404),
  mapper (detail), reversal IT (balances return to zero, original REVERSED, double reverse 409, outbox).

Local gates green: `test`, `spotlessCheck`, `detekt`, `compileIntegrationTestKotlin`, `assemble`
(integrationTest runs on CI).

Closes #105