### PR TITLE
feat(ledger): add stable rfc7807 type-uri catalog with machine-readable codes

### DIFF
--- a/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/api/ErrorContractIT.kt
+++ b/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/api/ErrorContractIT.kt
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.api
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fincore.core.AccountId
+import com.fincore.core.TransactionId
+import com.fincore.ledger.api.idempotency.IdempotencyAttributes
+import com.fincore.test.containers.PostgresContainerExtension
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldStartWith
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.MediaType
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import java.time.Instant
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ExtendWith(PostgresContainerExtension::class)
+@Import(ErrorContractIT.TestSecurity::class)
+class ErrorContractIT(
+    @Autowired private val rest: TestRestTemplate,
+    @Autowired private val objectMapper: ObjectMapper,
+) {
+    @TestConfiguration
+    class TestSecurity {
+        @Bean
+        fun jwtDecoder(): JwtDecoder =
+            JwtDecoder { token ->
+                Jwt
+                    .withTokenValue(token)
+                    .header("alg", "none")
+                    .subject("err-contract-it")
+                    .issuedAt(Instant.now())
+                    .expiresAt(Instant.now().plusSeconds(EXPIRY_SECONDS))
+                    .build()
+            }
+    }
+
+    @Test
+    fun `should return the account-not-found contract for an unknown account`() {
+        val body = get("/v1/accounts/${AccountId.generate()}")
+        body.get("type").asText() shouldBe "https://fincore.dev/errors/account-not-found"
+        body.get("code").asText() shouldBe "ACCOUNT_NOT_FOUND"
+    }
+
+    @Test
+    fun `should return the transaction-not-found contract for an unknown transaction`() {
+        val body = get("/v1/transactions/${TransactionId.generate()}")
+        body.get("type").asText() shouldBe "https://fincore.dev/errors/transaction-not-found"
+        body.get("code").asText() shouldBe "TRANSACTION_NOT_FOUND"
+    }
+
+    @Test
+    fun `should return the idempotency-conflict contract on key reuse with a different body`() {
+        val key = "i".repeat(KEY_LENGTH)
+        post("/v1/accounts", account("First wallet"), key)
+        val conflict = post("/v1/accounts", account("Second wallet"), key)
+        conflict.statusCode.value() shouldBe 409
+        val body = objectMapper.readTree(conflict.body)
+        body.get("type").asText() shouldBe "https://fincore.dev/errors/idempotency-conflict"
+        body.get("code").asText() shouldBe "IDEMPOTENCY_KEY_CONFLICT"
+    }
+
+    @Test
+    fun `should return the double-entry contract for an unbalanced transaction`() {
+        val unbalanced =
+            """
+            {"reference":"err-it-422","currency":"EUR","entries":[
+              {"accountId":"${AccountId.generate()}","direction":"DEBIT","amount":"100"},
+              {"accountId":"${AccountId.generate()}","direction":"CREDIT","amount":"50"}]}
+            """.trimIndent()
+        val response = post("/v1/transactions", unbalanced, "d".repeat(KEY_LENGTH))
+        response.statusCode.value() shouldBe 422
+        val body = objectMapper.readTree(response.body)
+        body.get("type").asText() shouldBe "https://fincore.dev/errors/double-entry-violation"
+        body.get("code").asText() shouldBe "ENTRIES_SUM_NOT_ZERO"
+    }
+
+    @Test
+    fun `should return per-field codes for an invalid transaction body`() {
+        val invalid =
+            """
+            {"reference":"err-it-400","currency":"","entries":[
+              {"accountId":"${AccountId.generate()}","direction":"DEBIT","amount":"100"}]}
+            """.trimIndent()
+        val response = post("/v1/transactions", invalid, "v".repeat(KEY_LENGTH))
+        response.statusCode.value() shouldBe 400
+        val body = objectMapper.readTree(response.body)
+        body.get("type").asText() shouldBe "https://fincore.dev/errors/validation-failed"
+        body.get("code").asText() shouldBe "VALIDATION_FAILED"
+        val fields = body.get("errors").map { it.get("field").asText() }
+        (fields.contains("currency") || fields.contains("entries")) shouldBe true
+        body.get("errors").forEach { (it.get("code").asText().isNotBlank()) shouldBe true }
+    }
+
+    @Test
+    fun `should return the invalid-request contract when the idempotency key is missing`() {
+        val response = post("/v1/transactions", account("ignored"), idemKey = null)
+        response.statusCode.value() shouldBe 400
+        val body = objectMapper.readTree(response.body)
+        body.get("type").asText() shouldStartWith "https://fincore.dev/errors/"
+        body.get("code").asText() shouldBe "INVALID_REQUEST"
+    }
+
+    private fun account(name: String): String = """{"name":"$name","type":"USER_WALLET","currency":"EUR"}"""
+
+    private fun get(path: String): JsonNode {
+        val headers = HttpHeaders().apply { setBearerAuth("err-it-token") }
+        val response = rest.exchange(path, HttpMethod.GET, HttpEntity<Void>(headers), String::class.java)
+        return objectMapper.readTree(response.body)
+    }
+
+    private fun post(
+        path: String,
+        body: String,
+        idemKey: String?,
+    ) = rest.exchange(path, HttpMethod.POST, HttpEntity(body, postHeaders(idemKey)), String::class.java)
+
+    private fun postHeaders(idemKey: String?): HttpHeaders =
+        HttpHeaders().apply {
+            contentType = MediaType.APPLICATION_JSON
+            setBearerAuth("err-it-token")
+            idemKey?.let { set(IdempotencyAttributes.HEADER, it) }
+        }
+
+    companion object {
+        private const val EXPIRY_SECONDS = 300L
+        private const val KEY_LENGTH = 40
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun datasourceProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { PostgresContainerExtension.jdbcUrl }
+            registry.add("spring.datasource.username") { PostgresContainerExtension.username }
+            registry.add("spring.datasource.password") { PostgresContainerExtension.password }
+            registry.add("spring.jpa.hibernate.ddl-auto") { "none" }
+        }
+    }
+}

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/api/error/ProblemType.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/api/error/ProblemType.kt
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.api.error
+
+import org.springframework.http.HttpStatus
+import java.net.URI
+
+/**
+ * Catalog of every error condition the ledger API can surface as an RFC 7807 problem.
+ *
+ * Each constant is a published, stable contract: its [type] URI and [code] are part of the public API and
+ * are guarded by integration tests. The `GlobalExceptionHandler` and `IdempotencyFilter` resolve the
+ * status, type, title, and code from here instead of deriving strings at runtime, so the contract cannot
+ * drift when a human-readable title is edited.
+ *
+ * @property slug URL-safe identifier; the [type] URI is [BASE_URI] + slug.
+ * @property status HTTP status returned for this condition.
+ * @property code machine-readable, SCREAMING_SNAKE code consumers branch on without parsing messages.
+ * @property title short human-readable summary.
+ */
+enum class ProblemType(
+    val slug: String,
+    val status: HttpStatus,
+    val code: String,
+    val title: String,
+) {
+    ACCOUNT_NOT_FOUND("account-not-found", HttpStatus.NOT_FOUND, "ACCOUNT_NOT_FOUND", "account not found"),
+    TRANSACTION_NOT_FOUND("transaction-not-found", HttpStatus.NOT_FOUND, "TRANSACTION_NOT_FOUND", "transaction not found"),
+    DUPLICATE_TRANSACTION(
+        "duplicate-transaction",
+        HttpStatus.CONFLICT,
+        "DUPLICATE_TRANSACTION_REFERENCE",
+        "duplicate transaction reference",
+    ),
+    TRANSACTION_ALREADY_REVERSED(
+        "transaction-already-reversed",
+        HttpStatus.CONFLICT,
+        "TRANSACTION_ALREADY_REVERSED",
+        "transaction already reversed",
+    ),
+    IDEMPOTENCY_CONFLICT("idempotency-conflict", HttpStatus.CONFLICT, "IDEMPOTENCY_KEY_CONFLICT", "idempotency key conflict"),
+    CURRENCY_CONSISTENCY_VIOLATION(
+        "currency-consistency-violation",
+        HttpStatus.UNPROCESSABLE_ENTITY,
+        "CURRENCY_CONSISTENCY_VIOLATION",
+        "currency consistency violation",
+    ),
+    DOUBLE_ENTRY_VIOLATION("double-entry-violation", HttpStatus.UNPROCESSABLE_ENTITY, "ENTRIES_SUM_NOT_ZERO", "double-entry violation"),
+    DOMAIN_RULE_VIOLATION("domain-rule-violation", HttpStatus.UNPROCESSABLE_ENTITY, "DOMAIN_RULE_VIOLATION", "domain rule violation"),
+    CONCURRENCY_CONFLICT("concurrency-conflict", HttpStatus.SERVICE_UNAVAILABLE, "CONCURRENCY_CONFLICT", "concurrency conflict, retry"),
+    VALIDATION_FAILED("validation-failed", HttpStatus.BAD_REQUEST, "VALIDATION_FAILED", "invalid request"),
+    MALFORMED_REQUEST("malformed-request", HttpStatus.BAD_REQUEST, "MALFORMED_REQUEST", "invalid request"),
+    INVALID_REQUEST("invalid-request", HttpStatus.BAD_REQUEST, "INVALID_REQUEST", "invalid request"),
+    INTERNAL_ERROR("internal-error", HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", "internal error"),
+    ;
+
+    val type: URI get() = URI.create(BASE_URI + slug)
+
+    companion object {
+        const val BASE_URI = "https://fincore.dev/errors/"
+    }
+}

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/api/idempotency/IdempotencyFilter.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/api/idempotency/IdempotencyFilter.kt
@@ -5,11 +5,11 @@ package com.fincore.ledger.api.idempotency
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fincore.core.IdempotencyKey
+import com.fincore.ledger.api.error.ProblemType
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.http.HttpMethod
-import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.http.ProblemDetail
 import org.springframework.stereotype.Component
@@ -52,11 +52,13 @@ class IdempotencyFilter(
         response: HttpServletResponse,
         detail: String?,
     ) {
-        val problem = ProblemDetail.forStatusAndDetail(HttpStatus.BAD_REQUEST, detail ?: "invalid request")
-        problem.title = "invalid request"
-        problem.type = URI.create("urn:fincore:ledger:invalid-request")
+        val type = ProblemType.INVALID_REQUEST
+        val problem = ProblemDetail.forStatusAndDetail(type.status, detail ?: type.title)
+        problem.title = type.title
+        problem.type = type.type
         problem.instance = URI.create(request.requestURI)
-        response.status = HttpStatus.BAD_REQUEST.value()
+        problem.setProperty("code", type.code)
+        response.status = type.status.value()
         response.contentType = MediaType.APPLICATION_PROBLEM_JSON_VALUE
         objectMapper.writeValue(response.writer, problem)
     }

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/exception/GlobalExceptionHandler.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/exception/GlobalExceptionHandler.kt
@@ -3,6 +3,7 @@
 
 package com.fincore.ledger.exception
 
+import com.fincore.ledger.api.error.ProblemType
 import com.fincore.ledger.domain.exception.AccountNotFoundException
 import com.fincore.ledger.domain.exception.ConcurrencyConflictException
 import com.fincore.ledger.domain.exception.CurrencyConsistencyViolationException
@@ -14,10 +15,10 @@ import com.fincore.ledger.domain.exception.TransactionAlreadyReversedException
 import com.fincore.ledger.domain.exception.TransactionNotFoundException
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.http.HttpHeaders
-import org.springframework.http.HttpStatus
 import org.springframework.http.ProblemDetail
 import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.validation.FieldError
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
@@ -29,58 +30,58 @@ class GlobalExceptionHandler {
     fun handleAccountNotFound(
         ex: AccountNotFoundException,
         request: HttpServletRequest,
-    ): ProblemDetail = problem(HttpStatus.NOT_FOUND, "account not found", ex.message, request)
+    ): ProblemDetail = problem(ProblemType.ACCOUNT_NOT_FOUND, ex.message, request)
 
     @ExceptionHandler(TransactionNotFoundException::class)
     fun handleTransactionNotFound(
         ex: TransactionNotFoundException,
         request: HttpServletRequest,
-    ): ProblemDetail = problem(HttpStatus.NOT_FOUND, "transaction not found", ex.message, request)
+    ): ProblemDetail = problem(ProblemType.TRANSACTION_NOT_FOUND, ex.message, request)
 
     @ExceptionHandler(DuplicateTransactionException::class)
     fun handleDuplicateTransaction(
         ex: DuplicateTransactionException,
         request: HttpServletRequest,
-    ): ProblemDetail = problem(HttpStatus.CONFLICT, "duplicate transaction reference", ex.message, request)
+    ): ProblemDetail = problem(ProblemType.DUPLICATE_TRANSACTION, ex.message, request)
 
     @ExceptionHandler(TransactionAlreadyReversedException::class)
     fun handleTransactionAlreadyReversed(
         ex: TransactionAlreadyReversedException,
         request: HttpServletRequest,
-    ): ProblemDetail = problem(HttpStatus.CONFLICT, "transaction already reversed", ex.message, request)
+    ): ProblemDetail = problem(ProblemType.TRANSACTION_ALREADY_REVERSED, ex.message, request)
 
     @ExceptionHandler(IdempotencyConflictException::class)
     fun handleIdempotencyConflict(
         ex: IdempotencyConflictException,
         request: HttpServletRequest,
-    ): ProblemDetail = problem(HttpStatus.CONFLICT, "idempotency key conflict", ex.message, request)
+    ): ProblemDetail = problem(ProblemType.IDEMPOTENCY_CONFLICT, ex.message, request)
 
     @ExceptionHandler(CurrencyConsistencyViolationException::class)
     fun handleCurrencyConsistency(
         ex: CurrencyConsistencyViolationException,
         request: HttpServletRequest,
-    ): ProblemDetail = problem(HttpStatus.UNPROCESSABLE_ENTITY, "currency consistency violation", ex.message, request)
+    ): ProblemDetail = problem(ProblemType.CURRENCY_CONSISTENCY_VIOLATION, ex.message, request)
 
     @ExceptionHandler(DoubleEntryViolationException::class)
     fun handleDoubleEntry(
         ex: DoubleEntryViolationException,
         request: HttpServletRequest,
-    ): ProblemDetail = problem(HttpStatus.UNPROCESSABLE_ENTITY, "double-entry violation", ex.message, request)
+    ): ProblemDetail = problem(ProblemType.DOUBLE_ENTRY_VIOLATION, ex.message, request)
 
     @ExceptionHandler(DomainException::class)
     fun handleDomain(
         ex: DomainException,
         request: HttpServletRequest,
-    ): ProblemDetail = problem(HttpStatus.UNPROCESSABLE_ENTITY, "domain rule violation", ex.message, request)
+    ): ProblemDetail = problem(ProblemType.DOMAIN_RULE_VIOLATION, ex.message, request)
 
     @ExceptionHandler(ConcurrencyConflictException::class)
     fun handleConcurrencyConflict(
         ex: ConcurrencyConflictException,
         request: HttpServletRequest,
     ): ResponseEntity<ProblemDetail> {
-        val body = problem(HttpStatus.SERVICE_UNAVAILABLE, "concurrency conflict, retry", ex.message, request)
+        val body = problem(ProblemType.CONCURRENCY_CONFLICT, ex.message, request)
         return ResponseEntity
-            .status(HttpStatus.SERVICE_UNAVAILABLE)
+            .status(ProblemType.CONCURRENCY_CONFLICT.status)
             .header(HttpHeaders.RETRY_AFTER, RETRY_AFTER_SECONDS)
             .body(body)
     }
@@ -90,43 +91,51 @@ class GlobalExceptionHandler {
         ex: MethodArgumentNotValidException,
         request: HttpServletRequest,
     ): ProblemDetail {
-        val detail = problem(HttpStatus.BAD_REQUEST, "invalid request", "Request validation failed", request)
-        detail.setProperty(
-            "errors",
-            ex.bindingResult.fieldErrors.map { mapOf("field" to it.field, "message" to (it.defaultMessage ?: "invalid")) },
-        )
+        val detail = problem(ProblemType.VALIDATION_FAILED, "Request validation failed", request)
+        detail.setProperty("errors", ex.bindingResult.fieldErrors.map(::toFieldError))
         return detail
     }
 
     @ExceptionHandler(HttpMessageNotReadableException::class)
     fun handleUnreadable(request: HttpServletRequest): ProblemDetail =
-        problem(HttpStatus.BAD_REQUEST, "invalid request", "Request body is missing or malformed", request)
+        problem(ProblemType.MALFORMED_REQUEST, "Request body is missing or malformed", request)
 
     @ExceptionHandler(IllegalArgumentException::class)
     fun handleIllegalArgument(
         ex: IllegalArgumentException,
         request: HttpServletRequest,
-    ): ProblemDetail = problem(HttpStatus.BAD_REQUEST, "invalid request", ex.message, request)
+    ): ProblemDetail = problem(ProblemType.INVALID_REQUEST, ex.message, request)
 
     @ExceptionHandler(Exception::class)
     fun handleUnexpected(request: HttpServletRequest): ProblemDetail =
-        problem(HttpStatus.INTERNAL_SERVER_ERROR, "internal error", "An unexpected error occurred", request)
+        problem(ProblemType.INTERNAL_ERROR, "An unexpected error occurred", request)
+
+    private fun toFieldError(error: FieldError): Map<String, String> =
+        mapOf(
+            "field" to error.field,
+            "code" to constraintCode(error),
+            "message" to (error.defaultMessage ?: "invalid"),
+        )
+
+    private fun constraintCode(error: FieldError): String {
+        val constraint = error.codes?.lastOrNull()?.substringAfterLast('.') ?: return "INVALID"
+        return constraint.replace(CAMEL_BOUNDARY, "_").uppercase()
+    }
 
     private fun problem(
-        status: HttpStatus,
-        title: String,
+        type: ProblemType,
         detail: String?,
         request: HttpServletRequest,
     ): ProblemDetail =
-        ProblemDetail.forStatusAndDetail(status, detail ?: title).apply {
-            this.title = title
-            this.type = URI.create(TYPE_PREFIX + title.replace(NON_SLUG, "-"))
+        ProblemDetail.forStatusAndDetail(type.status, detail ?: type.title).apply {
+            this.title = type.title
+            this.type = type.type
             this.instance = URI.create(request.requestURI)
+            setProperty("code", type.code)
         }
 
     private companion object {
-        const val TYPE_PREFIX = "urn:fincore:ledger:"
         const val RETRY_AFTER_SECONDS = "1"
-        val NON_SLUG = Regex("[^a-z0-9]+")
+        val CAMEL_BOUNDARY = Regex("(?<=.)(?=\\p{Lu})")
     }
 }

--- a/services/ledger/src/test/kotlin/com/fincore/ledger/api/error/ProblemTypeTest.kt
+++ b/services/ledger/src/test/kotlin/com/fincore/ledger/api/error/ProblemTypeTest.kt
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.api.error
+
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldMatch
+import org.junit.jupiter.api.Test
+import java.nio.file.Files
+import java.nio.file.Path
+
+class ProblemTypeTest {
+    @Test
+    fun `every type uri derives from the base uri and slug`() {
+        ProblemType.entries.forEach { it.type.toString() shouldBe ProblemType.BASE_URI + it.slug }
+    }
+
+    @Test
+    fun `every code is non-blank screaming snake`() {
+        ProblemType.entries.forEach { it.code shouldMatch SCREAMING_SNAKE }
+    }
+
+    @Test
+    fun `slugs and codes are unique across the catalog`() {
+        ProblemType.entries.map { it.slug }.let { it.size shouldBe it.toSet().size }
+        ProblemType.entries.map { it.code }.let { it.size shouldBe it.toSet().size }
+    }
+
+    @Test
+    fun `no urn scheme remains in the main source set`() {
+        val offenders =
+            Files.walk(Path.of("src/main/kotlin")).use { stream ->
+                stream
+                    .filter { it.toString().endsWith(".kt") }
+                    .filter { Files.readString(it).contains("urn:fincore") }
+                    .map { it.toString() }
+                    .toList()
+            }
+        offenders shouldBe emptyList()
+    }
+
+    private companion object {
+        val SCREAMING_SNAKE = Regex("^[A-Z][A-Z0-9_]*$")
+    }
+}

--- a/services/ledger/src/test/kotlin/com/fincore/ledger/exception/GlobalExceptionHandlerTest.kt
+++ b/services/ledger/src/test/kotlin/com/fincore/ledger/exception/GlobalExceptionHandlerTest.kt
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.exception
+
+import com.fincore.core.AccountId
+import com.fincore.ledger.domain.exception.AccountNotFoundException
+import com.fincore.ledger.domain.exception.ConcurrencyConflictException
+import com.fincore.ledger.domain.exception.DoubleEntryViolationException
+import com.fincore.ledger.domain.exception.IdempotencyConflictException
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.validation.BeanPropertyBindingResult
+import org.springframework.validation.FieldError
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.method.HandlerMethod
+
+class GlobalExceptionHandlerTest {
+    private val handler = GlobalExceptionHandler()
+    private val request = MockHttpServletRequest("GET", "/v1/test")
+
+    @Test
+    fun `should map account not found to the catalog type and code`() {
+        val problem = handler.handleAccountNotFound(AccountNotFoundException(AccountId.generate()), request)
+        problem.status shouldBe 404
+        problem.type.toString() shouldBe "https://fincore.dev/errors/account-not-found"
+        problem.properties?.get("code") shouldBe "ACCOUNT_NOT_FOUND"
+    }
+
+    @Test
+    fun `should map double-entry violation to the entries-sum-not-zero code`() {
+        val problem = handler.handleDoubleEntry(DoubleEntryViolationException("net=5"), request)
+        problem.status shouldBe 422
+        problem.type.toString() shouldBe "https://fincore.dev/errors/double-entry-violation"
+        problem.properties?.get("code") shouldBe "ENTRIES_SUM_NOT_ZERO"
+    }
+
+    @Test
+    fun `should map idempotency conflict to a 409 catalog code`() {
+        val problem = handler.handleIdempotencyConflict(IdempotencyConflictException(), request)
+        problem.status shouldBe 409
+        problem.properties?.get("code") shouldBe "IDEMPOTENCY_KEY_CONFLICT"
+    }
+
+    @Test
+    fun `should set retry-after and the catalog code on a concurrency conflict`() {
+        val response = handler.handleConcurrencyConflict(ConcurrencyConflictException(RuntimeException("retry")), request)
+        response.statusCode.value() shouldBe 503
+        response.headers.getFirst("Retry-After") shouldBe "1"
+        response.body?.properties?.get("code") shouldBe "CONCURRENCY_CONFLICT"
+    }
+
+    @Test
+    fun `should derive per-field codes from the failing constraint`() {
+        val problem = handler.handleValidation(validationException(fieldError("currency", "NotBlank")), request)
+        problem.status shouldBe 400
+        problem.properties?.get("code") shouldBe "VALIDATION_FAILED"
+        val errors = errorsOf(problem)
+        errors.first()["field"] shouldBe "currency"
+        errors.first()["code"] shouldBe "NOT_BLANK"
+    }
+
+    @Test
+    fun `should derive a compound constraint code with underscores`() {
+        val problem = handler.handleValidation(validationException(fieldError("type", "NotNull")), request)
+        errorsOf(problem).first()["code"] shouldBe "NOT_NULL"
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun errorsOf(problem: org.springframework.http.ProblemDetail): List<Map<String, String>> =
+        problem.properties?.get("errors") as List<Map<String, String>>
+
+    private fun fieldError(
+        field: String,
+        constraint: String,
+    ): FieldError =
+        FieldError(
+            "request",
+            field,
+            null,
+            false,
+            arrayOf("$constraint.request.$field", constraint),
+            null,
+            "must be valid",
+        )
+
+    private fun validationException(vararg errors: FieldError): MethodArgumentNotValidException {
+        val binding = BeanPropertyBindingResult(Any(), "request")
+        errors.forEach(binding::addError)
+        val method = HandlerMethod(this, this::class.java.getDeclaredMethod("dummy", String::class.java))
+        return MethodArgumentNotValidException(method.methodParameters[0], binding)
+    }
+
+    @Suppress("unused", "UnusedPrivateMember")
+    private fun dummy(value: String): String = value
+}


### PR DESCRIPTION
## What

Replaces the ledger API's fragile, runtime-derived error `type` URIs with a single authoritative catalog and adds machine-readable error codes so consumers can branch on errors without parsing English strings.

- **`ProblemType` enum** (`api/error`): 13 entries, one per error condition. Each owns a stable `https://fincore.dev/errors/<slug>` type URI (from a single `BASE_URI`), its HTTP status, a SCREAMING_SNAKE `code`, and a title. KDoc documents it as a published contract.
- **`GlobalExceptionHandler`**: every handler resolves `status`/`type`/`title`/`code` from the catalog; removes the title-slugification. Each error `ProblemDetail` gains a top-level `code`. Validation `errors[]` entries gain a per-field `code` derived from the failing Jakarta constraint (`NotBlank` -> `NOT_BLANK`). 503 keeps `Retry-After`.
- **`IdempotencyFilter`**: its `ProblemDetail` now uses `ProblemType.INVALID_REQUEST`; the `urn:fincore:ledger:*` literal is gone, so the whole API speaks one error vocabulary.

No status-code changes, no DTO changes, no business logic, no migration. Only the error-body shape changes (new `code`; `type` scheme `urn:` -> `https:`). Per-endpoint OpenAPI annotations (#41) and the generated-spec assertion (#42) follow as the next slices.

## Tests

- `ProblemTypeTest` (4): every `type` == BASE_URI+slug; codes are SCREAMING_SNAKE; slugs/codes unique; a source-walk asserts no `urn:fincore` remains in main.
- `GlobalExceptionHandlerTest` (6): per-handler `type`/`code`, 503 Retry-After, per-field validation codes (incl. compound `NOT_NULL`).
- `ErrorContractIT` (6): real 404 (account + transaction), 409 (idempotency-key reuse), 422 (`ENTRIES_SUM_NOT_ZERO`), 400 validation with per-field codes, 400 filter (missing key) - asserts `type` URI + `code` on each.

Local gates green: spotlessCheck, detekt, test, assemble, compileIntegrationTestKotlin. IT runs on CI.

Closes #46