### PR TITLE
test(ledger): assert generated openapi paths match the committed contract

### DIFF
--- a/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/api/OpenApiContractIT.kt
+++ b/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/api/OpenApiContractIT.kt
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.api
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fincore.test.containers.PostgresContainerExtension
+import io.kotest.assertions.withClue
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.yaml.snakeyaml.Yaml
+import java.nio.file.Files
+import java.nio.file.Path
+import java.time.Instant
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ExtendWith(PostgresContainerExtension::class)
+@Import(OpenApiContractIT.TestSecurity::class)
+class OpenApiContractIT(
+    @Autowired private val rest: TestRestTemplate,
+    @Autowired private val objectMapper: ObjectMapper,
+) {
+    @TestConfiguration
+    class TestSecurity {
+        @Bean
+        fun jwtDecoder(): JwtDecoder =
+            JwtDecoder { token ->
+                Jwt
+                    .withTokenValue(token)
+                    .header("alg", "none")
+                    .subject("openapi-contract-it")
+                    .issuedAt(Instant.now())
+                    .expiresAt(Instant.now().plusSeconds(EXPIRY_SECONDS))
+                    .build()
+            }
+    }
+
+    @Test
+    fun `should keep the generated ledger paths in sync with the committed contract`() {
+        val committed = ledgerPathsFromSpec()
+        val generated = generatedLedgerPaths()
+
+        val clue =
+            "OpenAPI drift. In api/openapi.yaml but not generated: ${committed - generated}. " +
+                "Generated but not in api/openapi.yaml: ${generated - committed}."
+        withClue(clue) {
+            generated shouldBe committed
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun ledgerPathsFromSpec(): Set<String> {
+        val root = Files.newBufferedReader(Path.of(SPEC_PATH)).use { Yaml().load<Map<String, Any>>(it) }
+        val paths = root["paths"] as Map<String, Any>
+        return paths.keys.filter(::isLedgerPath).toSet()
+    }
+
+    private fun generatedLedgerPaths(): Set<String> {
+        val doc = objectMapper.readTree(rest.getForEntity("/v3/api-docs", String::class.java).body)
+        return doc
+            .get("paths")
+            .fieldNames()
+            .asSequence()
+            .filter(::isLedgerPath)
+            .toSet()
+    }
+
+    private fun isLedgerPath(path: String): Boolean = path.startsWith("/v1/accounts") || path.startsWith("/v1/transactions")
+
+    companion object {
+        private const val EXPIRY_SECONDS = 300L
+        private const val SPEC_PATH = "../../api/openapi.yaml"
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun datasourceProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { PostgresContainerExtension.jdbcUrl }
+            registry.add("spring.datasource.username") { PostgresContainerExtension.username }
+            registry.add("spring.datasource.password") { PostgresContainerExtension.password }
+            registry.add("spring.jpa.hibernate.ddl-auto") { "none" }
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds `OpenApiContractIT`, a drift guard between the hand-authored `api/openapi.yaml` and the running service's generated `/v3/api-docs`.

- Loads `api/openapi.yaml`, extracts the ledger-owned path templates (`/v1/accounts*`, `/v1/transactions*`).
- Fetches `/v3/api-docs`, extracts the generated `/v1/**` path templates.
- Asserts the two sets are equal; a path in the yaml but not generated (or vice versa) fails with the symmetric difference in the message.

**Scope (owner decision):** `api/openapi.yaml` is the umbrella spec for the whole engine (it declares payments/KYC/compliance/decision/webhooks paths the ledger does not implement), so the test scopes the contract to the ledger's own paths and does a two-way path diff. Strict component-schema-name equality is deferred (generated schema names are DTO class names, e.g. `AccountResponse`, not curated names like `Account`); reconciling would need `@Schema(name=...)` on every DTO - a separate effort.

Test-only: no controller, DTO, or `api/openapi.yaml` change.

## Tests

`OpenApiContractIT` (1) over the 7 account/transaction path templates. Mirrors the existing IT setup incl. the test `JwtDecoder` bean (the oauth2 resource-server context needs it to start). Runs in the CI integration-test suite.

Local gates green: spotlessCheck, detekt, test, compileIntegrationTestKotlin.

Closes #42