### PR TITLE
fix(ledger): move optimistic retry outside the idempotency transaction

### DIFF
--- a/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/application/AuditRetryTopologyIT.kt
+++ b/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/application/AuditRetryTopologyIT.kt
@@ -11,13 +11,17 @@ import com.fincore.core.IdempotencyKey
 import com.fincore.ledger.domain.enum.AccountType
 import com.fincore.ledger.domain.enum.AuditAction
 import com.fincore.ledger.domain.enum.EntryDirection
+import com.fincore.ledger.domain.enum.TransactionStatus
+import com.fincore.ledger.domain.exception.ConcurrencyConflictException
 import com.fincore.ledger.infrastructure.audit.AuditTrailWriterImpl
 import com.fincore.ledger.infrastructure.outbox.OutboxEventPublisherImpl
 import com.fincore.ledger.infrastructure.persistence.AccountPersistenceAdapter
 import com.fincore.ledger.infrastructure.persistence.AuditEventRepository
+import com.fincore.ledger.infrastructure.persistence.IdempotencyKeyRepository
 import com.fincore.ledger.infrastructure.persistence.TransactionPersistenceAdapter
 import com.fincore.ledger.infrastructure.persistence.TransactionRepository
 import com.fincore.test.containers.PostgresContainerExtension
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -27,19 +31,33 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Import
+import org.springframework.dao.OptimisticLockingFailureException
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
 import java.math.BigDecimal
+import java.security.MessageDigest
+import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * Drives the real nesting idempotencyService.execute -> IdempotencyStore.runOrReplay (@Transactional)
- * -> withOptimisticRetry -> TransactionPoster.post, and asserts that posting through that chain writes
- * exactly one TRANSACTION_POST audit row together with the business write. The contended
- * optimistic-retry-inside-the-idempotency-transaction path is a pre-existing concern tracked in a
- * separate follow-up issue and is not exercised here.
+ * -> action lambda -> TransactionServiceImpl, and asserts atomicity and audit invariants.
+ *
+ * Contended-path tests (AC-1..AC-4) use @Transactional(propagation = NOT_SUPPORTED) at the class
+ * level so no ambient test tx wraps runOrReplay. Each runOrReplay call opens its own standalone,
+ * committing physical TX (INV-6). This is the proven pattern from OutboxEventPublisherIT.
+ *
+ * The forced OLF is injected at the action-lambda level: the lambda throws
+ * OptimisticLockingFailureException on the first invocation, then runs normally on subsequent
+ * invocations. This simulates the real OLF that the poster would throw on a @Version conflict:
+ * - On current broken code: OLF propagates out of runOrReplay (TX rolls back) and out of execute
+ *   with no retry -> test fails as RED.
+ * - After fix: execute catches OLF, retries runOrReplay in a fresh TX -> test passes as GREEN.
  */
 @DataJpaTest
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
 @ExtendWith(PostgresContainerExtension::class)
 @Import(
     AccountServiceImpl::class,
@@ -60,6 +78,7 @@ class AuditRetryTopologyIT(
     @Autowired private val idempotencyService: IdempotencyService,
     @Autowired private val auditRepository: AuditEventRepository,
     @Autowired private val transactionRepository: TransactionRepository,
+    @Autowired private val idempotencyKeyRepository: IdempotencyKeyRepository,
 ) {
     @TestConfiguration
     class JacksonConfig {
@@ -70,6 +89,7 @@ class AuditRetryTopologyIT(
     private fun newAccount(): com.fincore.ledger.domain.Account =
         accountService.create(CreateAccountCommand("Topology Account", AccountType.USER_WALLET, Currency.USD, ACTOR))
 
+    // AC-5 (regression guard): happy path, no forced conflict - must stay green
     @Test
     fun `should write exactly one TRANSACTION_POST audit row when post runs through the idempotency path`() {
         val debit = newAccount()
@@ -103,6 +123,151 @@ class AuditRetryTopologyIT(
         transactionRepository.findAll().filter { it.reference == "ref-topo-happy" }.size shouldBe 1
     }
 
+    // AC-1 / AC-2: action throws OLF on first invocation; execute must retry and succeed on second.
+    // On current broken code: OLF propagates out of execute uncaught -> test fails (RED).
+    // After fix: execute catches OLF, re-invokes runOrReplay in fresh TX -> exactly 1 business row + 1 audit row.
+    @Test
+    fun `should write exactly one audit row when post succeeds after one optimistic retry`() {
+        val debit = newAccount()
+        val credit = newAccount()
+        val ref = "ref-retry-once-${uniqueSuffix()}"
+        val key = idempotencyKey("retry-once-${uniqueSuffix()}")
+        val body = """{"reference":"$ref","currency":"USD"}"""
+        var postedId = ""
+        val actionCallCount = AtomicInteger(0)
+
+        idempotencyService.execute(key, body) { hash ->
+            val callIndex = actionCallCount.incrementAndGet()
+            // first invocation simulates the OLF that poster would throw on a @Version conflict
+            if (callIndex == 1) throw OptimisticLockingFailureException("forced OLF on attempt 1")
+            val posted =
+                transactionService.post(
+                    PostTransactionCommand(
+                        reference = ref,
+                        description = null,
+                        currency = Currency.USD,
+                        entries =
+                            listOf(
+                                EntryLine(debit.id, EntryDirection.DEBIT, BigDecimal("50.00")),
+                                EntryLine(credit.id, EntryDirection.CREDIT, BigDecimal("-50.00")),
+                            ),
+                        actor = ACTOR,
+                        correlationId = null,
+                        requestHash = hash,
+                    ),
+                )
+            postedId = posted.id.toString()
+            StoredResponse(201, """{"id":"${posted.id}"}""")
+        }
+
+        // AC-1: exactly one business row and one audit row (filter by unique resourceId - not global count)
+        auditRepository
+            .findAll()
+            .filter { it.resourceId == postedId && it.action == AuditAction.TRANSACTION_POST.name }
+            .size shouldBe 1
+        transactionRepository.findAll().filter { it.reference == ref }.size shouldBe 1
+        // AC-2: action was called exactly twice (first OLF, second success)
+        actionCallCount.get() shouldBe 2
+    }
+
+    // AC-3: every attempt writes a business row + audit row then the action throws OLF, so each TX#k
+    // rolls back wholesale. After MAX_ATTEMPTS the ConcurrencyConflictException surfaces and nothing
+    // survives: zero business rows, zero audit rows (proves audit-business rollback atomicity, FR-5),
+    // no committed idempotency reservation. failActor is a unique handle safe under parallel forks.
+    @Test
+    fun `should leave zero business rows and zero audit rows when optimistic conflict forces full rollback`() {
+        val debit = newAccount()
+        val credit = newAccount()
+        val ref = "ref-full-fail-${uniqueSuffix()}"
+        val failActor = "auth0|full-fail-${uniqueSuffix()}"
+        val key = idempotencyKey("full-fail-${uniqueSuffix()}")
+        val body = """{"reference":"$ref","currency":"USD"}"""
+        val keyHash = sha256Hex(key.value)
+
+        shouldThrow<ConcurrencyConflictException> {
+            idempotencyService.execute(key, body) { hash ->
+                transactionService.post(
+                    PostTransactionCommand(
+                        reference = ref,
+                        description = null,
+                        currency = Currency.USD,
+                        entries =
+                            listOf(
+                                EntryLine(debit.id, EntryDirection.DEBIT, BigDecimal("25.00")),
+                                EntryLine(credit.id, EntryDirection.CREDIT, BigDecimal("-25.00")),
+                            ),
+                        actor = failActor,
+                        correlationId = null,
+                        requestHash = hash,
+                    ),
+                )
+                throw OptimisticLockingFailureException("forced OLF after post on every attempt")
+            }
+        }
+
+        transactionRepository.findAll().filter { it.reference == ref }.size shouldBe 0
+        auditRepository.findAll().filter { it.actorId == failActor }.size shouldBe 0
+        idempotencyKeyRepository.findById(keyHash).isPresent shouldBe false
+    }
+
+    // AC-4: reverse path with forced first-attempt OLF on the action lambda -> succeeds on retry.
+    // The action lambda throws OLF on first call (simulating poster's @Version conflict on reversal).
+    // On current broken code: OLF propagates out of execute uncaught -> test fails (RED).
+    @Test
+    fun `should reverse on retry when first action invocation hits an optimistic lock`() {
+        val debit = newAccount()
+        val credit = newAccount()
+        val ref = "ref-rev-retry-${uniqueSuffix()}"
+        val postKey = idempotencyKey("post-for-rev-${uniqueSuffix()}")
+        val postBody = """{"reference":"$ref","currency":"USD"}"""
+        var originalId: com.fincore.core.TransactionId? = null
+
+        // post the original first (no conflict)
+        idempotencyService.execute(postKey, postBody) { hash ->
+            val posted =
+                transactionService.post(
+                    PostTransactionCommand(
+                        reference = ref,
+                        description = null,
+                        currency = Currency.USD,
+                        entries =
+                            listOf(
+                                EntryLine(debit.id, EntryDirection.DEBIT, BigDecimal("75.00")),
+                                EntryLine(credit.id, EntryDirection.CREDIT, BigDecimal("-75.00")),
+                            ),
+                        actor = ACTOR,
+                        correlationId = null,
+                        requestHash = hash,
+                    ),
+                )
+            originalId = posted.id
+            StoredResponse(201, """{"id":"${posted.id}"}""")
+        }
+
+        val txId = checkNotNull(originalId) { "original post must succeed" }
+        val revKey = idempotencyKey("reversal-${uniqueSuffix()}")
+        val revBody = """{"reversalOf":"$txId"}"""
+        val reversalCallCount = AtomicInteger(0)
+
+        idempotencyService.execute(revKey, revBody) { hash ->
+            val callIndex = reversalCallCount.incrementAndGet()
+            // first invocation simulates the OLF that postReversal would throw on @Version conflict
+            if (callIndex == 1) throw OptimisticLockingFailureException("forced OLF on reversal attempt 1")
+            val reversed = transactionService.reverse(txId, ACTOR, null, "test reversal", hash)
+            StoredResponse(201, """{"id":"${reversed.id}"}""")
+        }
+
+        // AC-4: exactly one TRANSACTION_REVERSE audit row for the original transaction id
+        auditRepository
+            .findAll()
+            .filter { it.resourceId == txId.toString() && it.action == AuditAction.TRANSACTION_REVERSE.name }
+            .size shouldBe 1
+        // AC-4: original marked REVERSED
+        transactionRepository.findById(txId.value).orElse(null)?.status shouldBe TransactionStatus.REVERSED
+        // AC-4: action was called exactly twice
+        reversalCallCount.get() shouldBe 2
+    }
+
     companion object {
         const val ACTOR = "auth0|topology-actor"
         const val CORR_ID = "corr-retry-topo-001"
@@ -115,5 +280,20 @@ class AuditRetryTopologyIT(
             registry.add("spring.datasource.password") { PostgresContainerExtension.password }
             registry.add("spring.jpa.hibernate.ddl-auto") { "none" }
         }
+
+        private val suffixCounter = AtomicInteger(0)
+
+        fun uniqueSuffix(): String = suffixCounter.incrementAndGet().toString().padStart(4, '0')
+
+        fun idempotencyKey(seed: String): IdempotencyKey {
+            val padded = seed.padEnd(40, '0').take(40)
+            return IdempotencyKey.of(padded)
+        }
+
+        fun sha256Hex(value: String): String =
+            MessageDigest
+                .getInstance("SHA-256")
+                .digest(value.toByteArray(Charsets.UTF_8))
+                .joinToString("") { "%02x".format(it) }
     }
 }

--- a/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/application/AuditRetryTopologyIT.kt
+++ b/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/application/AuditRetryTopologyIT.kt
@@ -18,11 +18,13 @@ import com.fincore.ledger.infrastructure.outbox.OutboxEventPublisherImpl
 import com.fincore.ledger.infrastructure.persistence.AccountPersistenceAdapter
 import com.fincore.ledger.infrastructure.persistence.AuditEventRepository
 import com.fincore.ledger.infrastructure.persistence.IdempotencyKeyRepository
+import com.fincore.ledger.infrastructure.persistence.OutboxEventRepository
 import com.fincore.ledger.infrastructure.persistence.TransactionPersistenceAdapter
 import com.fincore.ledger.infrastructure.persistence.TransactionRepository
 import com.fincore.test.containers.PostgresContainerExtension
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
@@ -79,11 +81,20 @@ class AuditRetryTopologyIT(
     @Autowired private val auditRepository: AuditEventRepository,
     @Autowired private val transactionRepository: TransactionRepository,
     @Autowired private val idempotencyKeyRepository: IdempotencyKeyRepository,
+    @Autowired private val outboxRepository: OutboxEventRepository,
 ) {
     @TestConfiguration
     class JacksonConfig {
         @Bean
         fun objectMapper(): ObjectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+    }
+
+    // These tests commit (NOT_SUPPORTED), so committed outbox rows would leak into the shared
+    // container and inflate the global-count assertions in other committing ITs. Audit rows cannot be
+    // deleted (append-only trigger 018); other ITs scope audit by unique resourceId, so leaving them is safe.
+    @AfterEach
+    fun cleanOutbox() {
+        outboxRepository.deleteAll()
     }
 
     private fun newAccount(): com.fincore.ledger.domain.Account =

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/application/IdempotencyServiceImpl.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/application/IdempotencyServiceImpl.kt
@@ -4,6 +4,8 @@
 package com.fincore.ledger.application
 
 import com.fincore.core.IdempotencyKey
+import com.fincore.ledger.domain.exception.ConcurrencyConflictException
+import org.springframework.dao.OptimisticLockingFailureException
 import org.springframework.stereotype.Service
 import java.security.MessageDigest
 
@@ -11,7 +13,6 @@ import java.security.MessageDigest
 class IdempotencyServiceImpl(
     private val store: IdempotencyStore,
 ) : IdempotencyService {
-    @Suppress("SwallowedException") // race is recovered by retry in a fresh transaction, not an error
     override fun execute(
         key: IdempotencyKey,
         requestBody: String,
@@ -19,11 +20,25 @@ class IdempotencyServiceImpl(
     ): IdempotentResult {
         val keyHash = sha256Hex(key.value)
         val requestHash = sha256Hex(requestBody)
-        return try {
-            store.runOrReplay(keyHash, requestHash, action)
-        } catch (race: IdempotencyRaceException) {
-            // The winner committed its response; a fresh transaction now replays it.
-            store.runOrReplay(keyHash, requestHash, action)
+        return runWithRetry(keyHash, requestHash, action)
+    }
+
+    @Suppress("SwallowedException") // race is recovered by single-shot replay in a fresh transaction, not an error
+    private fun runWithRetry(
+        keyHash: String,
+        requestHash: String,
+        action: (String) -> StoredResponse,
+    ): IdempotentResult {
+        var attempt = 0
+        while (true) {
+            try {
+                return store.runOrReplay(keyHash, requestHash, action)
+            } catch (lock: OptimisticLockingFailureException) {
+                attempt++
+                if (attempt >= MAX_ATTEMPTS) throw ConcurrencyConflictException(lock)
+            } catch (race: IdempotencyRaceException) {
+                return store.runOrReplay(keyHash, requestHash, action)
+            }
         }
     }
 
@@ -32,4 +47,8 @@ class IdempotencyServiceImpl(
             .getInstance("SHA-256")
             .digest(value.toByteArray(Charsets.UTF_8))
             .joinToString("") { "%02x".format(it) }
+
+    companion object {
+        const val MAX_ATTEMPTS = 3
+    }
 }

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/application/TransactionServiceImpl.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/application/TransactionServiceImpl.kt
@@ -5,13 +5,11 @@ package com.fincore.ledger.application
 
 import com.fincore.core.AccountId
 import com.fincore.core.TransactionId
-import com.fincore.ledger.domain.exception.ConcurrencyConflictException
 import com.fincore.ledger.domain.exception.TransactionNotFoundException
 import com.fincore.ledger.infrastructure.persistence.EntryEntity
 import com.fincore.ledger.infrastructure.persistence.EntryRepository
 import com.fincore.ledger.infrastructure.persistence.TransactionEntity
 import com.fincore.ledger.infrastructure.persistence.TransactionRepository
-import org.springframework.dao.OptimisticLockingFailureException
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
@@ -23,7 +21,7 @@ class TransactionServiceImpl(
     private val transactionRepository: TransactionRepository,
     private val entryRepository: EntryRepository,
 ) : TransactionService {
-    override fun post(command: PostTransactionCommand): PostedTransaction = withOptimisticRetry { poster.post(command) }
+    override fun post(command: PostTransactionCommand): PostedTransaction = poster.post(command)
 
     override fun reverse(
         id: TransactionId,
@@ -31,7 +29,7 @@ class TransactionServiceImpl(
         correlationId: String?,
         reason: String?,
         requestHash: String?,
-    ): PostedTransaction = withOptimisticRetry { poster.postReversal(id, actor, correlationId, reason, requestHash) }
+    ): PostedTransaction = poster.postReversal(id, actor, correlationId, reason, requestHash)
 
     @Transactional(readOnly = true)
     override fun get(id: TransactionId): TransactionDetail {
@@ -57,20 +55,6 @@ class TransactionServiceImpl(
         )
     }
 
-    private fun <T> withOptimisticRetry(action: () -> T): T {
-        var attempt = 0
-        while (true) {
-            try {
-                return action()
-            } catch (lock: OptimisticLockingFailureException) {
-                attempt++
-                if (attempt >= MAX_ATTEMPTS) {
-                    throw ConcurrencyConflictException(lock)
-                }
-            }
-        }
-    }
-
     private fun toSummary(entity: TransactionEntity): TransactionSummary =
         TransactionSummary(TransactionId(entity.id), entity.reference, entity.status, entity.postedAt)
 
@@ -89,8 +73,4 @@ class TransactionServiceImpl(
         )
 
     private fun toView(entry: EntryEntity): EntryView = EntryView(AccountId(entry.accountId), entry.direction, entry.amount, entry.currency)
-
-    private companion object {
-        const val MAX_ATTEMPTS = 3
-    }
 }

--- a/services/ledger/src/test/kotlin/com/fincore/ledger/application/IdempotencyServiceImplTest.kt
+++ b/services/ledger/src/test/kotlin/com/fincore/ledger/application/IdempotencyServiceImplTest.kt
@@ -4,6 +4,7 @@
 package com.fincore.ledger.application
 
 import com.fincore.core.IdempotencyKey
+import com.fincore.ledger.domain.exception.ConcurrencyConflictException
 import com.fincore.ledger.domain.exception.IdempotencyConflictException
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
@@ -11,6 +12,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import org.junit.jupiter.api.Test
+import org.springframework.dao.OptimisticLockingFailureException
 
 class IdempotencyServiceImplTest {
     private val store = mockk<IdempotencyStore>()
@@ -48,5 +50,51 @@ class IdempotencyServiceImplTest {
         shouldThrow<IdempotencyConflictException> {
             service.execute(key, "{}") { StoredResponse(200, "{}") }
         }
+    }
+
+    // AC-7 / FR-1: retry loop now lives in IdempotencyServiceImpl.execute
+    @Test
+    fun `should retry in a fresh transaction when the action hits an optimistic lock then succeed`() {
+        var calls = 0
+        every { store.runOrReplay(any(), any(), any()) } answers {
+            calls++
+            if (calls == 1) throw OptimisticLockingFailureException("version conflict")
+            IdempotentResult(201, "{}", replayed = false)
+        }
+
+        val result = service.execute(key, "{}") { StoredResponse(201, "{}") }
+
+        result.statusCode shouldBe 201
+        result.replayed shouldBe false
+        verify(exactly = 2) { store.runOrReplay(any(), any(), any()) }
+    }
+
+    // AC-7 / FR-2 / INV-4: exactly 3 total invocations (not 4) on full failure
+    @Test
+    fun `should fail with a concurrency conflict after exhausting optimistic retries`() {
+        every { store.runOrReplay(any(), any(), any()) } throws OptimisticLockingFailureException("version conflict")
+
+        shouldThrow<ConcurrencyConflictException> {
+            service.execute(key, "{}") { StoredResponse(201, "{}") }
+        }
+
+        verify(exactly = 3) { store.runOrReplay(any(), any(), any()) }
+    }
+
+    // OQ-4: IdempotencyRaceException does not consume an OLF attempt; race is single-shot
+    @Test
+    fun `should not consume an optimistic attempt when an idempotency race is resolved`() {
+        var calls = 0
+        every { store.runOrReplay(any(), any(), any()) } answers {
+            calls++
+            if (calls == 1) throw IdempotencyRaceException(RuntimeException("race"))
+            IdempotentResult(200, "{}", replayed = true)
+        }
+
+        val result = service.execute(key, "{}") { StoredResponse(200, "{}") }
+
+        result.replayed shouldBe true
+        // exactly 2 calls: original + race-replay; the race does not count toward MAX_ATTEMPTS
+        verify(exactly = 2) { store.runOrReplay(any(), any(), any()) }
     }
 }

--- a/services/ledger/src/test/kotlin/com/fincore/ledger/application/TransactionServiceImplTest.kt
+++ b/services/ledger/src/test/kotlin/com/fincore/ledger/application/TransactionServiceImplTest.kt
@@ -8,7 +8,6 @@ import com.fincore.core.Currency
 import com.fincore.core.TransactionId
 import com.fincore.ledger.domain.enum.EntryDirection
 import com.fincore.ledger.domain.enum.TransactionStatus
-import com.fincore.ledger.domain.exception.ConcurrencyConflictException
 import com.fincore.ledger.domain.exception.TransactionNotFoundException
 import com.fincore.ledger.infrastructure.persistence.EntryEntity
 import com.fincore.ledger.infrastructure.persistence.EntryKey
@@ -22,7 +21,6 @@ import io.mockk.mockk
 import io.mockk.slot
 import io.mockk.verify
 import org.junit.jupiter.api.Test
-import org.springframework.dao.OptimisticLockingFailureException
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
@@ -57,29 +55,8 @@ class TransactionServiceImplTest {
         every { poster.post(command) } returns PostedTransaction(TransactionId.generate(), "ref-1", TransactionStatus.POSTED, Instant.now())
 
         service.post(command).reference shouldBe "ref-1"
-    }
 
-    @Test
-    fun `should retry on an optimistic lock failure then succeed`() {
-        var calls = 0
-        every { poster.post(command) } answers {
-            calls++
-            if (calls < 2) throw OptimisticLockingFailureException("version conflict")
-            PostedTransaction(TransactionId.generate(), "ref-1", TransactionStatus.POSTED, Instant.now())
-        }
-
-        service.post(command)
-
-        verify(exactly = 2) { poster.post(command) }
-    }
-
-    @Test
-    fun `should fail with a concurrency conflict after three attempts`() {
-        every { poster.post(command) } throws OptimisticLockingFailureException("version conflict")
-
-        shouldThrow<ConcurrencyConflictException> { service.post(command) }
-
-        verify(exactly = 3) { poster.post(command) }
+        verify(exactly = 1) { poster.post(command) }
     }
 
     @Test
@@ -91,21 +68,6 @@ class TransactionServiceImplTest {
         service.reverse(id, "op", "corr-1", null, null) shouldBe compensating
 
         verify(exactly = 1) { poster.postReversal(id, "op", "corr-1", null, null) }
-    }
-
-    @Test
-    fun `should retry reverse on an optimistic lock failure then succeed`() {
-        val id = TransactionId.generate()
-        var calls = 0
-        every { poster.postReversal(id, "op", null, null, null) } answers {
-            calls++
-            if (calls < 2) throw OptimisticLockingFailureException("version conflict")
-            PostedTransaction(TransactionId.generate(), "reversal-of-$id", TransactionStatus.POSTED, Instant.now())
-        }
-
-        service.reverse(id, "op", null, null, null)
-
-        verify(exactly = 2) { poster.postReversal(id, "op", null, null, null) }
     }
 
     private val postedAt = Instant.parse("2026-06-12T08:00:00Z")


### PR DESCRIPTION
## What

The optimistic-retry loop sat in `TransactionServiceImpl`, between the `@Transactional` `IdempotencyStore.runOrReplay` (which opens the unit-of-work transaction TX#1) and the `@Transactional` `TransactionPoster` (which joins TX#1). On an `OptimisticLockingFailureException` the joined poster marked the shared TX#1 rollback-only, so the retry re-entered a doomed transaction and the commit raised `UnexpectedRollbackException`. The retry never worked on the real request path; it only passed where the poster was a MockK mock.

This moves the bounded retry loop into `IdempotencyServiceImpl.execute`, so each attempt re-invokes `runOrReplay` in a fresh physical transaction. The idempotency reservation, business rows and audit row commit or roll back together per attempt (no `REQUIRES_NEW`, no split reservation). The race recovery stays single-shot and does not consume a retry attempt; a body conflict still propagates without retry.

## Why

Pre-existing correctness defect surfaced by the #49 pre-mortem. Under real contention on a hot account, the broken retry could lose a committed-looking write together with its audit row - an audit-integrity gap on exactly the operations auditors scrutinise.

## Changes

- `IdempotencyServiceImpl`: bounded optimistic-retry loop (`MAX_ATTEMPTS=3`) wrapping `store.runOrReplay`; `ConcurrencyConflictException` on exhaustion (503 + Retry-After, unchanged surface).
- `TransactionServiceImpl`: `post`/`reverse` become plain delegations; `withOptimisticRetry` and `MAX_ATTEMPTS` removed.
- Tests: retry unit tests re-homed to `IdempotencyServiceImplTest`; `AuditRetryTopologyIT` gains contended cases on real committing boundaries (`NOT_SUPPORTED`) with a forced optimistic failure - exactly one business + audit row on retry, zero of each plus no reserved key on full rollback.

## Verification

Local gates green: `:test` (11/11 unit), `:detekt`, `:spotlessCheck`, `:assemble`, `:compileIntegrationTestKotlin`. The contended integration tests run on CI (Testcontainers).

Closes #134