### PR TITLE
feat(ledger): add correlation id filter with mdc propagation

### DIFF
--- a/services/ledger/src/main/kotlin/com/fincore/ledger/api/observability/CorrelationIdAttributes.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/api/observability/CorrelationIdAttributes.kt
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.api.observability
+
+object CorrelationIdAttributes {
+    const val HEADER = "X-Correlation-Id"
+    const val MDC_KEY = "correlation_id"
+}

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/api/observability/CorrelationIdFilter.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/api/observability/CorrelationIdFilter.kt
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.api.observability
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.MDC
+import org.springframework.web.filter.OncePerRequestFilter
+import java.util.UUID
+
+class CorrelationIdFilter : OncePerRequestFilter() {
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val correlationId = resolve(request.getHeader(CorrelationIdAttributes.HEADER))
+        MDC.put(CorrelationIdAttributes.MDC_KEY, correlationId)
+        response.setHeader(CorrelationIdAttributes.HEADER, correlationId)
+        try {
+            filterChain.doFilter(request, response)
+        } finally {
+            MDC.remove(CorrelationIdAttributes.MDC_KEY)
+        }
+    }
+
+    private fun resolve(inbound: String?): String =
+        inbound?.takeUnless { it.isBlank() }?.let(::canonicalUuidOrNull) ?: UUID.randomUUID().toString()
+
+    private fun canonicalUuidOrNull(value: String): String? = runCatching { UUID.fromString(value).toString() }.getOrNull()
+}

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/config/CorrelationIdFilterConfig.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/config/CorrelationIdFilterConfig.kt
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.config
+
+import com.fincore.ledger.api.observability.CorrelationIdFilter
+import org.springframework.boot.web.servlet.FilterRegistrationBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.Ordered
+
+@Configuration
+class CorrelationIdFilterConfig {
+    @Bean
+    fun correlationIdFilterRegistration(): FilterRegistrationBean<CorrelationIdFilter> =
+        FilterRegistrationBean(CorrelationIdFilter()).apply {
+            order = Ordered.HIGHEST_PRECEDENCE
+            addUrlPatterns("/*")
+        }
+}

--- a/services/ledger/src/main/resources/logback-spring.xml
+++ b/services/ledger/src/main/resources/logback-spring.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <property name="LOG_PATTERN"
+              value="%d{yyyy-MM-dd'T'HH:mm:ss.SSSXXX} %5p [%X{correlation_id:-}] [%t] %-40.40logger{39} : %m%n"/>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>

--- a/services/ledger/src/test/kotlin/com/fincore/ledger/api/observability/CorrelationIdFilterTest.kt
+++ b/services/ledger/src/test/kotlin/com/fincore/ledger/api/observability/CorrelationIdFilterTest.kt
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.api.observability
+
+import com.fincore.ledger.api.observability.CorrelationIdAttributes.HEADER
+import com.fincore.ledger.api.observability.CorrelationIdAttributes.MDC_KEY
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import jakarta.servlet.FilterChain
+import jakarta.servlet.ServletRequest
+import jakarta.servlet.ServletResponse
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.slf4j.MDC
+import org.springframework.mock.web.MockFilterChain
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import java.util.UUID
+
+class CorrelationIdFilterTest {
+    private val filter = CorrelationIdFilter()
+
+    @AfterEach
+    fun clearMdc() = MDC.clear()
+
+    @Test
+    fun `should echo a valid inbound correlation id on the response`() {
+        val inbound = "123e4567-e89b-12d3-a456-426614174000"
+        val response = MockHttpServletResponse()
+        filter.doFilter(requestWith(inbound), response, MockFilterChain())
+        response.getHeader(HEADER) shouldBe inbound
+    }
+
+    @Test
+    fun `should generate a valid uuid when no inbound id is present`() {
+        val response = MockHttpServletResponse()
+        filter.doFilter(MockHttpServletRequest(), response, MockFilterChain())
+        val header = response.getHeader(HEADER)
+        header.shouldNotBeNull()
+        shouldNotThrowAny { UUID.fromString(header) }
+    }
+
+    @Test
+    fun `should replace an invalid inbound id without rejecting the request`() {
+        val response = MockHttpServletResponse()
+        val chain = MockFilterChain()
+        filter.doFilter(requestWith("not-a-uuid"), response, chain)
+        val header = response.getHeader(HEADER)
+        header shouldNotBe "not-a-uuid"
+        shouldNotThrowAny { UUID.fromString(header) }
+        chain.request.shouldNotBeNull()
+        response.status shouldBe 200
+    }
+
+    @Test
+    fun `should expose the correlation id in the MDC during the chain`() {
+        val response = MockHttpServletResponse()
+        val captor = MdcCapturingChain()
+        filter.doFilter(MockHttpServletRequest(), response, captor)
+        captor.observed shouldBe response.getHeader(HEADER)
+    }
+
+    @Test
+    fun `should clear the MDC after the request completes`() {
+        filter.doFilter(MockHttpServletRequest(), MockHttpServletResponse(), MockFilterChain())
+        MDC.get(MDC_KEY).shouldBeNull()
+    }
+
+    @Test
+    fun `should clear the MDC even when the chain throws`() {
+        val boom = FilterChain { _, _ -> throw IllegalStateException("boom") }
+        shouldThrow<IllegalStateException> {
+            filter.doFilter(MockHttpServletRequest(), MockHttpServletResponse(), boom)
+        }
+        MDC.get(MDC_KEY).shouldBeNull()
+    }
+
+    private fun requestWith(correlationId: String): MockHttpServletRequest =
+        MockHttpServletRequest().apply { addHeader(HEADER, correlationId) }
+
+    private class MdcCapturingChain : FilterChain {
+        var observed: String? = null
+
+        override fun doFilter(
+            request: ServletRequest,
+            response: ServletResponse,
+        ) {
+            observed = MDC.get(MDC_KEY)
+        }
+    }
+}

--- a/services/ledger/src/test/kotlin/com/fincore/ledger/api/observability/CorrelationIdLogPatternTest.kt
+++ b/services/ledger/src/test/kotlin/com/fincore/ledger/api/observability/CorrelationIdLogPatternTest.kt
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.api.observability
+
+import io.kotest.matchers.string.shouldContain
+import org.junit.jupiter.api.Test
+
+class CorrelationIdLogPatternTest {
+    @Test
+    fun `console log pattern renders the correlation id with an empty default`() {
+        val logback = this::class.java.getResource("/logback-spring.xml")?.readText()
+        requireNotNull(logback) { "logback-spring.xml not found on the classpath" }
+        logback shouldContain "%X{${CorrelationIdAttributes.MDC_KEY}:-}"
+    }
+}

--- a/services/ledger/src/test/kotlin/com/fincore/ledger/config/CorrelationIdFilterConfigTest.kt
+++ b/services/ledger/src/test/kotlin/com/fincore/ledger/config/CorrelationIdFilterConfigTest.kt
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.config
+
+import com.fincore.ledger.api.observability.CorrelationIdFilter
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+import org.springframework.core.Ordered
+
+class CorrelationIdFilterConfigTest {
+    private val registration = CorrelationIdFilterConfig().correlationIdFilterRegistration()
+
+    @Test
+    fun `should register the filter at highest precedence`() {
+        registration.order shouldBe Ordered.HIGHEST_PRECEDENCE
+    }
+
+    @Test
+    fun `should apply the filter to every path`() {
+        registration.urlPatterns shouldContain "/*"
+    }
+
+    @Test
+    fun `should wrap the correlation id filter`() {
+        registration.filter.shouldBeInstanceOf<CorrelationIdFilter>()
+    }
+}


### PR DESCRIPTION
## What

Adds `CorrelationIdFilter` to the ledger service so every request carries a correlation id, propagated through logs and back to the client.

- Outermost servlet `OncePerRequestFilter` registered via `FilterRegistrationBean` at `Ordered.HIGHEST_PRECEDENCE` with url pattern `/*`. Runs before Spring Security and before `IdempotencyFilter`, so even pre-auth 401s and idempotency 400s carry the header.
- Reads inbound `X-Correlation-Id`; reuses it when it is a valid UUID (normalised to canonical lowercase), otherwise mints `UUID.randomUUID()`. An invalid inbound value is silently replaced, never rejected (observability must not break a request; UUID-only also blocks log/header injection).
- Sets the `correlation_id` MDC key for the request, echoes the id on the `X-Correlation-Id` response header, clears the MDC in a `finally` (no leak across pooled threads, even when the chain throws).
- Self-contained `logback-spring.xml` console pattern renders `%X{correlation_id:-}` on every log line (empty default for non-request lines, no literal `null`).

No DB, migration, JPA, or change to existing filters/controllers. Raw UUID is deliberate (a trace token, not an ADR-0010 entity id; matches the reserved `platform.audit_events.correlation_id VARCHAR(64)` column).

## Tests

10 unit tests, all green:
- `CorrelationIdFilterTest` (6): inbound echoed, absent generated, invalid replaced (not rejected), MDC populated mid-chain, MDC cleared after request, MDC cleared when the chain throws.
- `CorrelationIdFilterConfigTest` (3): registered at `HIGHEST_PRECEDENCE`, applies to `/*`, wraps the filter.
- `CorrelationIdLogPatternTest` (1): log pattern contains `%X{correlation_id:-}`.

Local gates green: spotlessCheck, detekt, test, assemble, compileIntegrationTestKotlin.

Closes #50