### PR TITLE
feat(web): add transaction detail drill-in screen

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,6 +7,7 @@ import { ThemeProvider } from '@/components/ThemeProvider'
 import { AccountDetail } from '@/routes/AccountDetail'
 import { Accounts } from '@/routes/Accounts'
 import { Overview } from '@/routes/Overview'
+import { TransactionDetail } from '@/routes/TransactionDetail'
 import { Transactions } from '@/routes/Transactions'
 
 const queryClient = new QueryClient()
@@ -21,6 +22,7 @@ export function App() {
                         <Route path="/accounts" element={<Accounts />} />
                         <Route path="/accounts/:id" element={<AccountDetail />} />
                         <Route path="/transactions" element={<Transactions />} />
+                        <Route path="/transactions/:id" element={<TransactionDetail />} />
                     </Routes>
                 </BrowserRouter>
             </ThemeProvider>

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -39,6 +39,25 @@ export interface TransactionResponse {
     postedAt: string
 }
 
+export type EntryDirection = 'DEBIT' | 'CREDIT'
+
+export interface EntryResponse {
+    accountId: string
+    direction: EntryDirection
+    amount: string
+    currency: string
+}
+
+export interface TransactionDetailResponse {
+    id: string
+    reference: string
+    description: string | null
+    status: TransactionStatus
+    reversesId: string | null
+    postedAt: string
+    entries: EntryResponse[]
+}
+
 export interface BalanceResponse {
     accountId: string
     currency: string

--- a/web/src/features/transactions/TransactionsTable.tsx
+++ b/web/src/features/transactions/TransactionsTable.tsx
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 FinCore Engine Authors
 
+import { Link } from 'react-router-dom'
 import type { TransactionResponse } from '@/api/types'
 import { formatInstant } from '@/lib/money'
 import { TxStatusPill } from './Pills'
@@ -19,12 +20,15 @@ export function TransactionsTable({ transactions }: { transactions: TransactionR
             <tbody>
                 {transactions.map((transaction) => (
                     <tr key={transaction.id}>
-                        <td
-                            className="mono"
-                            title={transaction.id}
-                            style={{ color: 'var(--text-2)' }}
-                        >
-                            {transaction.id}
+                        <td>
+                            <Link
+                                to={`/transactions/${transaction.id}`}
+                                className="mono"
+                                title={transaction.id}
+                                style={{ color: 'var(--text-accent)', textDecoration: 'none' }}
+                            >
+                                {transaction.id}
+                            </Link>
                         </td>
                         <td>{transaction.reference}</td>
                         <td>

--- a/web/src/features/transactions/useTransaction.ts
+++ b/web/src/features/transactions/useTransaction.ts
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+import { useQuery } from '@tanstack/react-query'
+import { apiFetch } from '@/api/client'
+import type { TransactionDetailResponse } from '@/api/types'
+
+export function useTransaction(id: string) {
+    return useQuery({
+        queryKey: ['transaction', id],
+        queryFn: () => apiFetch<TransactionDetailResponse>(`/v1/transactions/${id}`),
+    })
+}

--- a/web/src/routes/TransactionDetail.tsx
+++ b/web/src/routes/TransactionDetail.tsx
@@ -1,0 +1,143 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+import { Link, useParams } from 'react-router-dom'
+import { ApiError } from '@/api/client'
+import type { EntryResponse } from '@/api/types'
+import { Icon } from '@/components/Icon'
+import { Shell } from '@/components/Shell'
+import { StateMessage } from '@/components/StateMessage'
+import { TxStatusPill } from '@/features/transactions/Pills'
+import { useTransaction } from '@/features/transactions/useTransaction'
+import { formatAmount, formatInstant } from '@/lib/money'
+
+export function TransactionDetail() {
+    const { id = '' } = useParams()
+    const { data: transaction, isPending, isError, error, refetch } = useTransaction(id)
+
+    return (
+        <Shell activeNav="Transactions">
+            <div
+                style={{
+                    padding: '20px 24px',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 16,
+                    flex: 1,
+                    minHeight: 0,
+                }}
+            >
+                <Link
+                    to="/transactions"
+                    style={{
+                        display: 'inline-flex',
+                        alignItems: 'center',
+                        gap: 6,
+                        fontSize: 12,
+                        color: 'var(--text-2)',
+                        textDecoration: 'none',
+                    }}
+                >
+                    <Icon name="chevLeft" size={12} />
+                    Transactions
+                </Link>
+
+                {isPending ? (
+                    <StateMessage icon="activity" text="Loading transaction..." />
+                ) : isError ? (
+                    error instanceof ApiError && error.status === 404 ? (
+                        <StateMessage icon="inbox" text="Transaction not found." />
+                    ) : (
+                        <StateMessage icon="alert" text="Could not load transaction.">
+                            <button type="button" className="btn" onClick={() => refetch()}>
+                                Retry
+                            </button>
+                        </StateMessage>
+                    )
+                ) : (
+                    <>
+                        <div
+                            className="card"
+                            style={{
+                                padding: 18,
+                                display: 'flex',
+                                alignItems: 'center',
+                                gap: 12,
+                                flexWrap: 'wrap',
+                            }}
+                        >
+                            <span
+                                style={{ fontSize: 19, fontWeight: 500, letterSpacing: '-0.01em' }}
+                            >
+                                {transaction.reference}
+                            </span>
+                            <TxStatusPill status={transaction.status} />
+                            <span
+                                className="mono"
+                                style={{ fontSize: 11.5, color: 'var(--text-3)' }}
+                            >
+                                {transaction.id} · {formatInstant(transaction.postedAt)}
+                            </span>
+                            {transaction.reversesId && (
+                                <span style={{ fontSize: 11.5, color: 'var(--text-3)' }}>
+                                    reverses{' '}
+                                    <Link
+                                        to={`/transactions/${transaction.reversesId}`}
+                                        className="mono"
+                                        style={{
+                                            color: 'var(--text-accent)',
+                                            textDecoration: 'none',
+                                        }}
+                                    >
+                                        {transaction.reversesId}
+                                    </Link>
+                                </span>
+                            )}
+                        </div>
+                        <EntriesTable entries={transaction.entries} />
+                    </>
+                )}
+            </div>
+        </Shell>
+    )
+}
+
+function EntriesTable({ entries }: { entries: EntryResponse[] }) {
+    return (
+        <div className="card" style={{ overflow: 'hidden' }}>
+            <table className="tbl">
+                <thead>
+                    <tr>
+                        <th>Account ID</th>
+                        <th>Direction</th>
+                        <th style={{ textAlign: 'right' }}>Amount</th>
+                        <th>Currency</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {entries.map((entry, index) => (
+                        <tr key={`${entry.accountId}-${entry.direction}-${index}`}>
+                            <td>
+                                <Link
+                                    to={`/accounts/${entry.accountId}`}
+                                    className="mono"
+                                    title={entry.accountId}
+                                    style={{ color: 'var(--text-accent)', textDecoration: 'none' }}
+                                >
+                                    {entry.accountId}
+                                </Link>
+                            </td>
+                            <td>{entry.direction}</td>
+                            <td className="mono tnum" style={{ textAlign: 'right' }}>
+                                {formatAmount(entry.amount)}
+                            </td>
+                            <td className="mono" style={{ color: 'var(--text-2)' }}>
+                                {entry.currency}
+                            </td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </div>
+    )
+}

--- a/web/src/test/TransactionDetail.test.tsx
+++ b/web/src/test/TransactionDetail.test.tsx
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { TransactionDetailResponse } from '@/api/types'
+import { ThemeProvider } from '@/components/ThemeProvider'
+import { TransactionDetail } from '@/routes/TransactionDetail'
+
+const DETAIL: TransactionDetailResponse = {
+    id: 'tx_0001',
+    reference: 'payroll-0425',
+    description: 'monthly payroll',
+    status: 'POSTED',
+    reversesId: null,
+    postedAt: '2026-06-13T10:00:00Z',
+    entries: [
+        { accountId: 'acc_0001', direction: 'DEBIT', amount: '1234567.89', currency: 'EUR' },
+        { accountId: 'acc_0002', direction: 'CREDIT', amount: '-1234567.89', currency: 'EUR' },
+    ],
+}
+
+function ok(body: unknown) {
+    return { ok: true, status: 200, json: async () => body } as Response
+}
+function fail(status: number) {
+    return { ok: false, status, json: async () => ({}) } as Response
+}
+
+function renderDetail(id = 'tx_0001') {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    return render(
+        <QueryClientProvider client={client}>
+            <MemoryRouter initialEntries={[`/transactions/${id}`]}>
+                <ThemeProvider>
+                    <Routes>
+                        <Route path="/transactions/:id" element={<TransactionDetail />} />
+                    </Routes>
+                </ThemeProvider>
+            </MemoryRouter>
+        </QueryClientProvider>,
+    )
+}
+
+afterEach(() => {
+    vi.restoreAllMocks()
+})
+
+describe('TransactionDetail', () => {
+    it('renders the header and entries with losslessly formatted amounts', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(ok(DETAIL))
+        renderDetail()
+        expect(await screen.findByText('payroll-0425')).toBeInTheDocument()
+        expect(screen.getByText('POSTED')).toBeInTheDocument()
+        expect(screen.getByText('1,234,567.89')).toBeInTheDocument()
+        expect(screen.getByText('-1,234,567.89')).toBeInTheDocument()
+        expect(screen.getByText('DEBIT')).toBeInTheDocument()
+        expect(screen.getByText('CREDIT')).toBeInTheDocument()
+        expect(screen.getByRole('link', { name: 'acc_0001' })).toHaveAttribute(
+            'href',
+            '/accounts/acc_0001',
+        )
+    })
+
+    it('links to the reversed original when reversesId is present', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+            ok({ ...DETAIL, status: 'POSTED', reversesId: 'tx_9999' }),
+        )
+        renderDetail()
+        await screen.findByText('payroll-0425')
+        expect(screen.getByRole('link', { name: 'tx_9999' })).toHaveAttribute(
+            'href',
+            '/transactions/tx_9999',
+        )
+    })
+
+    it('shows a not-found state on 404', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(fail(404))
+        renderDetail()
+        expect(await screen.findByText('Transaction not found.')).toBeInTheDocument()
+    })
+
+    it('shows an error state with a working Retry', async () => {
+        const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(fail(500))
+        renderDetail()
+        expect(await screen.findByText('Could not load transaction.')).toBeInTheDocument()
+        const before = fetchMock.mock.calls.length
+        fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+        await waitFor(() => expect(fetchMock.mock.calls.length).toBeGreaterThan(before))
+    })
+})


### PR DESCRIPTION
## What

Closes #122. Adds the `/transactions/:id` drill-in on the live `GET /v1/transactions/{id}` (#105, shipped in #121).

- Each Transaction Explorer (Screen 3) row id is now a link to `/transactions/:id`.
- New detail route: header (reference, status pill, posted time, optional `reverses` link to the original) and an entries table (account id linking to `/accounts/:id`, direction, amount as a lossless decimal string via `formatAmount`, currency).
- `useTransaction(id)` TanStack hook.
- Loading / 404 not-found / error+retry states mirror `AccountDetail`.

## Tests

`TransactionDetail.test.tsx` (4): header + entries with lossless amounts, reverses link, 404 not-found, error+retry. 32 web tests total. typecheck, lint (0 errors), test, build all green.

Closes #122