### PR TITLE
feat(ledger): add docker-compose smoke test for ledger stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,34 @@ jobs:
           TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
           TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db
 
+  compose-smoke:
+    name: Compose smoke
+    runs-on: ubuntu-latest
+    needs: build-test
+
+    permissions:
+      contents: read
+
+    # Step order is load-bearing: smoke -> logs (on failure) -> teardown (always).
+    # `docker compose down` removes containers, so logs must be dumped before it.
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Bring up stack
+        run: docker compose up -d --build --wait --wait-timeout 90
+
+      - name: Smoke (readiness < 30s, public surface served)
+        run: bash scripts/demo.sh
+
+      - name: Dump container logs on failure
+        if: failure()
+        run: docker compose logs --no-color
+
+      - name: Tear down stack
+        if: always()
+        run: docker compose down -v
+
   lint-security:
     name: Security Scan
     runs-on: ubuntu-latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,26 @@
+services:
+  postgres:
+    image: postgres:17-alpine
+    environment:
+      POSTGRES_DB: ledger
+      POSTGRES_USER: ledger
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-ledger}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ledger -d ledger"]
+      interval: 2s
+      timeout: 3s
+      retries: 10
+      start_period: 5s
+
+  ledger:
+    build: .
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "8080:8080"
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/ledger
+      SPRING_DATASOURCE_USERNAME: ledger
+      SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD:-ledger}
+      KEYCLOAK_ISSUER_URI: http://localhost/realms/fincore

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_URL="${1:-http://localhost:8080}"
+READINESS="$BASE_URL/actuator/health/readiness"
+LIVENESS="$BASE_URL/actuator/health/liveness"
+API_DOCS="$BASE_URL/v3/api-docs"
+
+attempts=15
+interval=2
+
+ready=false
+for i in $(seq 1 "$attempts"); do
+  if curl -fsS -o /dev/null "$READINESS"; then
+    ready=true
+    break
+  fi
+  [ "$i" -lt "$attempts" ] && sleep "$interval"
+done
+
+if [ "$ready" != true ]; then
+  echo "FAIL: ledger readiness not UP within $((attempts * interval))s at $READINESS"
+  exit 1
+fi
+
+if ! curl -fsS -o /dev/null "$LIVENESS"; then
+  echo "FAIL: ledger liveness not UP at $LIVENESS"
+  exit 1
+fi
+
+code=$(curl -sS -o /dev/null -w '%{http_code}' "$API_DOCS")
+if [ "$code" != "200" ]; then
+  echo "FAIL: api-docs returned $code at $API_DOCS"
+  exit 1
+fi
+
+echo "ledger smoke OK: readiness UP, liveness UP, api-docs 200"


### PR DESCRIPTION
## What

Adds a runnable two-service stack and a CI smoke that proves the ledger boots to a healthy state against a real PostgreSQL in under 30 seconds, closing the last open Epic E-01 ops acceptance criterion and the deferred live docker-compose dev boot (#62 AC-5).

- `docker-compose.yml` (root): `ledger` (built from the root distroless Dockerfile) + `postgres:17-alpine`. Postgres carries a `pg_isready` healthcheck; `ledger` waits on `service_healthy` and reaches Postgres by service name via `SPRING_DATASOURCE_*` env. No broker, no IdP (the ledger has no Kafka dependency and the OAuth2 resource server uses a lazy decoder, so an unreachable `KEYCLOAK_ISSUER_URI` does not block readiness).
- `scripts/demo.sh`: strict bash smoke, polls `/actuator/health/readiness` every 2s up to 30s, then asserts liveness and `/v3/api-docs` 200. Runnable locally and from CI.
- `.github/workflows/ci.yml`: new `compose-smoke` job (`needs: build-test`) that builds the stack, runs the smoke, dumps container logs on failure, and tears the stack down unconditionally.

## Design notes

- The distroless runtime has no shell or curl, so the `ledger` service intentionally has no in-container healthcheck (a `CMD-SHELL`/curl probe would make it permanently unhealthy). The host-side `demo.sh` poll is the binding readiness gate; only `postgres` carries a healthcheck.
- Readiness gates on HTTP 200 of the probe (Boot maps UP to 200, not-UP to 503), which is the authoritative aggregate signal and avoids matching a per-component status under `show-components: always`.

## Verification

Infra + bash + CI only, zero Kotlin/app/migration changes. WSL has no Docker, so the `compose-smoke` CI job is the binding evidence. Gate chain: analyst, architect, critic (GO-WITH-CHANGES, folded), code-reviewer, security-auditor (PASS).

Closes #66