### PR TITLE
feat(ledger): add transactional OutboxEventPublisher write path

### DIFF
--- a/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/application/AccountEntriesIT.kt
+++ b/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/application/AccountEntriesIT.kt
@@ -10,6 +10,7 @@ import com.fincore.core.AccountId
 import com.fincore.core.Currency
 import com.fincore.ledger.domain.enum.AccountType
 import com.fincore.ledger.domain.enum.EntryDirection
+import com.fincore.ledger.infrastructure.outbox.OutboxEventPublisherImpl
 import com.fincore.ledger.infrastructure.persistence.AccountPersistenceAdapter
 import com.fincore.ledger.infrastructure.persistence.TransactionPersistenceAdapter
 import com.fincore.test.containers.PostgresContainerExtension
@@ -39,6 +40,7 @@ import java.time.Instant
     AccountServiceImpl::class,
     AccountPersistenceAdapter::class,
     AccountEntriesIT.JacksonConfig::class,
+    OutboxEventPublisherImpl::class,
 )
 class AccountEntriesIT(
     @Autowired private val entryQueryService: EntryQueryService,

--- a/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/application/TransactionBalanceServiceIT.kt
+++ b/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/application/TransactionBalanceServiceIT.kt
@@ -13,6 +13,7 @@ import com.fincore.ledger.domain.enum.EntryDirection
 import com.fincore.ledger.domain.exception.DomainException
 import com.fincore.ledger.domain.exception.DoubleEntryViolationException
 import com.fincore.ledger.domain.exception.DuplicateTransactionException
+import com.fincore.ledger.infrastructure.outbox.OutboxEventPublisherImpl
 import com.fincore.ledger.infrastructure.persistence.AccountPersistenceAdapter
 import com.fincore.ledger.infrastructure.persistence.OutboxEventRepository
 import com.fincore.ledger.infrastructure.persistence.TransactionPersistenceAdapter
@@ -43,6 +44,7 @@ import java.time.Instant
     AccountServiceImpl::class,
     AccountPersistenceAdapter::class,
     TransactionBalanceServiceIT.JacksonConfig::class,
+    OutboxEventPublisherImpl::class,
 )
 class TransactionBalanceServiceIT(
     @Autowired private val transactionService: TransactionService,

--- a/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/application/TransactionReversalIT.kt
+++ b/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/application/TransactionReversalIT.kt
@@ -12,6 +12,7 @@ import com.fincore.ledger.domain.enum.AccountType
 import com.fincore.ledger.domain.enum.EntryDirection
 import com.fincore.ledger.domain.enum.TransactionStatus
 import com.fincore.ledger.domain.exception.TransactionAlreadyReversedException
+import com.fincore.ledger.infrastructure.outbox.OutboxEventPublisherImpl
 import com.fincore.ledger.infrastructure.persistence.AccountPersistenceAdapter
 import com.fincore.ledger.infrastructure.persistence.OutboxEventRepository
 import com.fincore.ledger.infrastructure.persistence.TransactionPersistenceAdapter
@@ -41,6 +42,7 @@ import java.math.BigDecimal
     AccountServiceImpl::class,
     AccountPersistenceAdapter::class,
     TransactionReversalIT.JacksonConfig::class,
+    OutboxEventPublisherImpl::class,
 )
 class TransactionReversalIT(
     @Autowired private val transactionService: TransactionService,

--- a/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/infrastructure/outbox/OutboxEventPublisherIT.kt
+++ b/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/infrastructure/outbox/OutboxEventPublisherIT.kt
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.infrastructure.outbox
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fincore.events.EventEnvelope
+import com.fincore.events.LedgerEvents
+import com.fincore.ledger.infrastructure.persistence.OutboxEventRepository
+import com.fincore.test.containers.PostgresContainerExtension
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.context.TestComponent
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ExtendWith(PostgresContainerExtension::class)
+@Import(
+    OutboxEventPublisherImpl::class,
+    OutboxEventPublisherIT.JacksonConfig::class,
+    OutboxEventPublisherIT.PublishHelper::class,
+)
+class OutboxEventPublisherIT(
+    @Autowired private val publisher: OutboxEventPublisher,
+    @Autowired private val outboxRepository: OutboxEventRepository,
+    @Autowired private val helper: OutboxEventPublisherIT.PublishHelper,
+) {
+    @TestConfiguration
+    class JacksonConfig {
+        @Bean
+        fun objectMapper(): ObjectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+    }
+
+    @TestComponent
+    class PublishHelper(
+        @Autowired private val publisher: OutboxEventPublisher,
+    ) {
+        private val envelope: EventEnvelope<Map<String, String>> =
+            EventEnvelope.of(
+                source = "ledger",
+                type = LedgerEvents.TransactionPosted,
+                data = mapOf("ref" to "ref-1"),
+                subject = "tx_01",
+                correlationId = "corr-1",
+            )
+
+        @Transactional
+        fun commit(aggregateId: String) {
+            publisher.publish(
+                envelope,
+                "Transaction",
+                aggregateId,
+                LedgerEvents.TransactionPosted.fullType,
+                Instant.parse("2026-06-15T10:00:00Z"),
+            )
+        }
+
+        @Transactional
+        fun rollback(aggregateId: String) {
+            publisher.publish(
+                envelope,
+                "Transaction",
+                aggregateId,
+                LedgerEvents.TransactionPosted.fullType,
+                Instant.parse("2026-06-15T10:00:00Z"),
+            )
+            throw RuntimeException("forced rollback")
+        }
+    }
+
+    @AfterEach
+    fun cleanUp() {
+        outboxRepository.deleteAll()
+    }
+
+    @Test
+    fun `should commit one outbox row when the surrounding transaction commits`() {
+        helper.commit("tx-commit-1")
+
+        val rows = outboxRepository.findAll()
+        rows.size shouldBe 1
+        rows.first().aggregateId shouldBe "tx-commit-1"
+        rows.first().aggregateType shouldBe "Transaction"
+        rows.first().eventType shouldBe LedgerEvents.TransactionPosted.fullType
+        rows.first().attempts shouldBe 0
+        rows.first().publishedAt shouldBe null
+    }
+
+    @Test
+    fun `should leave no outbox row when the surrounding transaction rolls back`() {
+        shouldThrow<RuntimeException> {
+            helper.rollback("tx-rollback-1")
+        }
+
+        outboxRepository.findAll().size shouldBe 0
+    }
+
+    @Test
+    fun `should throw IllegalStateException when publish runs with no active transaction`() {
+        val envelope: EventEnvelope<Map<String, String>> =
+            EventEnvelope.of(
+                source = "ledger",
+                type = LedgerEvents.TransactionPosted,
+                data = mapOf("ref" to "direct"),
+                correlationId = null,
+            )
+
+        shouldThrow<IllegalStateException> {
+            publisher.publish(
+                envelope,
+                "Transaction",
+                "tx-no-tx",
+                LedgerEvents.TransactionPosted.fullType,
+                Instant.parse("2026-06-15T10:00:00Z"),
+            )
+        }
+
+        outboxRepository.findAll().size shouldBe 0
+    }
+
+    companion object {
+        @JvmStatic
+        @DynamicPropertySource
+        fun datasourceProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { PostgresContainerExtension.jdbcUrl }
+            registry.add("spring.datasource.username") { PostgresContainerExtension.username }
+            registry.add("spring.datasource.password") { PostgresContainerExtension.password }
+            registry.add("spring.jpa.hibernate.ddl-auto") { "none" }
+        }
+    }
+}

--- a/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/infrastructure/outbox/OutboxEventPublisherIT.kt
+++ b/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/infrastructure/outbox/OutboxEventPublisherIT.kt
@@ -24,11 +24,13 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Import
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
+import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
 
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
 @ExtendWith(PostgresContainerExtension::class)
 @Import(
     OutboxEventPublisherImpl::class,

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/application/TransactionPoster.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/application/TransactionPoster.kt
@@ -3,7 +3,6 @@
 
 package com.fincore.ledger.application
 
-import com.fasterxml.jackson.databind.ObjectMapper
 import com.fincore.core.AccountId
 import com.fincore.core.Currency
 import com.fincore.core.EntryId
@@ -11,7 +10,6 @@ import com.fincore.core.Money
 import com.fincore.core.TransactionId
 import com.fincore.events.EventEnvelope
 import com.fincore.events.LedgerEvents
-import com.fincore.events.OutboxStatus
 import com.fincore.ledger.application.event.EntryLinePayload
 import com.fincore.ledger.application.event.TransactionPostedPayload
 import com.fincore.ledger.domain.Entry
@@ -23,14 +21,13 @@ import com.fincore.ledger.domain.exception.DomainException
 import com.fincore.ledger.domain.exception.DuplicateTransactionException
 import com.fincore.ledger.domain.exception.TransactionAlreadyReversedException
 import com.fincore.ledger.domain.exception.TransactionNotFoundException
+import com.fincore.ledger.infrastructure.outbox.OutboxEventPublisher
 import com.fincore.ledger.infrastructure.persistence.AccountBalanceEntity
 import com.fincore.ledger.infrastructure.persistence.AccountBalanceKey
 import com.fincore.ledger.infrastructure.persistence.AccountBalanceRepository
 import com.fincore.ledger.infrastructure.persistence.AccountRepository
 import com.fincore.ledger.infrastructure.persistence.EntryEntity
 import com.fincore.ledger.infrastructure.persistence.EntryRepository
-import com.fincore.ledger.infrastructure.persistence.OutboxEventEntity
-import com.fincore.ledger.infrastructure.persistence.OutboxEventRepository
 import com.fincore.ledger.infrastructure.persistence.TransactionPersistenceAdapter
 import com.fincore.ledger.infrastructure.persistence.TransactionRepository
 import org.springframework.dao.DataIntegrityViolationException
@@ -45,9 +42,8 @@ class TransactionPoster(
     private val transactionRepository: TransactionRepository,
     private val entryRepository: EntryRepository,
     private val balanceRepository: AccountBalanceRepository,
-    private val outboxRepository: OutboxEventRepository,
+    private val outboxEventPublisher: OutboxEventPublisher,
     private val adapter: TransactionPersistenceAdapter,
-    private val objectMapper: ObjectMapper,
 ) {
     @Transactional
     fun post(command: PostTransactionCommand): PostedTransaction {
@@ -181,19 +177,12 @@ class TransactionPoster(
                 subject = transaction.id.toString(),
                 correlationId = correlationId,
             )
-        outboxRepository.saveAndFlush(
-            OutboxEventEntity(
-                id = UUID.randomUUID(),
-                aggregateType = AGGREGATE_TYPE,
-                aggregateId = transaction.id.toString(),
-                eventType = LedgerEvents.TransactionPosted.fullType,
-                payload = objectMapper.writeValueAsString(envelope),
-                status = OutboxStatus.PENDING,
-                createdAt = postedAt,
-                publishedAt = null,
-                attempts = 0,
-                lastError = null,
-            ),
+        outboxEventPublisher.publish(
+            envelope,
+            AGGREGATE_TYPE,
+            transaction.id.toString(),
+            LedgerEvents.TransactionPosted.fullType,
+            postedAt,
         )
     }
 

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/outbox/OutboxEventPublisher.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/outbox/OutboxEventPublisher.kt
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.infrastructure.outbox
+
+import com.fincore.events.EventEnvelope
+import java.time.Instant
+
+interface OutboxEventPublisher {
+    fun publish(
+        envelope: EventEnvelope<*>,
+        aggregateType: String,
+        aggregateId: String,
+        eventType: String,
+        createdAt: Instant,
+    )
+}

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/outbox/OutboxEventPublisherImpl.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/outbox/OutboxEventPublisherImpl.kt
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.infrastructure.outbox
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fincore.events.EventEnvelope
+import com.fincore.events.OutboxStatus
+import com.fincore.ledger.infrastructure.persistence.OutboxEventEntity
+import com.fincore.ledger.infrastructure.persistence.OutboxEventRepository
+import org.springframework.stereotype.Component
+import org.springframework.transaction.support.TransactionSynchronizationManager
+import java.time.Instant
+import java.util.UUID
+
+@Component
+class OutboxEventPublisherImpl(
+    private val outboxRepository: OutboxEventRepository,
+    private val objectMapper: ObjectMapper,
+) : OutboxEventPublisher {
+    override fun publish(
+        envelope: EventEnvelope<*>,
+        aggregateType: String,
+        aggregateId: String,
+        eventType: String,
+        createdAt: Instant,
+    ) {
+        check(TransactionSynchronizationManager.isActualTransactionActive()) {
+            "OutboxEventPublisher.publish must be called within an active transaction"
+        }
+        outboxRepository.saveAndFlush(
+            OutboxEventEntity(
+                id = UUID.randomUUID(),
+                aggregateType = aggregateType,
+                aggregateId = aggregateId,
+                eventType = eventType,
+                payload = objectMapper.writeValueAsString(envelope),
+                status = OutboxStatus.PENDING,
+                createdAt = createdAt,
+                publishedAt = null,
+                attempts = 0,
+                lastError = null,
+            ),
+        )
+    }
+}

--- a/services/ledger/src/test/kotlin/com/fincore/ledger/application/TransactionPosterTest.kt
+++ b/services/ledger/src/test/kotlin/com/fincore/ledger/application/TransactionPosterTest.kt
@@ -3,8 +3,6 @@
 
 package com.fincore.ledger.application
 
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fincore.core.AccountId
 import com.fincore.core.Currency
 import com.fincore.core.TransactionId
@@ -18,19 +16,20 @@ import com.fincore.ledger.domain.exception.DoubleEntryViolationException
 import com.fincore.ledger.domain.exception.DuplicateTransactionException
 import com.fincore.ledger.domain.exception.TransactionAlreadyReversedException
 import com.fincore.ledger.domain.exception.TransactionNotFoundException
+import com.fincore.ledger.infrastructure.outbox.OutboxEventPublisher
 import com.fincore.ledger.infrastructure.persistence.AccountBalanceRepository
 import com.fincore.ledger.infrastructure.persistence.AccountEntity
 import com.fincore.ledger.infrastructure.persistence.AccountRepository
 import com.fincore.ledger.infrastructure.persistence.EntryEntity
 import com.fincore.ledger.infrastructure.persistence.EntryKey
 import com.fincore.ledger.infrastructure.persistence.EntryRepository
-import com.fincore.ledger.infrastructure.persistence.OutboxEventRepository
 import com.fincore.ledger.infrastructure.persistence.TransactionEntity
 import com.fincore.ledger.infrastructure.persistence.TransactionPersistenceAdapter
 import com.fincore.ledger.infrastructure.persistence.TransactionRepository
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.mockk.every
+import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Test
@@ -44,17 +43,15 @@ class TransactionPosterTest {
     private val transactionRepository = mockk<TransactionRepository>()
     private val entryRepository = mockk<EntryRepository>()
     private val balanceRepository = mockk<AccountBalanceRepository>()
-    private val outboxRepository = mockk<OutboxEventRepository>()
-    private val objectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+    private val outboxEventPublisher = mockk<OutboxEventPublisher>()
     private val poster =
         TransactionPoster(
             accountRepository,
             transactionRepository,
             entryRepository,
             balanceRepository,
-            outboxRepository,
+            outboxEventPublisher,
             TransactionPersistenceAdapter(),
-            objectMapper,
         )
 
     private val now = Instant.parse("2026-06-05T12:00:00Z")
@@ -98,14 +95,14 @@ class TransactionPosterTest {
         every { entryRepository.saveAndFlush(any()) } answers { firstArg() }
         every { balanceRepository.findById(any()) } returns Optional.empty()
         every { balanceRepository.saveAndFlush(any()) } answers { firstArg() }
-        every { outboxRepository.saveAndFlush(any()) } answers { firstArg() }
+        justRun { outboxEventPublisher.publish(any(), any(), any(), any(), any()) }
 
         val result = poster.post(command())
 
         result.reference shouldBe "ref-1"
         verify(exactly = 2) { entryRepository.saveAndFlush(any()) }
         verify(exactly = 2) { balanceRepository.saveAndFlush(any()) }
-        verify(exactly = 1) { outboxRepository.saveAndFlush(any()) }
+        verify(exactly = 1) { outboxEventPublisher.publish(any(), any(), any(), any(), any()) }
     }
 
     @Test
@@ -181,7 +178,7 @@ class TransactionPosterTest {
         every { entryRepository.saveAndFlush(capture(entrySlots)) } answers { firstArg() }
         every { balanceRepository.findById(any()) } returns Optional.empty()
         every { balanceRepository.saveAndFlush(any()) } answers { firstArg() }
-        every { outboxRepository.saveAndFlush(any()) } answers { firstArg() }
+        justRun { outboxEventPublisher.publish(any(), any(), any(), any(), any()) }
 
         val result = poster.postReversal(originalId, "op", "corr-1")
 
@@ -192,7 +189,7 @@ class TransactionPosterTest {
         entrySlots[0].amount.compareTo(BigDecimal("-100.00")) shouldBe 0
         entrySlots[1].direction shouldBe EntryDirection.DEBIT
         entrySlots[1].amount.compareTo(BigDecimal("100.00")) shouldBe 0
-        verify(exactly = 1) { outboxRepository.saveAndFlush(any()) }
+        verify(exactly = 1) { outboxEventPublisher.publish(any(), any(), any(), any(), any()) }
     }
 
     @Test

--- a/services/ledger/src/test/kotlin/com/fincore/ledger/infrastructure/outbox/OutboxEventPublisherImplTest.kt
+++ b/services/ledger/src/test/kotlin/com/fincore/ledger/infrastructure/outbox/OutboxEventPublisherImplTest.kt
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.infrastructure.outbox
+
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fincore.events.EventEnvelope
+import com.fincore.events.LedgerEvents
+import com.fincore.events.OutboxStatus
+import com.fincore.ledger.infrastructure.persistence.OutboxEventEntity
+import com.fincore.ledger.infrastructure.persistence.OutboxEventRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.springframework.transaction.support.TransactionSynchronizationManager
+import java.time.Instant
+
+class OutboxEventPublisherImplTest {
+    private val outboxRepository = mockk<OutboxEventRepository>()
+    private val objectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+    private val publisher = OutboxEventPublisherImpl(outboxRepository, objectMapper)
+
+    private val createdAt = Instant.parse("2026-06-15T10:00:00Z")
+    private val envelope: EventEnvelope<Map<String, String>> =
+        EventEnvelope.of(
+            source = "ledger",
+            type = LedgerEvents.TransactionPosted,
+            data = mapOf("ref" to "ref-1"),
+            subject = "tx_01",
+            correlationId = "corr-1",
+        )
+
+    @AfterEach
+    fun tearDown() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `should persist a pending row with zero attempts when publish is called in an active transaction`() {
+        mockkStatic(TransactionSynchronizationManager::class)
+        every { TransactionSynchronizationManager.isActualTransactionActive() } returns true
+        val slot = slot<OutboxEventEntity>()
+        every { outboxRepository.saveAndFlush(capture(slot)) } answers { firstArg() }
+
+        publisher.publish(envelope, "Transaction", "tx-uuid", LedgerEvents.TransactionPosted.fullType, createdAt)
+
+        val saved = slot.captured
+        saved.aggregateType shouldBe "Transaction"
+        saved.aggregateId shouldBe "tx-uuid"
+        saved.eventType shouldBe LedgerEvents.TransactionPosted.fullType
+        saved.status shouldBe OutboxStatus.PENDING
+        saved.attempts shouldBe 0
+        saved.publishedAt shouldBe null
+        saved.lastError shouldBe null
+        saved.createdAt shouldBe createdAt
+    }
+
+    @Test
+    fun `should serialize the envelope into the payload when publish is called`() {
+        mockkStatic(TransactionSynchronizationManager::class)
+        every { TransactionSynchronizationManager.isActualTransactionActive() } returns true
+        val slot = slot<OutboxEventEntity>()
+        every { outboxRepository.saveAndFlush(capture(slot)) } answers { firstArg() }
+
+        publisher.publish(envelope, "Transaction", "tx-uuid", LedgerEvents.TransactionPosted.fullType, createdAt)
+
+        slot.captured.payload shouldBe objectMapper.writeValueAsString(envelope)
+    }
+
+    @Test
+    fun `should throw IllegalStateException when no active transaction is present`() {
+        mockkStatic(TransactionSynchronizationManager::class)
+        every { TransactionSynchronizationManager.isActualTransactionActive() } returns false
+
+        shouldThrow<IllegalStateException> {
+            publisher.publish(envelope, "Transaction", "tx-uuid", LedgerEvents.TransactionPosted.fullType, createdAt)
+        }
+
+        verify(exactly = 0) { outboxRepository.saveAndFlush(any()) }
+    }
+
+    @Test
+    fun `should set pending status and null published at when caller supplies only metadata`() {
+        mockkStatic(TransactionSynchronizationManager::class)
+        every { TransactionSynchronizationManager.isActualTransactionActive() } returns true
+        val slot = slot<OutboxEventEntity>()
+        every { outboxRepository.saveAndFlush(capture(slot)) } answers { firstArg() }
+
+        publisher.publish(envelope, "Account", "acc-uuid", LedgerEvents.AccountCreated.fullType, createdAt)
+
+        slot.captured.status shouldBe OutboxStatus.PENDING
+        slot.captured.publishedAt shouldBe null
+    }
+}


### PR DESCRIPTION
## What

Extract the inline outbox write from `TransactionPoster` into a reusable `OutboxEventPublisher` (interface + `@Component` impl in `infrastructure/outbox`). It is now the single production path that writes `platform.outbox_events` rows.

## Why

The transactional outbox requires the event row to commit atomically with the business write. The publisher writes one `PENDING` row inside the caller's active transaction and fails fast with `IllegalStateException` when no transaction is active (guard via `TransactionSynchronizationManager.isActualTransactionActive()`). It never opens its own transaction and never calls a broker (the relay is Epic-03). The previously inlined write in `TransactionPoster.emit` is removed, so there is exactly one place that constructs an `OutboxEventEntity`.

## Behaviour parity

The persisted `transaction.posted` row and JSON payload are byte-identical to before (all 10 columns, same envelope, same `ObjectMapper`). `created_at` keeps using `postedAt`.

## Tests

- Unit (`OutboxEventPublisherImplTest`, 4): PENDING/attempts=0 defaults, payload round-trip via the injected mapper, `IllegalStateException` when no active transaction, component-owned defaults.
- Integration (`OutboxEventPublisherIT`, 3): commit persists one row, rollback leaves none, no-transaction throws. Non-`@Transactional` class driven through an injected `@Transactional` helper bean with a fresh `findAll()` after the tx settles and `@AfterEach` cleanup (avoids the `@DataJpaTest` default-rollback trap).
- Existing `TransactionPosterTest` updated to mock the publisher; 3 ITs import the new bean.

Closes #21