### PR TITLE
docs(ledger): annotate account and transaction endpoints with springdoc openapi

### DIFF
--- a/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/api/OpenApiDocsIT.kt
+++ b/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/api/OpenApiDocsIT.kt
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.api
+
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fincore.test.containers.PostgresContainerExtension
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldNotBeBlank
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ExtendWith(PostgresContainerExtension::class)
+class OpenApiDocsIT(
+    @Autowired private val rest: TestRestTemplate,
+    @Autowired private val objectMapper: ObjectMapper,
+) {
+    private fun apiDocs(): JsonNode = objectMapper.readTree(rest.getForEntity("/v3/api-docs", String::class.java).body)
+
+    @Test
+    fun `should document the create-account operation with a summary tag and responses`() {
+        val post = apiDocs().at("/paths/~1v1~1accounts/post")
+        post.get("summary").asText().shouldNotBeBlank()
+        post.get("tags").map { it.asText() }.contains("Accounts") shouldBe true
+        val responses = post.get("responses")
+        listOf("201", "400", "409").forEach { responses.has(it) shouldBe true }
+    }
+
+    @Test
+    fun `should document the reverse-transaction operation with conflict and not-found responses`() {
+        val post = apiDocs().at("/paths/~1v1~1transactions~1{id}~1reverse/post")
+        post.get("summary").asText().shouldNotBeBlank()
+        val responses = post.get("responses")
+        listOf("201", "404", "409").forEach { responses.has(it) shouldBe true }
+    }
+
+    @Test
+    fun `should document the get-account operation with a not-found response`() {
+        val get = apiDocs().at("/paths/~1v1~1accounts~1{id}/get")
+        get.get("summary").asText().shouldNotBeBlank()
+        get.get("responses").has("404") shouldBe true
+    }
+
+    companion object {
+        @JvmStatic
+        @DynamicPropertySource
+        fun datasourceProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { PostgresContainerExtension.jdbcUrl }
+            registry.add("spring.datasource.username") { PostgresContainerExtension.username }
+            registry.add("spring.datasource.password") { PostgresContainerExtension.password }
+            registry.add("spring.jpa.hibernate.ddl-auto") { "none" }
+        }
+    }
+}

--- a/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/api/OpenApiDocsIT.kt
+++ b/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/api/OpenApiDocsIT.kt
@@ -12,16 +12,38 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
+import java.time.Instant
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ExtendWith(PostgresContainerExtension::class)
+@Import(OpenApiDocsIT.TestSecurity::class)
 class OpenApiDocsIT(
     @Autowired private val rest: TestRestTemplate,
     @Autowired private val objectMapper: ObjectMapper,
 ) {
+    @TestConfiguration
+    class TestSecurity {
+        @Bean
+        fun jwtDecoder(): JwtDecoder =
+            JwtDecoder { token ->
+                Jwt
+                    .withTokenValue(token)
+                    .header("alg", "none")
+                    .subject("openapi-docs-it")
+                    .issuedAt(Instant.now())
+                    .expiresAt(Instant.now().plusSeconds(EXPIRY_SECONDS))
+                    .build()
+            }
+    }
+
     private fun apiDocs(): JsonNode = objectMapper.readTree(rest.getForEntity("/v3/api-docs", String::class.java).body)
 
     @Test
@@ -49,6 +71,8 @@ class OpenApiDocsIT(
     }
 
     companion object {
+        private const val EXPIRY_SECONDS = 300L
+
         @JvmStatic
         @DynamicPropertySource
         fun datasourceProperties(registry: DynamicPropertyRegistry) {

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/api/AccountController.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/api/AccountController.kt
@@ -19,9 +19,18 @@ import com.fincore.ledger.application.EntryQueryService
 import com.fincore.ledger.application.IdempotencyService
 import com.fincore.ledger.application.IdempotentResult
 import com.fincore.ledger.application.StoredResponse
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.enums.ParameterIn
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
+import org.springframework.http.ProblemDetail
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.jwt.Jwt
@@ -36,6 +45,7 @@ import org.springframework.web.bind.annotation.RestController
 import java.net.URI
 import java.time.Instant
 
+@Tag(name = "Accounts", description = "Ledger account lifecycle, balances, and entries")
 @RestController
 @RequestMapping("/v1/accounts")
 class AccountController(
@@ -46,12 +56,42 @@ class AccountController(
     private val mapper: LedgerApiMapper,
     private val objectMapper: ObjectMapper,
 ) {
+    @Operation(
+        summary = "Create a ledger account",
+        description = "Creates an account. Requires an Idempotency-Key; same key plus same body replays the original result.",
+        parameters = [
+            Parameter(
+                `in` = ParameterIn.HEADER,
+                name = "Idempotency-Key",
+                required = true,
+                description = "Idempotency key, 32-128 chars matching ^[A-Za-z0-9_-]+$",
+            ),
+        ],
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "201", description = "Account created"),
+        ApiResponse(
+            responseCode = "400",
+            description = "Invalid body or missing Idempotency-Key",
+            content = [Content(mediaType = PROBLEM_JSON, schema = Schema(implementation = ProblemDetail::class))],
+        ),
+        ApiResponse(
+            responseCode = "401",
+            description = "Missing or invalid bearer token",
+            content = [Content(mediaType = PROBLEM_JSON, schema = Schema(implementation = ProblemDetail::class))],
+        ),
+        ApiResponse(
+            responseCode = "409",
+            description = "Idempotency-Key reused with a different body",
+            content = [Content(mediaType = PROBLEM_JSON, schema = Schema(implementation = ProblemDetail::class))],
+        ),
+    )
     @PostMapping
     fun create(
         @Valid @RequestBody request: CreateAccountRequest,
-        @AuthenticationPrincipal jwt: Jwt,
-        @RequestAttribute(IdempotencyAttributes.KEY) key: String,
-        @RequestAttribute(IdempotencyAttributes.BODY) rawBody: String,
+        @Parameter(hidden = true) @AuthenticationPrincipal jwt: Jwt,
+        @Parameter(hidden = true) @RequestAttribute(IdempotencyAttributes.KEY) key: String,
+        @Parameter(hidden = true) @RequestAttribute(IdempotencyAttributes.BODY) rawBody: String,
     ): ResponseEntity<String> {
         var location: URI? = null
         val result =
@@ -63,37 +103,91 @@ class AccountController(
         return respond(result, location)
     }
 
+    @Operation(summary = "List accounts", description = "Returns a page of accounts, newest first.")
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "Page of accounts"),
+        ApiResponse(
+            responseCode = "400",
+            description = "Invalid page or size",
+            content = [Content(mediaType = PROBLEM_JSON, schema = Schema(implementation = ProblemDetail::class))],
+        ),
+        ApiResponse(
+            responseCode = "401",
+            description = "Missing or invalid bearer token",
+            content = [Content(mediaType = PROBLEM_JSON, schema = Schema(implementation = ProblemDetail::class))],
+        ),
+    )
     @GetMapping
     fun list(
-        @RequestParam(defaultValue = "0") page: Int,
-        @RequestParam(defaultValue = "20") size: Int,
+        @Parameter(description = "Zero-based page index") @RequestParam(defaultValue = "0") page: Int,
+        @Parameter(description = "Page size, 1..100") @RequestParam(defaultValue = "20") size: Int,
     ): PageResponse<AccountResponse> {
         require(page >= 0) { "page must be >= 0" }
         require(size in 1..MAX_PAGE_SIZE) { "size must be 1..$MAX_PAGE_SIZE" }
         return mapper.toPageResponse(accountService.list(page, size))
     }
 
+    @Operation(summary = "Get an account", description = "Returns a single account by id.")
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "The account"),
+        ApiResponse(
+            responseCode = "400",
+            description = "Malformed account id",
+            content = [Content(mediaType = PROBLEM_JSON, schema = Schema(implementation = ProblemDetail::class))],
+        ),
+        ApiResponse(
+            responseCode = "404",
+            description = "Account not found",
+            content = [Content(mediaType = PROBLEM_JSON, schema = Schema(implementation = ProblemDetail::class))],
+        ),
+    )
     @GetMapping("/{id}")
     fun get(
-        @PathVariable id: String,
+        @Parameter(description = "Account id (acc_ prefixed ULID)") @PathVariable id: String,
     ): AccountResponse = mapper.toResponse(accountService.get(AccountId.fromString(id)))
 
+    @Operation(summary = "Get an account balance", description = "Returns the current balance for an account in its currency.")
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "The current balance"),
+        ApiResponse(
+            responseCode = "404",
+            description = "Account not found",
+            content = [Content(mediaType = PROBLEM_JSON, schema = Schema(implementation = ProblemDetail::class))],
+        ),
+    )
     @GetMapping("/{id}/balance")
     fun balance(
-        @PathVariable id: String,
+        @Parameter(description = "Account id (acc_ prefixed ULID)") @PathVariable id: String,
     ): BalanceResponse {
         val accountId = AccountId.fromString(id)
         val account = accountService.get(accountId)
         return mapper.toResponse(balanceService.current(accountId, account.currency))
     }
 
+    @Operation(
+        summary = "List account entries",
+        description = "Returns a page of ledger entries for an account, newest first, over an optional time window with cursor pagination.",
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "Page of entries"),
+        ApiResponse(
+            responseCode = "400",
+            description = "Malformed id, timestamps, window, limit, or cursor",
+            content = [Content(mediaType = PROBLEM_JSON, schema = Schema(implementation = ProblemDetail::class))],
+        ),
+        ApiResponse(
+            responseCode = "404",
+            description = "Account not found",
+            content = [Content(mediaType = PROBLEM_JSON, schema = Schema(implementation = ProblemDetail::class))],
+        ),
+    )
     @GetMapping("/{id}/entries")
     fun entries(
-        @PathVariable id: String,
-        @RequestParam(required = false) from: String?,
-        @RequestParam(required = false) to: String?,
-        @RequestParam(required = false) cursor: String?,
-        @RequestParam(defaultValue = "50") limit: Int,
+        @Parameter(description = "Account id (acc_ prefixed ULID)") @PathVariable id: String,
+        @Parameter(description = "Inclusive window start, ISO-8601 instant") @RequestParam(required = false) from: String?,
+        @Parameter(description = "Exclusive window end, ISO-8601 instant") @RequestParam(required = false) to: String?,
+        @Parameter(description = "Opaque pagination cursor") @RequestParam(required = false) cursor: String?,
+        @Parameter(description = "Page size, 1..200") @RequestParam(defaultValue = "50") limit: Int,
     ): EntryPageResponse {
         val page =
             entryQueryService.listAccountEntries(
@@ -122,5 +216,6 @@ class AccountController(
 
     private companion object {
         const val MAX_PAGE_SIZE = 100
+        const val PROBLEM_JSON = "application/problem+json"
     }
 }

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/api/TransactionController.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/api/TransactionController.kt
@@ -16,9 +16,18 @@ import com.fincore.ledger.application.IdempotencyService
 import com.fincore.ledger.application.IdempotentResult
 import com.fincore.ledger.application.StoredResponse
 import com.fincore.ledger.application.TransactionService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.enums.ParameterIn
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
+import org.springframework.http.ProblemDetail
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.security.oauth2.jwt.Jwt
@@ -33,6 +42,7 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.net.URI
 
+@Tag(name = "Transactions", description = "Double-entry transaction posting, lookup, and reversal")
 @RestController
 @RequestMapping("/v1/transactions")
 class TransactionController(
@@ -41,13 +51,48 @@ class TransactionController(
     private val mapper: LedgerApiMapper,
     private val objectMapper: ObjectMapper,
 ) {
+    @Operation(
+        summary = "Post a transaction",
+        description = "Posts a balanced double-entry transaction. Requires an Idempotency-Key; entries net to zero in one currency.",
+        parameters = [
+            Parameter(
+                `in` = ParameterIn.HEADER,
+                name = "Idempotency-Key",
+                required = true,
+                description = "Idempotency key, 32-128 chars matching ^[A-Za-z0-9_-]+$",
+            ),
+        ],
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "201", description = "Transaction posted"),
+        ApiResponse(
+            responseCode = "400",
+            description = "Invalid body or missing Idempotency-Key",
+            content = [Content(mediaType = PROBLEM_JSON, schema = Schema(implementation = ProblemDetail::class))],
+        ),
+        ApiResponse(
+            responseCode = "404",
+            description = "Referenced account not found",
+            content = [Content(mediaType = PROBLEM_JSON, schema = Schema(implementation = ProblemDetail::class))],
+        ),
+        ApiResponse(
+            responseCode = "409",
+            description = "Duplicate reference or idempotency conflict",
+            content = [Content(mediaType = PROBLEM_JSON, schema = Schema(implementation = ProblemDetail::class))],
+        ),
+        ApiResponse(
+            responseCode = "422",
+            description = "Double-entry or currency consistency violation",
+            content = [Content(mediaType = PROBLEM_JSON, schema = Schema(implementation = ProblemDetail::class))],
+        ),
+    )
     @PostMapping
     fun post(
         @Valid @RequestBody request: PostTransactionRequest,
-        @AuthenticationPrincipal jwt: Jwt,
+        @Parameter(hidden = true) @AuthenticationPrincipal jwt: Jwt,
         @RequestHeader(value = CORRELATION_HEADER, required = false) correlationId: String?,
-        @RequestAttribute(IdempotencyAttributes.KEY) key: String,
-        @RequestAttribute(IdempotencyAttributes.BODY) rawBody: String,
+        @Parameter(hidden = true) @RequestAttribute(IdempotencyAttributes.KEY) key: String,
+        @Parameter(hidden = true) @RequestAttribute(IdempotencyAttributes.BODY) rawBody: String,
     ): ResponseEntity<String> {
         var location: URI? = null
         val result =
@@ -59,28 +104,81 @@ class TransactionController(
         return respond(result, location)
     }
 
+    @Operation(summary = "List transactions", description = "Returns a page of transactions, newest first.")
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "Page of transactions"),
+        ApiResponse(
+            responseCode = "400",
+            description = "Invalid page or size",
+            content = [Content(mediaType = PROBLEM_JSON, schema = Schema(implementation = ProblemDetail::class))],
+        ),
+    )
     @GetMapping
     fun list(
-        @RequestParam(defaultValue = "0") page: Int,
-        @RequestParam(defaultValue = "20") size: Int,
+        @Parameter(description = "Zero-based page index") @RequestParam(defaultValue = "0") page: Int,
+        @Parameter(description = "Page size, 1..100") @RequestParam(defaultValue = "20") size: Int,
     ): PageResponse<TransactionResponse> {
         require(page >= 0) { "page must be >= 0" }
         require(size in 1..MAX_PAGE_SIZE) { "size must be 1..$MAX_PAGE_SIZE" }
         return mapper.toPageResponse(transactionService.list(page, size))
     }
 
+    @Operation(summary = "Get a transaction", description = "Returns a transaction with its entries by id.")
+    @ApiResponses(
+        ApiResponse(responseCode = "200", description = "The transaction with entries"),
+        ApiResponse(
+            responseCode = "400",
+            description = "Malformed transaction id",
+            content = [Content(mediaType = PROBLEM_JSON, schema = Schema(implementation = ProblemDetail::class))],
+        ),
+        ApiResponse(
+            responseCode = "404",
+            description = "Transaction not found",
+            content = [Content(mediaType = PROBLEM_JSON, schema = Schema(implementation = ProblemDetail::class))],
+        ),
+    )
     @GetMapping("/{id}")
     fun get(
-        @PathVariable id: String,
+        @Parameter(description = "Transaction id (tx_ prefixed ULID)") @PathVariable id: String,
     ): TransactionDetailResponse = mapper.toDetailResponse(transactionService.get(TransactionId.fromString(id)))
 
+    @Operation(
+        summary = "Reverse a transaction",
+        description = "Posts a compensating transaction that reverses an existing POSTED transaction. Requires an Idempotency-Key header.",
+        parameters = [
+            Parameter(
+                `in` = ParameterIn.HEADER,
+                name = "Idempotency-Key",
+                required = true,
+                description = "Idempotency key, 32-128 chars matching ^[A-Za-z0-9_-]+$",
+            ),
+        ],
+    )
+    @ApiResponses(
+        ApiResponse(responseCode = "201", description = "Compensating transaction posted"),
+        ApiResponse(
+            responseCode = "400",
+            description = "Malformed id or missing Idempotency-Key",
+            content = [Content(mediaType = PROBLEM_JSON, schema = Schema(implementation = ProblemDetail::class))],
+        ),
+        ApiResponse(
+            responseCode = "404",
+            description = "Transaction not found",
+            content = [Content(mediaType = PROBLEM_JSON, schema = Schema(implementation = ProblemDetail::class))],
+        ),
+        ApiResponse(
+            responseCode = "409",
+            description = "Transaction already reversed",
+            content = [Content(mediaType = PROBLEM_JSON, schema = Schema(implementation = ProblemDetail::class))],
+        ),
+    )
     @PostMapping("/{id}/reverse")
     fun reverse(
-        @PathVariable id: String,
-        @AuthenticationPrincipal jwt: Jwt,
+        @Parameter(description = "Transaction id (tx_ prefixed ULID)") @PathVariable id: String,
+        @Parameter(hidden = true) @AuthenticationPrincipal jwt: Jwt,
         @RequestHeader(value = CORRELATION_HEADER, required = false) correlationId: String?,
-        @RequestAttribute(IdempotencyAttributes.KEY) key: String,
-        @RequestAttribute(IdempotencyAttributes.BODY) rawBody: String,
+        @Parameter(hidden = true) @RequestAttribute(IdempotencyAttributes.KEY) key: String,
+        @Parameter(hidden = true) @RequestAttribute(IdempotencyAttributes.BODY) rawBody: String,
     ): ResponseEntity<String> {
         val transactionId = TransactionId.fromString(id)
         var location: URI? = null
@@ -107,5 +205,6 @@ class TransactionController(
     private companion object {
         const val CORRELATION_HEADER = "X-Correlation-Id"
         const val MAX_PAGE_SIZE = 100
+        const val PROBLEM_JSON = "application/problem+json"
     }
 }


### PR DESCRIPTION
## What

Annotates all 9 ledger endpoints so the generated `/v3/api-docs` is rich and accurate (sets up #42).

- `@Tag` on both controllers (`Accounts`, `Transactions`).
- `@Operation` summary + description on every endpoint.
- `@ApiResponse`s documenting the success code and each error status the endpoint can actually return (400/401/404/409/422 as applicable), with error bodies typed as RFC 7807 `ProblemDetail` (`application/problem+json`).
- `Idempotency-Key` header documented on the 3 write endpoints; internal binding params (`jwt`, idempotency `@RequestAttribute`s) hidden from the spec.

Doc-only: no route, signature, status code, request/response body, or behaviour change. `api/openapi.yaml` is untouched (reconciliation is #42).

## Tests

`OpenApiDocsIT` fetches `/v3/api-docs` and asserts the create-account, reverse-transaction, and get-account operations carry summaries, tags, and the documented response codes. Existing `LedgerApiSmokeIT` still green.

Local gates green: spotlessCheck, detekt, test, assemble, compileIntegrationTestKotlin. ITs run on CI.

Closes #41