### PR TITLE
feat(web): add per-account entries table to account detail

### DIFF
--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -58,6 +58,20 @@ export interface TransactionDetailResponse {
     entries: EntryResponse[]
 }
 
+export interface AccountEntryResponse {
+    id: string
+    transactionId: string
+    direction: EntryDirection
+    amount: string
+    currency: string
+    postedAt: string
+}
+
+export interface EntryPageResponse {
+    items: AccountEntryResponse[]
+    nextCursor: string | null
+}
+
 export interface BalanceResponse {
     accountId: string
     currency: string

--- a/web/src/features/accounts/useAccountEntries.ts
+++ b/web/src/features/accounts/useAccountEntries.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+import { useInfiniteQuery } from '@tanstack/react-query'
+import { apiFetch } from '@/api/client'
+import type { EntryPageResponse } from '@/api/types'
+
+export function useAccountEntries(id: string) {
+    return useInfiniteQuery({
+        queryKey: ['account', id, 'entries'],
+        queryFn: ({ pageParam }) =>
+            apiFetch<EntryPageResponse>(
+                `/v1/accounts/${id}/entries${pageParam ? `?cursor=${pageParam}` : ''}`,
+            ),
+        initialPageParam: '',
+        getNextPageParam: (last) => last.nextCursor ?? undefined,
+    })
+}

--- a/web/src/routes/AccountDetail.tsx
+++ b/web/src/routes/AccountDetail.tsx
@@ -8,6 +8,7 @@ import { Shell } from '@/components/Shell'
 import { StateMessage } from '@/components/StateMessage'
 import { StatusPill, TypePill } from '@/features/accounts/Pills'
 import { useAccount, useBalance } from '@/features/accounts/useAccount'
+import { useAccountEntries } from '@/features/accounts/useAccountEntries'
 import { formatAmount, formatInstant } from '@/lib/money'
 
 export function AccountDetail() {
@@ -80,6 +81,7 @@ export function AccountDetail() {
                             </span>
                         </div>
                         <BalanceCard id={id} />
+                        <AccountEntries id={id} />
                     </>
                 )}
             </div>
@@ -149,6 +151,82 @@ function BalanceCard({ id }: { id: string }) {
                         )}
                     </div>
                 </>
+            )}
+        </div>
+    )
+}
+
+function AccountEntries({ id }: { id: string }) {
+    const { data, isPending, isError, refetch, hasNextPage, fetchNextPage, isFetchingNextPage } =
+        useAccountEntries(id)
+
+    if (isPending) return <StateMessage icon="activity" text="Loading entries..." />
+    if (isError)
+        return (
+            <StateMessage icon="alert" text="Could not load entries.">
+                <button type="button" className="btn" onClick={() => refetch()}>
+                    Retry
+                </button>
+            </StateMessage>
+        )
+
+    const entries = data.pages.flatMap((page) => page.items)
+    if (entries.length === 0) return <StateMessage icon="inbox" text="No entries yet." />
+
+    return (
+        <div className="card" style={{ overflow: 'hidden' }}>
+            <table className="tbl">
+                <thead>
+                    <tr>
+                        <th>Entry ID</th>
+                        <th>Transaction ID</th>
+                        <th>Direction</th>
+                        <th style={{ textAlign: 'right' }}>Amount</th>
+                        <th>Currency</th>
+                        <th>Posted At</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {entries.map((entry) => (
+                        <tr key={entry.id}>
+                            <td className="mono" style={{ color: 'var(--text-2)' }}>
+                                {entry.id}
+                            </td>
+                            <td>
+                                <Link
+                                    to={`/transactions/${entry.transactionId}`}
+                                    className="mono"
+                                    title={entry.transactionId}
+                                    style={{ color: 'var(--text-accent)', textDecoration: 'none' }}
+                                >
+                                    {entry.transactionId}
+                                </Link>
+                            </td>
+                            <td>{entry.direction}</td>
+                            <td className="mono tnum" style={{ textAlign: 'right' }}>
+                                {formatAmount(entry.amount)}
+                            </td>
+                            <td className="mono" style={{ color: 'var(--text-2)' }}>
+                                {entry.currency}
+                            </td>
+                            <td className="mono" style={{ color: 'var(--text-2)' }}>
+                                {formatInstant(entry.postedAt)}
+                            </td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+            {hasNextPage && (
+                <div style={{ padding: 12, textAlign: 'center' }}>
+                    <button
+                        type="button"
+                        className="btn btn-sm"
+                        disabled={isFetchingNextPage}
+                        onClick={() => fetchNextPage()}
+                    >
+                        Load more
+                    </button>
+                </div>
             )}
         </div>
     )

--- a/web/src/test/AccountDetail.test.tsx
+++ b/web/src/test/AccountDetail.test.tsx
@@ -5,7 +5,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter, Route, Routes } from 'react-router-dom'
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import type { AccountResponse, BalanceResponse } from '@/api/types'
+import type { AccountEntryResponse, AccountResponse, BalanceResponse } from '@/api/types'
 import { ThemeProvider } from '@/components/ThemeProvider'
 import { AccountDetail } from '@/routes/AccountDetail'
 
@@ -22,6 +22,23 @@ const BALANCE: BalanceResponse = {
     amount: '1234567.89',
     lastPostedAt: '2026-06-13T10:00:00Z',
 }
+const ENTRY_A: AccountEntryResponse = {
+    id: 'ent_0001',
+    transactionId: 'tx_aaa',
+    direction: 'DEBIT',
+    amount: '100.00',
+    currency: 'EUR',
+    postedAt: '2026-06-13T09:00:00Z',
+}
+const ENTRY_B: AccountEntryResponse = {
+    id: 'ent_0002',
+    transactionId: 'tx_bbb',
+    direction: 'CREDIT',
+    amount: '250.50',
+    currency: 'EUR',
+    postedAt: '2026-06-12T08:00:00Z',
+}
+const EMPTY_ENTRIES = { items: [], nextCursor: null }
 
 function ok(body: unknown) {
     return { ok: true, status: 200, json: async () => body } as Response
@@ -30,9 +47,17 @@ function fail(status: number) {
     return { ok: false, status, json: async () => ({}) } as Response
 }
 
-function mockFetch(opts: { account?: () => Response; balance?: () => Response } = {}) {
+function mockFetch(
+    opts: {
+        account?: () => Response
+        balance?: () => Response
+        entries?: (url: string) => Response
+    } = {},
+) {
     return vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
         const url = String(input)
+        if (url.includes('/entries'))
+            return Promise.resolve((opts.entries ?? (() => ok(EMPTY_ENTRIES)))(url))
         if (url.endsWith('/balance'))
             return Promise.resolve((opts.balance ?? (() => ok(BALANCE)))())
         return Promise.resolve((opts.account ?? (() => ok(ACCOUNT)))())
@@ -96,5 +121,51 @@ describe('AccountDetail', () => {
         mockFetch({ balance: () => ok({ ...BALANCE, lastPostedAt: null }) })
         renderDetail()
         expect(await screen.findByText('No postings yet.')).toBeInTheDocument()
+    })
+
+    it('renders entry rows with a transaction link and lossless amounts', async () => {
+        mockFetch({ entries: () => ok({ items: [ENTRY_A, ENTRY_B], nextCursor: null }) })
+        renderDetail()
+        expect(await screen.findByText('ent_0001')).toBeInTheDocument()
+        expect(screen.getByText('ent_0002')).toBeInTheDocument()
+        expect(screen.getByText('100.00')).toBeInTheDocument()
+        expect(screen.getByText('250.50')).toBeInTheDocument()
+        const link = screen.getByRole('link', { name: 'tx_aaa' })
+        expect(link).toHaveAttribute('href', '/transactions/tx_aaa')
+        expect(screen.queryByRole('button', { name: 'Load more' })).not.toBeInTheDocument()
+    })
+
+    it('appends the next page and hides Load more when the cursor is exhausted', async () => {
+        mockFetch({
+            entries: (url) =>
+                url.includes('cursor=c2')
+                    ? ok({ items: [ENTRY_B], nextCursor: null })
+                    : ok({ items: [ENTRY_A], nextCursor: 'c2' }),
+        })
+        renderDetail()
+        expect(await screen.findByText('ent_0001')).toBeInTheDocument()
+        fireEvent.click(screen.getByRole('button', { name: 'Load more' }))
+        expect(await screen.findByText('ent_0002')).toBeInTheDocument()
+        await waitFor(() =>
+            expect(screen.queryByRole('button', { name: 'Load more' })).not.toBeInTheDocument(),
+        )
+    })
+
+    it('shows an empty state when the account has no entries', async () => {
+        mockFetch({ entries: () => ok(EMPTY_ENTRIES) })
+        renderDetail()
+        expect(await screen.findByText('No entries yet.')).toBeInTheDocument()
+    })
+
+    it('shows an entries error with Retry while keeping the header visible', async () => {
+        mockFetch({ entries: () => fail(500) })
+        renderDetail()
+        expect(await screen.findByText('Operating Cash')).toBeInTheDocument()
+        expect(await screen.findByText('Could not load entries.')).toBeInTheDocument()
+        const retry = screen.getByRole('button', { name: 'Retry' })
+        const fetchMock = globalThis.fetch as unknown as ReturnType<typeof vi.fn>
+        const before = fetchMock.mock.calls.length
+        fireEvent.click(retry)
+        await waitFor(() => expect(fetchMock.mock.calls.length).toBeGreaterThan(before))
     })
 })


### PR DESCRIPTION
Wires Screen 2 (Account Detail) to the live `GET /v1/accounts/{id}/entries` endpoint (#124).

## What
- New `useAccountEntries(id)` hook (`useInfiniteQuery`) over the entries endpoint, paginating on the opaque `nextCursor`.
- Entries table on `/accounts/:id` below the balance card: entry id, transaction id (`tx_` -> Link to `/transactions/:id`), direction, amount (`formatAmount`, lossless decimal string), currency, posted-at (`formatInstant`).
- "Load more" appends the next page; hidden once the cursor is exhausted.
- Loading / empty / error+retry states mirror the existing screens; an entries failure does not blank the account header or balance card.
- `AccountEntryResponse` / `EntryPageResponse` added to `web/src/api/types.ts`.

## Tests
4 new Vitest + RTL cases (rows + tx link + lossless amount, load-more append, empty, error+retry). Full web suite green: 36 tests, typecheck/lint/build clean.

Spec/plan: docs/plans/account-entries-web/.

Closes #125