### PR TITLE
test(ledger): assert full scope matrix per endpoint

### DIFF
--- a/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/api/ScopeAuthorizationMatrixIT.kt
+++ b/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/api/ScopeAuthorizationMatrixIT.kt
@@ -4,13 +4,22 @@
 package com.fincore.ledger.api
 
 import com.fincore.core.AccountId
-import com.fincore.core.TransactionId
+import com.fincore.core.Currency
 import com.fincore.ledger.api.idempotency.IdempotencyAttributes
 import com.fincore.ledger.api.observability.CorrelationIdAttributes
+import com.fincore.ledger.application.AccountService
+import com.fincore.ledger.application.CreateAccountCommand
+import com.fincore.ledger.application.EntryLine
+import com.fincore.ledger.application.PostTransactionCommand
+import com.fincore.ledger.application.TransactionService
+import com.fincore.ledger.domain.enum.AccountType
+import com.fincore.ledger.domain.enum.EntryDirection
+import com.fincore.ledger.infrastructure.persistence.OutboxEventRepository
 import com.fincore.test.containers.PostgresContainerExtension
 import io.kotest.assertions.withClue
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
@@ -28,6 +37,7 @@ import org.springframework.security.oauth2.jwt.Jwt
 import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
+import java.math.BigDecimal
 import java.time.Instant
 import java.util.UUID
 
@@ -36,6 +46,9 @@ import java.util.UUID
 @Import(ScopeAuthorizationMatrixIT.ScopeFromTokenSecurity::class)
 class ScopeAuthorizationMatrixIT(
     @Autowired private val rest: TestRestTemplate,
+    @Autowired private val accountService: AccountService,
+    @Autowired private val transactionService: TransactionService,
+    @Autowired private val outboxRepository: OutboxEventRepository,
 ) {
     @TestConfiguration
     class ScopeFromTokenSecurity {
@@ -57,33 +70,50 @@ class ScopeAuthorizationMatrixIT(
 
     private data class Endpoint(
         val method: HttpMethod,
-        val path: String,
+        val path: () -> String,
         val access: Access,
+        val body: () -> String? = { null },
     )
 
-    private val accountId = AccountId.generate().toString()
-    private val transactionId = TransactionId.generate().toString()
+    private lateinit var accountAId: String
+    private lateinit var accountBId: String
+    private lateinit var readTransactionId: String
+    private lateinit var reverseTransactionId: String
 
     private val endpoints =
         listOf(
-            Endpoint(HttpMethod.POST, "/v1/accounts", Access.WRITE),
-            Endpoint(HttpMethod.GET, "/v1/accounts", Access.READ),
-            Endpoint(HttpMethod.GET, "/v1/accounts/$accountId", Access.READ),
-            Endpoint(HttpMethod.GET, "/v1/accounts/$accountId/balance", Access.READ),
-            Endpoint(HttpMethod.GET, "/v1/accounts/$accountId/entries", Access.READ),
-            Endpoint(HttpMethod.POST, "/v1/transactions", Access.WRITE),
-            Endpoint(HttpMethod.GET, "/v1/transactions", Access.READ),
-            Endpoint(HttpMethod.GET, "/v1/transactions/$transactionId", Access.READ),
-            Endpoint(HttpMethod.POST, "/v1/transactions/$transactionId/reverse", Access.WRITE),
+            Endpoint(HttpMethod.GET, { "/v1/accounts" }, Access.READ),
+            Endpoint(HttpMethod.POST, { "/v1/accounts" }, Access.WRITE, { accountBody() }),
+            Endpoint(HttpMethod.GET, { "/v1/accounts/$accountAId" }, Access.READ),
+            Endpoint(HttpMethod.GET, { "/v1/accounts/$accountAId/balance" }, Access.READ),
+            Endpoint(HttpMethod.GET, { "/v1/accounts/$accountAId/entries" }, Access.READ),
+            Endpoint(HttpMethod.GET, { "/v1/transactions" }, Access.READ),
+            Endpoint(HttpMethod.POST, { "/v1/transactions" }, Access.WRITE, { transactionBody() }),
+            Endpoint(HttpMethod.GET, { "/v1/transactions/$readTransactionId" }, Access.READ),
+            Endpoint(HttpMethod.POST, { "/v1/transactions/$reverseTransactionId/reverse" }, Access.WRITE),
         )
 
+    @BeforeEach
+    fun seed() {
+        val debit = accountService.create(CreateAccountCommand("matrix-${nextSeq()}", AccountType.USER_WALLET, Currency.EUR, ACTOR))
+        val credit = accountService.create(CreateAccountCommand("matrix-${nextSeq()}", AccountType.USER_WALLET, Currency.EUR, ACTOR))
+        accountAId = debit.id.toString()
+        accountBId = credit.id.toString()
+        readTransactionId = postBalanced("matrix-read-${nextSeq()}", debit.id, credit.id)
+        reverseTransactionId = postBalanced("matrix-rev-${nextSeq()}", debit.id, credit.id)
+    }
+
+    @AfterEach
+    fun cleanOutbox() {
+        outboxRepository.deleteAll()
+    }
+
     @Test
-    fun `should pass authorization for every endpoint when the token carries the matching scope`() {
+    fun `should return 2xx for every endpoint when the token carries the matching scope`() {
         endpoints.forEach { endpoint ->
             val response = call(endpoint, endpoint.access)
-            withClue("${endpoint.method} ${endpoint.path} with ${endpoint.access}") {
-                response.statusCode.value() shouldNotBe FORBIDDEN
-                response.statusCode.value() shouldNotBe UNAUTHORIZED
+            withClue("${endpoint.method} ${endpoint.path()} expected 2xx got ${response.statusCode.value()}") {
+                (response.statusCode.value() in OK_MIN..OK_MAX) shouldBe true
             }
         }
     }
@@ -93,26 +123,65 @@ class ScopeAuthorizationMatrixIT(
         endpoints.forEach { endpoint ->
             val opposite = if (endpoint.access == Access.READ) Access.WRITE else Access.READ
             val response = call(endpoint, opposite)
-            withClue("${endpoint.method} ${endpoint.path} with $opposite") {
+            withClue("${endpoint.method} ${endpoint.path()} with $opposite") {
                 response.statusCode.value() shouldBe FORBIDDEN
+            }
+        }
+    }
+
+    @Test
+    fun `should return 401 for every endpoint when no token is presented`() {
+        endpoints.forEach { endpoint ->
+            val response = call(endpoint, null)
+            withClue("${endpoint.method} ${endpoint.path()} without a token") {
+                response.statusCode.value() shouldBe UNAUTHORIZED
             }
         }
     }
 
     private fun call(
         endpoint: Endpoint,
-        access: Access,
+        access: Access?,
     ): ResponseEntity<String> {
         val headers =
             HttpHeaders().apply {
                 contentType = MediaType.APPLICATION_JSON
-                setBearerAuth(bearerFor(access))
+                if (access != null) setBearerAuth(bearerFor(access))
                 set(CorrelationIdAttributes.HEADER, UUID.randomUUID().toString())
                 if (endpoint.method == HttpMethod.POST) set(IdempotencyAttributes.HEADER, idemKey())
             }
-        val body = if (endpoint.method == HttpMethod.POST) "{}" else null
-        return rest.exchange(endpoint.path, endpoint.method, HttpEntity(body, headers), String::class.java)
+        val body = endpoint.body() ?: if (endpoint.method == HttpMethod.POST) "{}" else null
+        return rest.exchange(endpoint.path(), endpoint.method, HttpEntity(body, headers), String::class.java)
     }
+
+    private fun accountBody(): String = """{"name":"matrix-${nextSeq()}","type":"USER_WALLET","currency":"EUR"}"""
+
+    private fun transactionBody(): String =
+        """{"reference":"matrix-${nextSeq()}","currency":"EUR","entries":[""" +
+            """{"accountId":"$accountAId","direction":"DEBIT","amount":"$AMOUNT"},""" +
+            """{"accountId":"$accountBId","direction":"CREDIT","amount":"$AMOUNT_NEG"}]}"""
+
+    private fun postBalanced(
+        reference: String,
+        debit: AccountId,
+        credit: AccountId,
+    ): String =
+        transactionService
+            .post(
+                PostTransactionCommand(
+                    reference = reference,
+                    description = null,
+                    currency = Currency.EUR,
+                    entries =
+                        listOf(
+                            EntryLine(debit, EntryDirection.DEBIT, BigDecimal(AMOUNT)),
+                            EntryLine(credit, EntryDirection.CREDIT, BigDecimal(AMOUNT_NEG)),
+                        ),
+                    actor = ACTOR,
+                    correlationId = UUID.randomUUID().toString(),
+                ),
+            ).id
+            .toString()
 
     private fun bearerFor(access: Access): String = if (access == Access.READ) "read" else "write"
 
@@ -121,10 +190,17 @@ class ScopeAuthorizationMatrixIT(
         const val KEY_LENGTH = 40
         const val FORBIDDEN = 403
         const val UNAUTHORIZED = 401
+        const val OK_MIN = 200
+        const val OK_MAX = 299
+        const val ACTOR = "scope-matrix-it"
+        const val AMOUNT = "100.00"
+        const val AMOUNT_NEG = "-100.00"
         private var counter = 0
 
+        fun nextSeq(): Int = ++counter
+
         fun idemKey(): String {
-            val suffix = (++counter).toString()
+            val suffix = nextSeq().toString()
             return "m".repeat(KEY_LENGTH - suffix.length) + suffix
         }
 


### PR DESCRIPTION
## What

Upgrades `ScopeAuthorizationMatrixIT` to a full per-endpoint authorization contract: for every ledger endpoint it asserts the matching scope grants a genuine 2xx, the opposite scope returns 403, and a request with no token returns 401.

## Why

The prior matrix only checked wrong-scope 403 and a weak `!= 403/401` proxy against unseeded ids, so it could never observe a real 2xx and had no no-token case. This guards against authorization regressions when endpoints are added.

## How

- Lazy data-driven table (method, path supplier, required scope, optional body), the single extension point for new endpoints.
- `@BeforeEach` seeds two accounts, a read-target transaction, and a dedicated POSTED reversal target via the application services, so the correct-scope path executes against real state.
- Balanced double-entry seed body uses signed amounts (DEBIT 100.00 / CREDIT -100.00) summing to zero.
- In-process `alg=none` JwtDecoder maps the bearer value to the scope claim, exercising the real `SecurityConfig` matchers without a live Keycloak.
- Outbox cleaned `@AfterEach`; hikari pool capped at 2; UUID correlation id on every request.

Test-only slice, no production code changed. integrationTest runs on CI (no Docker in the dev WSL).

Closes #60