### PR TITLE
feat(ledger): add per-account entries listing with cursor pagination

### DIFF
--- a/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/application/AccountEntriesIT.kt
+++ b/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/application/AccountEntriesIT.kt
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.application
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fincore.core.AccountId
+import com.fincore.core.Currency
+import com.fincore.ledger.domain.enum.AccountType
+import com.fincore.ledger.domain.enum.EntryDirection
+import com.fincore.ledger.infrastructure.persistence.AccountPersistenceAdapter
+import com.fincore.ledger.infrastructure.persistence.TransactionPersistenceAdapter
+import com.fincore.test.containers.PostgresContainerExtension
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import java.math.BigDecimal
+import java.time.Instant
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ExtendWith(PostgresContainerExtension::class)
+@Import(
+    EntryQueryServiceImpl::class,
+    TransactionServiceImpl::class,
+    TransactionPoster::class,
+    TransactionPersistenceAdapter::class,
+    BalanceServiceImpl::class,
+    AccountServiceImpl::class,
+    AccountPersistenceAdapter::class,
+    AccountEntriesIT.JacksonConfig::class,
+)
+class AccountEntriesIT(
+    @Autowired private val entryQueryService: EntryQueryService,
+    @Autowired private val transactionService: TransactionService,
+    @Autowired private val accountService: AccountService,
+) {
+    @TestConfiguration
+    class JacksonConfig {
+        @Bean
+        fun objectMapper(): ObjectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+    }
+
+    private fun newAccount() = accountService.create(CreateAccountCommand("Account", AccountType.USER_WALLET, Currency.USD, "op"))
+
+    private fun post(
+        reference: String,
+        debit: AccountId,
+        credit: AccountId,
+    ) = transactionService.post(
+        PostTransactionCommand(
+            reference = reference,
+            description = null,
+            currency = Currency.USD,
+            entries =
+                listOf(
+                    EntryLine(debit, EntryDirection.DEBIT, BigDecimal("100.00")),
+                    EntryLine(credit, EntryDirection.CREDIT, BigDecimal("-100.00")),
+                ),
+            actor = "op",
+            correlationId = "corr-1",
+        ),
+    )
+
+    @Test
+    fun `should page account entries newest first with an opaque cursor`() {
+        val account = newAccount()
+        val other = newAccount()
+        post("ref-e1", account.id, other.id)
+        post("ref-e2", account.id, other.id)
+        post("ref-e3", account.id, other.id)
+
+        val firstPage = entryQueryService.listAccountEntries(account.id, null, null, null, 2)
+        firstPage.items.size shouldBe 2
+        (firstPage.nextCursor != null) shouldBe true
+
+        val secondPage = entryQueryService.listAccountEntries(account.id, null, null, firstPage.nextCursor, 2)
+        secondPage.items.size shouldBe 1
+        secondPage.nextCursor shouldBe null
+
+        val firstIds = firstPage.items.map { it.id }.toSet()
+        val secondIds = secondPage.items.map { it.id }.toSet()
+        firstIds.intersect(secondIds).isEmpty() shouldBe true
+    }
+
+    @Test
+    fun `should only return the debit leg for the queried account`() {
+        val account = newAccount()
+        val other = newAccount()
+        post("ref-e4", account.id, other.id)
+
+        val page = entryQueryService.listAccountEntries(account.id, null, null, null, 50)
+
+        page.items.size shouldBe 1
+        page.items.single().direction shouldBe EntryDirection.DEBIT
+        page.items
+            .single()
+            .amount
+            .compareTo(BigDecimal("100.00")) shouldBe 0
+    }
+
+    @Test
+    fun `should exclude entries outside the window`() {
+        val account = newAccount()
+        val other = newAccount()
+        post("ref-e5", account.id, other.id)
+
+        val future = Instant.now().plusSeconds(3600)
+        val page = entryQueryService.listAccountEntries(account.id, future, future.plusSeconds(3600), null, 50)
+
+        page.items.size shouldBe 0
+    }
+
+    companion object {
+        @JvmStatic
+        @DynamicPropertySource
+        fun datasourceProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { PostgresContainerExtension.jdbcUrl }
+            registry.add("spring.datasource.username") { PostgresContainerExtension.username }
+            registry.add("spring.datasource.password") { PostgresContainerExtension.password }
+            registry.add("spring.jpa.hibernate.ddl-auto") { "none" }
+        }
+    }
+}

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/api/AccountController.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/api/AccountController.kt
@@ -9,11 +9,13 @@ import com.fincore.core.IdempotencyKey
 import com.fincore.ledger.api.dto.request.CreateAccountRequest
 import com.fincore.ledger.api.dto.response.AccountResponse
 import com.fincore.ledger.api.dto.response.BalanceResponse
+import com.fincore.ledger.api.dto.response.EntryPageResponse
 import com.fincore.ledger.api.dto.response.PageResponse
 import com.fincore.ledger.api.idempotency.IdempotencyAttributes
 import com.fincore.ledger.api.mapper.LedgerApiMapper
 import com.fincore.ledger.application.AccountService
 import com.fincore.ledger.application.BalanceService
+import com.fincore.ledger.application.EntryQueryService
 import com.fincore.ledger.application.IdempotencyService
 import com.fincore.ledger.application.IdempotentResult
 import com.fincore.ledger.application.StoredResponse
@@ -32,12 +34,14 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.net.URI
+import java.time.Instant
 
 @RestController
 @RequestMapping("/v1/accounts")
 class AccountController(
     private val accountService: AccountService,
     private val balanceService: BalanceService,
+    private val entryQueryService: EntryQueryService,
     private val idempotencyService: IdempotencyService,
     private val mapper: LedgerApiMapper,
     private val objectMapper: ObjectMapper,
@@ -82,6 +86,28 @@ class AccountController(
         val account = accountService.get(accountId)
         return mapper.toResponse(balanceService.current(accountId, account.currency))
     }
+
+    @GetMapping("/{id}/entries")
+    fun entries(
+        @PathVariable id: String,
+        @RequestParam(required = false) from: String?,
+        @RequestParam(required = false) to: String?,
+        @RequestParam(required = false) cursor: String?,
+        @RequestParam(defaultValue = "50") limit: Int,
+    ): EntryPageResponse {
+        val page =
+            entryQueryService.listAccountEntries(
+                AccountId.fromString(id),
+                parseInstant(from),
+                parseInstant(to),
+                cursor,
+                limit,
+            )
+        return mapper.toPageResponse(page)
+    }
+
+    private fun parseInstant(raw: String?): Instant? =
+        raw?.let { runCatching { Instant.parse(it) }.getOrElse { throw IllegalArgumentException("invalid timestamp: $raw") } }
 
     private fun respond(
         result: IdempotentResult,

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/api/dto/response/AccountEntryResponse.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/api/dto/response/AccountEntryResponse.kt
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.api.dto.response
+
+import com.fasterxml.jackson.databind.annotation.JsonSerialize
+import com.fincore.ledger.api.serialization.MoneyAmountSerializer
+import com.fincore.ledger.domain.enum.EntryDirection
+import io.swagger.v3.oas.annotations.media.Schema
+import java.math.BigDecimal
+import java.time.Instant
+
+data class AccountEntryResponse(
+    val id: String,
+    val transactionId: String,
+    val direction: EntryDirection,
+    @JsonSerialize(using = MoneyAmountSerializer::class)
+    @Schema(type = "string", format = "decimal", example = "100.00")
+    val amount: BigDecimal,
+    val currency: String,
+    val postedAt: Instant,
+)

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/api/dto/response/EntryPageResponse.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/api/dto/response/EntryPageResponse.kt
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.api.dto.response
+
+data class EntryPageResponse(
+    val items: List<AccountEntryResponse>,
+    val nextCursor: String?,
+)

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/api/mapper/LedgerApiMapper.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/api/mapper/LedgerApiMapper.kt
@@ -7,13 +7,17 @@ import com.fincore.core.AccountId
 import com.fincore.core.Currency
 import com.fincore.ledger.api.dto.request.CreateAccountRequest
 import com.fincore.ledger.api.dto.request.PostTransactionRequest
+import com.fincore.ledger.api.dto.response.AccountEntryResponse
 import com.fincore.ledger.api.dto.response.AccountResponse
 import com.fincore.ledger.api.dto.response.BalanceResponse
+import com.fincore.ledger.api.dto.response.EntryPageResponse
 import com.fincore.ledger.api.dto.response.EntryResponse
 import com.fincore.ledger.api.dto.response.PageResponse
 import com.fincore.ledger.api.dto.response.TransactionDetailResponse
 import com.fincore.ledger.api.dto.response.TransactionResponse
 import com.fincore.ledger.application.AccountBalance
+import com.fincore.ledger.application.AccountEntry
+import com.fincore.ledger.application.AccountEntryPage
 import com.fincore.ledger.application.AccountPage
 import com.fincore.ledger.application.CreateAccountCommand
 import com.fincore.ledger.application.EntryLine
@@ -121,6 +125,22 @@ class LedgerApiMapper {
             direction = entry.direction,
             amount = entry.amount,
             currency = entry.currency,
+        )
+
+    fun toResponse(entry: AccountEntry): AccountEntryResponse =
+        AccountEntryResponse(
+            id = entry.id.toString(),
+            transactionId = entry.transactionId.toString(),
+            direction = entry.direction,
+            amount = entry.amount,
+            currency = entry.currency,
+            postedAt = entry.postedAt,
+        )
+
+    fun toPageResponse(page: AccountEntryPage): EntryPageResponse =
+        EntryPageResponse(
+            items = page.items.map(::toResponse),
+            nextCursor = page.nextCursor,
         )
 
     fun toPageResponse(page: TransactionPage): PageResponse<TransactionResponse> =

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/application/AccountEntry.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/application/AccountEntry.kt
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.application
+
+import com.fincore.core.EntryId
+import com.fincore.core.TransactionId
+import com.fincore.ledger.domain.enum.EntryDirection
+import java.math.BigDecimal
+import java.time.Instant
+
+data class AccountEntry(
+    val id: EntryId,
+    val transactionId: TransactionId,
+    val direction: EntryDirection,
+    val amount: BigDecimal,
+    val currency: String,
+    val postedAt: Instant,
+)
+
+data class AccountEntryPage(
+    val items: List<AccountEntry>,
+    val nextCursor: String?,
+)

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/application/EntryCursor.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/application/EntryCursor.kt
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.application
+
+import java.time.Instant
+import java.util.Base64
+import java.util.UUID
+
+// Opaque keyset cursor over (postedAt, id). The wire form is base64url; clients must treat it as opaque.
+data class EntryCursor(
+    val postedAt: Instant,
+    val id: UUID,
+) {
+    fun encode(): String = ENCODER.encodeToString("$postedAt$DELIMITER$id".toByteArray(Charsets.UTF_8))
+
+    companion object {
+        private const val DELIMITER = '|'
+        private val ENCODER = Base64.getUrlEncoder().withoutPadding()
+        private val DECODER = Base64.getUrlDecoder()
+
+        fun decode(raw: String): EntryCursor {
+            val decoded = orInvalid { String(DECODER.decode(raw), Charsets.UTF_8) }
+            val separator = decoded.indexOf(DELIMITER)
+            require(separator > 0) { "invalid cursor" }
+            val postedAt = orInvalid { Instant.parse(decoded.substring(0, separator)) }
+            val id = orInvalid { UUID.fromString(decoded.substring(separator + 1)) }
+            return EntryCursor(postedAt, id)
+        }
+
+        private fun <T> orInvalid(block: () -> T): T = runCatching(block).getOrElse { throw IllegalArgumentException("invalid cursor", it) }
+    }
+}

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/application/EntryQueryService.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/application/EntryQueryService.kt
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.application
+
+import com.fincore.core.AccountId
+import java.time.Instant
+
+interface EntryQueryService {
+    fun listAccountEntries(
+        accountId: AccountId,
+        from: Instant?,
+        to: Instant?,
+        cursor: String?,
+        limit: Int,
+    ): AccountEntryPage
+}

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/application/EntryQueryServiceImpl.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/application/EntryQueryServiceImpl.kt
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.application
+
+import com.fincore.core.AccountId
+import com.fincore.core.EntryId
+import com.fincore.core.TransactionId
+import com.fincore.ledger.infrastructure.persistence.EntryEntity
+import com.fincore.ledger.infrastructure.persistence.EntryRepository
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Duration
+import java.time.Instant
+
+@Service
+class EntryQueryServiceImpl(
+    private val accountService: AccountService,
+    private val entryRepository: EntryRepository,
+) : EntryQueryService {
+    @Transactional(readOnly = true)
+    override fun listAccountEntries(
+        accountId: AccountId,
+        from: Instant?,
+        to: Instant?,
+        cursor: String?,
+        limit: Int,
+    ): AccountEntryPage {
+        require(limit in 1..MAX_LIMIT) { "limit must be 1..$MAX_LIMIT" }
+        accountService.get(accountId)
+        val end = to ?: Instant.now()
+        val start = from ?: end.minus(DEFAULT_WINDOW)
+        require(!start.isAfter(end)) { "from must be on or before to" }
+        require(Duration.between(start, end) <= MAX_WINDOW) { "range must span at most ${MAX_WINDOW.toDays()} days" }
+        val decoded = cursor?.let(EntryCursor::decode)
+        val rows =
+            entryRepository.findAccountEntries(
+                accountId.value,
+                start,
+                end,
+                decoded?.postedAt,
+                decoded?.id,
+                PageRequest.of(0, limit + 1),
+            )
+        val hasMore = rows.size > limit
+        val page = if (hasMore) rows.take(limit) else rows
+        val nextCursor = if (hasMore) EntryCursor(page.last().postedAt, page.last().key.id).encode() else null
+        return AccountEntryPage(page.map(::toEntry), nextCursor)
+    }
+
+    private fun toEntry(entry: EntryEntity): AccountEntry =
+        AccountEntry(
+            EntryId(entry.key.id),
+            TransactionId(entry.transactionId),
+            entry.direction,
+            entry.amount,
+            entry.currency,
+            entry.postedAt,
+        )
+
+    private companion object {
+        const val MAX_LIMIT = 200
+        val DEFAULT_WINDOW: Duration = Duration.ofDays(30)
+        val MAX_WINDOW: Duration = Duration.ofDays(90)
+    }
+}

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/application/EntryQueryServiceImpl.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/application/EntryQueryServiceImpl.kt
@@ -34,15 +34,13 @@ class EntryQueryServiceImpl(
         require(!start.isAfter(end)) { "from must be on or before to" }
         require(Duration.between(start, end) <= MAX_WINDOW) { "range must span at most ${MAX_WINDOW.toDays()} days" }
         val decoded = cursor?.let(EntryCursor::decode)
+        val pageable = PageRequest.of(0, limit + 1)
         val rows =
-            entryRepository.findAccountEntries(
-                accountId.value,
-                start,
-                end,
-                decoded?.postedAt,
-                decoded?.id,
-                PageRequest.of(0, limit + 1),
-            )
+            if (decoded == null) {
+                entryRepository.findAccountEntries(accountId.value, start, end, pageable)
+            } else {
+                entryRepository.findAccountEntriesAfter(accountId.value, start, end, decoded.postedAt, decoded.id, pageable)
+            }
         val hasMore = rows.size > limit
         val page = if (hasMore) rows.take(limit) else rows
         val nextCursor = if (hasMore) EntryCursor(page.last().postedAt, page.last().key.id).encode() else null

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/EntryRepository.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/EntryRepository.kt
@@ -3,6 +3,7 @@
 
 package com.fincore.ledger.infrastructure.persistence
 
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
@@ -24,5 +25,21 @@ interface EntryRepository : JpaRepository<EntryEntity, EntryKey> {
     @Query("select e from EntryEntity e where e.transactionId = :transactionId order by e.key.id")
     fun findByTransactionId(
         @Param("transactionId") transactionId: UUID,
+    ): List<EntryEntity>
+
+    @Query(
+        "select e from EntryEntity e where e.accountId = :accountId " +
+            "and e.postedAt >= :from and e.postedAt <= :to " +
+            "and (:cursorPostedAt is null or e.postedAt < :cursorPostedAt " +
+            "or (e.postedAt = :cursorPostedAt and e.key.id < :cursorId)) " +
+            "order by e.postedAt desc, e.key.id desc",
+    )
+    fun findAccountEntries(
+        @Param("accountId") accountId: UUID,
+        @Param("from") from: Instant,
+        @Param("to") to: Instant,
+        @Param("cursorPostedAt") cursorPostedAt: Instant?,
+        @Param("cursorId") cursorId: UUID?,
+        pageable: Pageable,
     ): List<EntryEntity>
 }

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/EntryRepository.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/EntryRepository.kt
@@ -30,16 +30,27 @@ interface EntryRepository : JpaRepository<EntryEntity, EntryKey> {
     @Query(
         "select e from EntryEntity e where e.accountId = :accountId " +
             "and e.postedAt >= :from and e.postedAt <= :to " +
-            "and (:cursorPostedAt is null or e.postedAt < :cursorPostedAt " +
-            "or (e.postedAt = :cursorPostedAt and e.key.id < :cursorId)) " +
             "order by e.postedAt desc, e.key.id desc",
     )
     fun findAccountEntries(
         @Param("accountId") accountId: UUID,
         @Param("from") from: Instant,
         @Param("to") to: Instant,
-        @Param("cursorPostedAt") cursorPostedAt: Instant?,
-        @Param("cursorId") cursorId: UUID?,
+        pageable: Pageable,
+    ): List<EntryEntity>
+
+    @Query(
+        "select e from EntryEntity e where e.accountId = :accountId " +
+            "and e.postedAt >= :from and e.postedAt <= :to " +
+            "and (e.postedAt < :cursorPostedAt or (e.postedAt = :cursorPostedAt and e.key.id < :cursorId)) " +
+            "order by e.postedAt desc, e.key.id desc",
+    )
+    fun findAccountEntriesAfter(
+        @Param("accountId") accountId: UUID,
+        @Param("from") from: Instant,
+        @Param("to") to: Instant,
+        @Param("cursorPostedAt") cursorPostedAt: Instant,
+        @Param("cursorId") cursorId: UUID,
         pageable: Pageable,
     ): List<EntryEntity>
 }

--- a/services/ledger/src/test/kotlin/com/fincore/ledger/api/AccountControllerTest.kt
+++ b/services/ledger/src/test/kotlin/com/fincore/ledger/api/AccountControllerTest.kt
@@ -5,19 +5,25 @@ package com.fincore.ledger.api
 
 import com.fincore.core.AccountId
 import com.fincore.core.Currency
+import com.fincore.core.EntryId
 import com.fincore.core.Money
+import com.fincore.core.TransactionId
 import com.fincore.ledger.api.idempotency.IdempotencyAttributes
 import com.fincore.ledger.api.idempotency.IdempotencyFilter
 import com.fincore.ledger.api.mapper.LedgerApiMapper
 import com.fincore.ledger.application.AccountBalance
+import com.fincore.ledger.application.AccountEntry
+import com.fincore.ledger.application.AccountEntryPage
 import com.fincore.ledger.application.AccountPage
 import com.fincore.ledger.application.AccountService
 import com.fincore.ledger.application.BalanceService
 import com.fincore.ledger.application.CreateAccountCommand
+import com.fincore.ledger.application.EntryQueryService
 import com.fincore.ledger.application.IdempotentResult
 import com.fincore.ledger.config.SecurityConfig
 import com.fincore.ledger.domain.Account
 import com.fincore.ledger.domain.enum.AccountType
+import com.fincore.ledger.domain.enum.EntryDirection
 import com.fincore.ledger.domain.exception.AccountNotFoundException
 import com.fincore.ledger.domain.exception.IdempotencyConflictException
 import io.kotest.matchers.shouldBe
@@ -55,6 +61,7 @@ class AccountControllerTest(
     @Autowired private val mockMvc: MockMvc,
     @Autowired private val accountService: AccountService,
     @Autowired private val balanceService: BalanceService,
+    @Autowired private val entryQueryService: EntryQueryService,
     @Autowired private val idempotencyService: FakeIdempotencyService,
 ) {
     private val key = "k".repeat(40)
@@ -65,6 +72,8 @@ class AccountControllerTest(
 
         @Bean fun balanceService(): BalanceService = mockk()
 
+        @Bean fun entryQueryService(): EntryQueryService = mockk()
+
         @Bean fun idempotencyService(): FakeIdempotencyService = FakeIdempotencyService()
 
         @Bean fun jwtDecoder(): JwtDecoder = mockk()
@@ -73,7 +82,7 @@ class AccountControllerTest(
     @BeforeEach
     fun resetMocks() {
         idempotencyService.reset()
-        clearMocks(accountService, balanceService)
+        clearMocks(accountService, balanceService, entryQueryService)
     }
 
     @Test
@@ -239,5 +248,75 @@ class AccountControllerTest(
     @Test
     fun `should reject an unauthenticated list request with 401`() {
         mockMvc.perform(get("/v1/accounts")).andExpect(status().isUnauthorized)
+    }
+
+    private fun entry() =
+        AccountEntry(
+            EntryId.generate(),
+            TransactionId.generate(),
+            EntryDirection.DEBIT,
+            BigDecimal("100.00"),
+            "EUR",
+            Instant.parse("2026-06-13T10:00:00Z"),
+        )
+
+    @Test
+    fun `should list account entries with prefixed ids, decimal amounts and a next cursor`() {
+        every { entryQueryService.listAccountEntries(any(), any(), any(), any(), any()) } returns
+            AccountEntryPage(listOf(entry()), "Y3Vyc29y")
+
+        mockMvc
+            .perform(get("/v1/accounts/${AccountId.generate()}/entries").with(jwt()))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.items[0].id").value(matchesPattern("^ent_[0-9A-HJKMNP-TV-Z]{26}$")))
+            .andExpect(jsonPath("$.items[0].transactionId").value(matchesPattern("^tx_[0-9A-HJKMNP-TV-Z]{26}$")))
+            .andExpect(jsonPath("$.items[0].amount").value("100.00"))
+            .andExpect(jsonPath("$.items[0].direction").value("DEBIT"))
+            .andExpect(jsonPath("$.nextCursor").value("Y3Vyc29y"))
+    }
+
+    @Test
+    fun `should return 400 for a malformed account id on the entries endpoint`() {
+        mockMvc
+            .perform(get("/v1/accounts/acc_zzz/entries").with(jwt()))
+            .andExpect(status().isBadRequest)
+
+        verify(exactly = 0) { entryQueryService.listAccountEntries(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `should return 400 for a malformed from timestamp`() {
+        mockMvc
+            .perform(get("/v1/accounts/${AccountId.generate()}/entries?from=not-a-date").with(jwt()))
+            .andExpect(status().isBadRequest)
+
+        verify(exactly = 0) { entryQueryService.listAccountEntries(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `should map an entries range violation to 400`() {
+        every { entryQueryService.listAccountEntries(any(), any(), any(), any(), any()) } throws
+            IllegalArgumentException("range must span at most 90 days")
+
+        mockMvc
+            .perform(get("/v1/accounts/${AccountId.generate()}/entries?limit=300").with(jwt()))
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `should map a missing account to 404 on the entries endpoint`() {
+        every { entryQueryService.listAccountEntries(any(), any(), any(), any(), any()) } throws
+            AccountNotFoundException(AccountId.generate())
+
+        mockMvc
+            .perform(get("/v1/accounts/${AccountId.generate()}/entries").with(jwt()))
+            .andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun `should reject an unauthenticated entries request with 401`() {
+        mockMvc
+            .perform(get("/v1/accounts/${AccountId.generate()}/entries"))
+            .andExpect(status().isUnauthorized)
     }
 }

--- a/services/ledger/src/test/kotlin/com/fincore/ledger/application/EntryCursorTest.kt
+++ b/services/ledger/src/test/kotlin/com/fincore/ledger/application/EntryCursorTest.kt
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.application
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.UUID
+
+class EntryCursorTest {
+    @Test
+    fun `should round-trip a cursor through encode and decode`() {
+        val cursor = EntryCursor(Instant.parse("2026-06-13T10:00:00.123456Z"), UUID.randomUUID())
+
+        val decoded = EntryCursor.decode(cursor.encode())
+
+        decoded.postedAt shouldBe cursor.postedAt
+        decoded.id shouldBe cursor.id
+    }
+
+    @Test
+    fun `should reject a non-base64 cursor`() {
+        shouldThrow<IllegalArgumentException> { EntryCursor.decode("!!! not base64 !!!") }
+    }
+
+    @Test
+    fun `should reject a base64 cursor without the delimiter`() {
+        val noDelimiter =
+            java.util.Base64
+                .getUrlEncoder()
+                .withoutPadding()
+                .encodeToString("garbage".toByteArray())
+
+        shouldThrow<IllegalArgumentException> { EntryCursor.decode(noDelimiter) }
+    }
+
+    @Test
+    fun `should reject a cursor with a bad timestamp`() {
+        val badTimestamp =
+            java.util.Base64
+                .getUrlEncoder()
+                .withoutPadding()
+                .encodeToString("nope|${UUID.randomUUID()}".toByteArray())
+
+        shouldThrow<IllegalArgumentException> { EntryCursor.decode(badTimestamp) }
+    }
+}

--- a/services/ledger/src/test/kotlin/com/fincore/ledger/application/EntryQueryServiceImplTest.kt
+++ b/services/ledger/src/test/kotlin/com/fincore/ledger/application/EntryQueryServiceImplTest.kt
@@ -53,7 +53,7 @@ class EntryQueryServiceImplTest {
         val to = slot<Instant>()
         val pageable = slot<Pageable>()
         every {
-            entryRepository.findAccountEntries(accountId.value, capture(from), capture(to), null, null, capture(pageable))
+            entryRepository.findAccountEntries(accountId.value, capture(from), capture(to), capture(pageable))
         } returns emptyList()
 
         service.listAccountEntries(accountId, null, null, null, 50)
@@ -67,7 +67,7 @@ class EntryQueryServiceImplTest {
         stubAccount()
         val newest = Instant.parse("2026-06-13T10:00:00Z")
         val rows = listOf(row(newest), row(newest.minusSeconds(1)), row(newest.minusSeconds(2)))
-        every { entryRepository.findAccountEntries(any(), any(), any(), any(), any(), any()) } returns rows
+        every { entryRepository.findAccountEntries(any(), any(), any(), any()) } returns rows
 
         val page = service.listAccountEntries(accountId, null, null, null, 2)
 
@@ -79,7 +79,7 @@ class EntryQueryServiceImplTest {
     @Test
     fun `should return a null next cursor when the page does not overflow`() {
         stubAccount()
-        every { entryRepository.findAccountEntries(any(), any(), any(), any(), any(), any()) } returns
+        every { entryRepository.findAccountEntries(any(), any(), any(), any()) } returns
             listOf(row(Instant.parse("2026-06-13T10:00:00Z")))
 
         service.listAccountEntries(accountId, null, null, null, 2).nextCursor shouldBe null
@@ -91,7 +91,7 @@ class EntryQueryServiceImplTest {
         val cursorPostedAt = Instant.parse("2026-06-10T08:00:00Z")
         val cursorId = UUID.randomUUID()
         every {
-            entryRepository.findAccountEntries(accountId.value, any(), any(), cursorPostedAt, cursorId, any())
+            entryRepository.findAccountEntriesAfter(accountId.value, any(), any(), cursorPostedAt, cursorId, any())
         } returns emptyList()
 
         service.listAccountEntries(accountId, null, null, EntryCursor(cursorPostedAt, cursorId).encode(), 50)

--- a/services/ledger/src/test/kotlin/com/fincore/ledger/application/EntryQueryServiceImplTest.kt
+++ b/services/ledger/src/test/kotlin/com/fincore/ledger/application/EntryQueryServiceImplTest.kt
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.application
+
+import com.fincore.core.AccountId
+import com.fincore.core.Currency
+import com.fincore.ledger.domain.Account
+import com.fincore.ledger.domain.enum.AccountType
+import com.fincore.ledger.domain.enum.EntryDirection
+import com.fincore.ledger.domain.exception.AccountNotFoundException
+import com.fincore.ledger.infrastructure.persistence.EntryEntity
+import com.fincore.ledger.infrastructure.persistence.EntryKey
+import com.fincore.ledger.infrastructure.persistence.EntryRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.junit.jupiter.api.Test
+import org.springframework.data.domain.Pageable
+import java.math.BigDecimal
+import java.time.Duration
+import java.time.Instant
+import java.util.UUID
+
+class EntryQueryServiceImplTest {
+    private val accountService = mockk<AccountService>()
+    private val entryRepository = mockk<EntryRepository>()
+    private val service = EntryQueryServiceImpl(accountService, entryRepository)
+
+    private val accountId = AccountId.generate()
+
+    private fun stubAccount() {
+        every { accountService.get(accountId) } returns Account(accountId, "Wallet", AccountType.USER_WALLET, Currency.EUR)
+    }
+
+    private fun row(postedAt: Instant) =
+        EntryEntity(
+            EntryKey(UUID.randomUUID(), postedAt),
+            UUID.randomUUID(),
+            accountId.value,
+            BigDecimal("100.00"),
+            "EUR",
+            EntryDirection.DEBIT,
+            postedAt,
+        )
+
+    @Test
+    fun `should default to a 30 day window and request one more than the limit`() {
+        stubAccount()
+        val from = slot<Instant>()
+        val to = slot<Instant>()
+        val pageable = slot<Pageable>()
+        every {
+            entryRepository.findAccountEntries(accountId.value, capture(from), capture(to), null, null, capture(pageable))
+        } returns emptyList()
+
+        service.listAccountEntries(accountId, null, null, null, 50)
+
+        Duration.between(from.captured, to.captured) shouldBe Duration.ofDays(30)
+        pageable.captured.pageSize shouldBe 51
+    }
+
+    @Test
+    fun `should emit a next cursor only when the page overflows`() {
+        stubAccount()
+        val newest = Instant.parse("2026-06-13T10:00:00Z")
+        val rows = listOf(row(newest), row(newest.minusSeconds(1)), row(newest.minusSeconds(2)))
+        every { entryRepository.findAccountEntries(any(), any(), any(), any(), any(), any()) } returns rows
+
+        val page = service.listAccountEntries(accountId, null, null, null, 2)
+
+        page.items.size shouldBe 2
+        val decoded = EntryCursor.decode(page.nextCursor!!)
+        decoded.id shouldBe rows[1].key.id
+    }
+
+    @Test
+    fun `should return a null next cursor when the page does not overflow`() {
+        stubAccount()
+        every { entryRepository.findAccountEntries(any(), any(), any(), any(), any(), any()) } returns
+            listOf(row(Instant.parse("2026-06-13T10:00:00Z")))
+
+        service.listAccountEntries(accountId, null, null, null, 2).nextCursor shouldBe null
+    }
+
+    @Test
+    fun `should pass a decoded cursor to the repository`() {
+        stubAccount()
+        val cursorPostedAt = Instant.parse("2026-06-10T08:00:00Z")
+        val cursorId = UUID.randomUUID()
+        every {
+            entryRepository.findAccountEntries(accountId.value, any(), any(), cursorPostedAt, cursorId, any())
+        } returns emptyList()
+
+        service.listAccountEntries(accountId, null, null, EntryCursor(cursorPostedAt, cursorId).encode(), 50)
+    }
+
+    @Test
+    fun `should reject a window wider than 90 days`() {
+        stubAccount()
+        val from = Instant.parse("2026-01-01T00:00:00Z")
+        val to = Instant.parse("2026-06-01T00:00:00Z")
+
+        shouldThrow<IllegalArgumentException> { service.listAccountEntries(accountId, from, to, null, 50) }
+    }
+
+    @Test
+    fun `should reject a limit outside one to two hundred`() {
+        shouldThrow<IllegalArgumentException> { service.listAccountEntries(accountId, null, null, null, 0) }
+        shouldThrow<IllegalArgumentException> { service.listAccountEntries(accountId, null, null, null, 201) }
+    }
+
+    @Test
+    fun `should propagate a missing account`() {
+        every { accountService.get(accountId) } throws AccountNotFoundException(accountId)
+
+        shouldThrow<AccountNotFoundException> { service.listAccountEntries(accountId, null, null, null, 50) }
+    }
+}


### PR DESCRIPTION
## What

Closes #39 and #28. Adds `GET /v1/accounts/{id}/entries` (unblocks Screen 2 per-account view).

- Per-entry row: `id` (`ent_`), `transactionId` (`tx_`), `direction`, `amount` (decimal string, ADR-0012), `currency`, `postedAt`.
- Time window: default last 30 days; max span 90 days (`#39`). Span > 90d -> `400`.
- Opaque keyset cursor over `(postedAt, id)`, order `postedAt DESC, id DESC` (`#28`); `nextCursor` null at the end.
- `limit` 1..200 (default 50). Invalid input (malformed id/timestamps, span/limit/cursor) -> `400`; unknown account -> `404`; JWT secured (`401`).

## Design

- `EntryQueryService` (readOnly) validates the window/limit, decodes the cursor, fetches `limit + 1` rows to detect a next page, and maps to an app read-model. Keyset (not offset) for stable deep paging on the range-partitioned `entries` table.
- `EntryCursor` is an opaque base64url codec; malformed input decodes to `IllegalArgumentException` (-> 400).
- New `EntryRepository.findAccountEntries` keyset query with nullable cursor params.

## Tests

`EntryCursorTest` (round-trip + 3 malformed cases), `EntryQueryServiceImplTest` (default window, limit+1 fetch, nextCursor overflow/null, decoded cursor passthrough, span>90d, limit guard, 404), `AccountControllerTest` (200 page with prefixed ids + decimal amount + nextCursor, 400 malformed id/timestamp/range, 404, 401), `AccountEntriesIT` (newest-first cursor paging to null, debit-leg only, window exclusion).

Local gates green: `test`, `spotlessCheck`, `detekt`, `compileIntegrationTestKotlin`, `assemble` (IT on CI).

Closes #39
Closes #28