### PR TITLE
feat(ledger): add scheduled ttl cleanup for idempotency keys and outbox

### DIFF
--- a/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/application/CleanupServiceIT.kt
+++ b/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/application/CleanupServiceIT.kt
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.application
+
+import com.fincore.events.OutboxStatus
+import com.fincore.ledger.config.CleanupProperties
+import com.fincore.ledger.infrastructure.persistence.IdempotencyKeyEntity
+import com.fincore.ledger.infrastructure.persistence.IdempotencyKeyRepository
+import com.fincore.ledger.infrastructure.persistence.OutboxEventEntity
+import com.fincore.ledger.infrastructure.persistence.OutboxEventRepository
+import com.fincore.test.containers.PostgresContainerExtension
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import java.time.Duration
+import java.time.Instant
+import java.util.UUID
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@ExtendWith(PostgresContainerExtension::class)
+@EnableConfigurationProperties(CleanupProperties::class)
+@Import(CleanupServiceImpl::class)
+class CleanupServiceIT(
+    @Autowired private val cleanupService: CleanupService,
+    @Autowired private val idempotencyKeyRepository: IdempotencyKeyRepository,
+    @Autowired private val outboxEventRepository: OutboxEventRepository,
+) {
+    @AfterEach
+    fun tearDown() {
+        outboxEventRepository.deleteAll()
+        idempotencyKeyRepository.deleteAll()
+    }
+
+    @Test
+    fun `should purge expired keys and old published events while retaining the rest`() {
+        val now = Instant.now()
+        idempotencyKeyRepository.save(idempotencyKey("expired", now.minus(Duration.ofHours(1))))
+        idempotencyKeyRepository.save(idempotencyKey("fresh", now.plus(Duration.ofHours(1))))
+        outboxEventRepository.save(publishedEvent(now.minus(Duration.ofDays(40))))
+        outboxEventRepository.save(publishedEvent(now.minus(Duration.ofDays(1))))
+        outboxEventRepository.save(unpublishedEvent(OutboxStatus.PENDING, now.minus(Duration.ofDays(60))))
+
+        val result = cleanupService.purge()
+
+        result.idempotencyKeysDeleted shouldBe 1
+        result.outboxEventsDeleted shouldBe 1
+        idempotencyKeyRepository.existsById("expired") shouldBe false
+        idempotencyKeyRepository.existsById("fresh") shouldBe true
+        outboxEventRepository.count() shouldBe 2
+    }
+
+    @Test
+    fun `should never delete unpublished outbox events regardless of age`() {
+        val old = Instant.now().minus(Duration.ofDays(40))
+        outboxEventRepository.save(unpublishedEvent(OutboxStatus.PENDING, old))
+        outboxEventRepository.save(unpublishedEvent(OutboxStatus.PUBLISHING, old))
+        outboxEventRepository.save(unpublishedEvent(OutboxStatus.FAILED, old))
+        outboxEventRepository.save(unpublishedEvent(OutboxStatus.PERMANENTLY_FAILED, old))
+
+        val result = cleanupService.purge()
+
+        result.outboxEventsDeleted shouldBe 0
+        outboxEventRepository.count() shouldBe 4
+    }
+
+    @Test
+    fun `should be idempotent when run again with nothing left to purge`() {
+        idempotencyKeyRepository.save(idempotencyKey("expired", Instant.now().minus(Duration.ofHours(1))))
+        outboxEventRepository.save(publishedEvent(Instant.now().minus(Duration.ofDays(40))))
+
+        cleanupService.purge()
+        val second = cleanupService.purge()
+
+        second shouldBe CleanupResult(0, 0)
+    }
+
+    private fun idempotencyKey(
+        keyHash: String,
+        expiresAt: Instant,
+    ): IdempotencyKeyEntity =
+        IdempotencyKeyEntity(
+            keyHash = keyHash,
+            requestHash = "hash",
+            statusCode = null,
+            responseBody = null,
+            createdAt = Instant.now(),
+            expiresAt = expiresAt,
+        )
+
+    private fun publishedEvent(publishedAt: Instant): OutboxEventEntity =
+        outboxEvent(OutboxStatus.PUBLISHED, createdAt = publishedAt, publishedAt = publishedAt)
+
+    private fun unpublishedEvent(
+        status: OutboxStatus,
+        createdAt: Instant,
+    ): OutboxEventEntity = outboxEvent(status, createdAt = createdAt, publishedAt = null)
+
+    private fun outboxEvent(
+        status: OutboxStatus,
+        createdAt: Instant,
+        publishedAt: Instant?,
+    ): OutboxEventEntity =
+        OutboxEventEntity(
+            id = UUID.randomUUID(),
+            aggregateType = "Transaction",
+            aggregateId = "tx_1",
+            eventType = "ledger.transaction.posted",
+            payload = "{}",
+            status = status,
+            createdAt = createdAt,
+            publishedAt = publishedAt,
+            attempts = 0,
+            lastError = null,
+        )
+}

--- a/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/application/CleanupServiceIT.kt
+++ b/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/application/CleanupServiceIT.kt
@@ -19,6 +19,8 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.context.annotation.Import
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 import java.time.Duration
@@ -40,6 +42,17 @@ class CleanupServiceIT(
     fun tearDown() {
         outboxEventRepository.deleteAll()
         idempotencyKeyRepository.deleteAll()
+    }
+
+    companion object {
+        @JvmStatic
+        @DynamicPropertySource
+        fun datasourceProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { PostgresContainerExtension.jdbcUrl }
+            registry.add("spring.datasource.username") { PostgresContainerExtension.username }
+            registry.add("spring.datasource.password") { PostgresContainerExtension.password }
+            registry.add("spring.jpa.hibernate.ddl-auto") { "none" }
+        }
     }
 
     @Test

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/LedgerApplication.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/LedgerApplication.kt
@@ -3,13 +3,14 @@
 
 package com.fincore.ledger
 
+import com.fincore.ledger.config.CleanupProperties
 import com.fincore.ledger.config.IdempotencyProperties
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.runApplication
 
 @SpringBootApplication
-@EnableConfigurationProperties(IdempotencyProperties::class)
+@EnableConfigurationProperties(IdempotencyProperties::class, CleanupProperties::class)
 class LedgerApplication
 
 fun main(args: Array<String>) {

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/application/CleanupService.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/application/CleanupService.kt
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.application
+
+interface CleanupService {
+    fun purge(): CleanupResult
+}
+
+data class CleanupResult(
+    val idempotencyKeysDeleted: Int,
+    val outboxEventsDeleted: Int,
+)

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/application/CleanupServiceImpl.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/application/CleanupServiceImpl.kt
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.application
+
+import com.fincore.events.OutboxStatus
+import com.fincore.ledger.config.CleanupProperties
+import com.fincore.ledger.infrastructure.persistence.IdempotencyKeyRepository
+import com.fincore.ledger.infrastructure.persistence.OutboxEventRepository
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+@Service
+class CleanupServiceImpl(
+    private val idempotencyKeyRepository: IdempotencyKeyRepository,
+    private val outboxEventRepository: OutboxEventRepository,
+    private val properties: CleanupProperties,
+) : CleanupService {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    @Transactional
+    override fun purge(): CleanupResult {
+        val now = Instant.now()
+        val idempotencyKeysDeleted = idempotencyKeyRepository.deleteExpiredBefore(now)
+        val outboxEventsDeleted =
+            outboxEventRepository.deletePublishedBefore(OutboxStatus.PUBLISHED, now.minus(properties.outboxRetention))
+        log
+            .atInfo()
+            .addKeyValue("idempotencyKeysDeleted", idempotencyKeysDeleted)
+            .addKeyValue("outboxEventsDeleted", outboxEventsDeleted)
+            .log("ledger cleanup purge completed")
+        return CleanupResult(idempotencyKeysDeleted, outboxEventsDeleted)
+    }
+}

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/config/CleanupProperties.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/config/CleanupProperties.kt
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.validation.annotation.Validated
+import java.time.Duration
+
+@Validated
+@ConfigurationProperties(prefix = "fincore.ledger.cleanup")
+data class CleanupProperties(
+    val enabled: Boolean = false,
+    val cron: String = "0 0 * * * *",
+    val outboxRetention: Duration = defaultRetention,
+) {
+    init {
+        require(!outboxRetention.isNegative) {
+            "fincore.ledger.cleanup.outbox-retention must not be negative"
+        }
+    }
+
+    private companion object {
+        val defaultRetention: Duration = Duration.ofDays(30)
+    }
+}

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/config/CleanupScheduler.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/config/CleanupScheduler.kt
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.config
+
+import com.fincore.ledger.application.CleanupService
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Configuration
+import org.springframework.scheduling.annotation.EnableScheduling
+import org.springframework.scheduling.annotation.Scheduled
+
+@Configuration
+@EnableScheduling
+@ConditionalOnProperty(prefix = "fincore.ledger.cleanup", name = ["enabled"], havingValue = "true", matchIfMissing = false)
+class CleanupScheduler(
+    private val cleanupService: CleanupService,
+) {
+    @Scheduled(cron = "\${fincore.ledger.cleanup.cron}")
+    fun purgeExpired() {
+        cleanupService.purge()
+    }
+}

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/IdempotencyKeyRepository.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/IdempotencyKeyRepository.kt
@@ -4,5 +4,15 @@
 package com.fincore.ledger.infrastructure.persistence
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.time.Instant
 
-interface IdempotencyKeyRepository : JpaRepository<IdempotencyKeyEntity, String>
+interface IdempotencyKeyRepository : JpaRepository<IdempotencyKeyEntity, String> {
+    @Modifying(clearAutomatically = true)
+    @Query("delete from IdempotencyKeyEntity e where e.expiresAt < :cutoff")
+    fun deleteExpiredBefore(
+        @Param("cutoff") cutoff: Instant,
+    ): Int
+}

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/OutboxEventRepository.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/OutboxEventRepository.kt
@@ -3,7 +3,19 @@
 
 package com.fincore.ledger.infrastructure.persistence
 
+import com.fincore.events.OutboxStatus
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.time.Instant
 import java.util.UUID
 
-interface OutboxEventRepository : JpaRepository<OutboxEventEntity, UUID>
+interface OutboxEventRepository : JpaRepository<OutboxEventEntity, UUID> {
+    @Modifying(clearAutomatically = true)
+    @Query("delete from OutboxEventEntity e where e.status = :status and e.publishedAt < :cutoff")
+    fun deletePublishedBefore(
+        @Param("status") status: OutboxStatus,
+        @Param("cutoff") cutoff: Instant,
+    ): Int
+}

--- a/services/ledger/src/main/resources/application-dev.yml
+++ b/services/ledger/src/main/resources/application-dev.yml
@@ -19,3 +19,7 @@ management:
   tracing:
     sampling:
       probability: 1.0
+fincore:
+  ledger:
+    cleanup:
+      enabled: true

--- a/services/ledger/src/main/resources/application-prod.yml
+++ b/services/ledger/src/main/resources/application-prod.yml
@@ -17,3 +17,7 @@ management:
   tracing:
     sampling:
       probability: ${TRACING_SAMPLING_PROBABILITY:0.1}
+fincore:
+  ledger:
+    cleanup:
+      enabled: true

--- a/services/ledger/src/main/resources/application.yml
+++ b/services/ledger/src/main/resources/application.yml
@@ -20,6 +20,10 @@ fincore:
   ledger:
     idempotency:
       max-attempts: 3
+    cleanup:
+      enabled: false
+      cron: "0 0 * * * *"
+      outbox-retention: 30d
 springdoc:
   api-docs:
     path: /v3/api-docs

--- a/services/ledger/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/ledger/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -34,3 +34,6 @@ databaseChangeLog:
   - include:
       file: v0.1/019-audit-events-payload.sql
       relativeToChangelogFile: true
+  - include:
+      file: v0.1/020-outbox-events-published-index.sql
+      relativeToChangelogFile: true

--- a/services/ledger/src/main/resources/db/changelog/v0.1/020-outbox-events-published-index.sql
+++ b/services/ledger/src/main/resources/db/changelog/v0.1/020-outbox-events-published-index.sql
@@ -1,0 +1,8 @@
+--liquibase formatted sql
+-- SPDX-License-Identifier: BUSL-1.1
+-- SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+--changeset fincore:020-outbox-events-published-index dbms:postgresql
+CREATE INDEX IF NOT EXISTS idx_outbox_events_published
+    ON platform.outbox_events(published_at)
+    WHERE status = 'PUBLISHED';

--- a/services/ledger/src/test/kotlin/com/fincore/ledger/application/CleanupServiceImplTest.kt
+++ b/services/ledger/src/test/kotlin/com/fincore/ledger/application/CleanupServiceImplTest.kt
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.application
+
+import ch.qos.logback.classic.Logger
+import ch.qos.logback.classic.spi.ILoggingEvent
+import ch.qos.logback.core.read.ListAppender
+import com.fincore.events.OutboxStatus
+import com.fincore.ledger.config.CleanupProperties
+import com.fincore.ledger.infrastructure.persistence.IdempotencyKeyRepository
+import com.fincore.ledger.infrastructure.persistence.OutboxEventRepository
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+import java.time.Duration
+
+class CleanupServiceImplTest {
+    private val idempotencyKeyRepository = mockk<IdempotencyKeyRepository>()
+    private val outboxEventRepository = mockk<OutboxEventRepository>()
+    private val service =
+        CleanupServiceImpl(
+            idempotencyKeyRepository,
+            outboxEventRepository,
+            CleanupProperties(outboxRetention = Duration.ofDays(30)),
+        )
+
+    @Test
+    fun `should delegate to both repositories and return the deleted counts`() {
+        every { idempotencyKeyRepository.deleteExpiredBefore(any()) } returns 3
+        every { outboxEventRepository.deletePublishedBefore(OutboxStatus.PUBLISHED, any()) } returns 5
+
+        val result = service.purge()
+
+        result shouldBe CleanupResult(3, 5)
+        verify { idempotencyKeyRepository.deleteExpiredBefore(any()) }
+        verify { outboxEventRepository.deletePublishedBefore(OutboxStatus.PUBLISHED, any()) }
+    }
+
+    @Test
+    fun `should log the deleted counts as structured fields`() {
+        every { idempotencyKeyRepository.deleteExpiredBefore(any()) } returns 2
+        every { outboxEventRepository.deletePublishedBefore(OutboxStatus.PUBLISHED, any()) } returns 4
+        val appender = attachAppender()
+
+        service.purge()
+
+        val event = appender.list.single()
+        event.keyValuePairs.associate { it.key to it.value } shouldBe
+            mapOf("idempotencyKeysDeleted" to 2, "outboxEventsDeleted" to 4)
+    }
+
+    private fun attachAppender(): ListAppender<ILoggingEvent> {
+        val logger = LoggerFactory.getLogger(CleanupServiceImpl::class.java) as Logger
+        return ListAppender<ILoggingEvent>().apply {
+            start()
+            logger.addAppender(this)
+        }
+    }
+}

--- a/services/ledger/src/test/kotlin/com/fincore/ledger/config/CleanupPropertiesTest.kt
+++ b/services/ledger/src/test/kotlin/com/fincore/ledger/config/CleanupPropertiesTest.kt
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.config
+
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.autoconfigure.validation.ValidationAutoConfiguration
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import java.time.Duration
+
+class CleanupPropertiesTest {
+    private val runner =
+        ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(ValidationAutoConfiguration::class.java))
+            .withUserConfiguration(EnablingConfig::class.java)
+
+    @EnableConfigurationProperties(CleanupProperties::class)
+    class EnablingConfig
+
+    @Test
+    fun `should bind the defaults`() {
+        runner.run { context ->
+            val properties = context.getBean(CleanupProperties::class.java)
+            properties.enabled shouldBe false
+            properties.cron shouldBe "0 0 * * * *"
+            properties.outboxRetention shouldBe Duration.ofDays(30)
+        }
+    }
+
+    @Test
+    fun `should bind overridden values from configuration`() {
+        runner
+            .withPropertyValues(
+                "fincore.ledger.cleanup.enabled=true",
+                "fincore.ledger.cleanup.outbox-retention=7d",
+            ).run { context ->
+                val properties = context.getBean(CleanupProperties::class.java)
+                properties.enabled shouldBe true
+                properties.outboxRetention shouldBe Duration.ofDays(7)
+            }
+    }
+
+    @Test
+    fun `should reject a negative outbox retention`() {
+        runner.withPropertyValues("fincore.ledger.cleanup.outbox-retention=-1d").run { context ->
+            context.startupFailure.shouldNotBeNull()
+        }
+    }
+}

--- a/services/ledger/src/test/kotlin/com/fincore/ledger/config/CleanupSchedulerConfigTest.kt
+++ b/services/ledger/src/test/kotlin/com/fincore/ledger/config/CleanupSchedulerConfigTest.kt
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.config
+
+import com.fincore.ledger.application.CleanupResult
+import com.fincore.ledger.application.CleanupService
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+
+class CleanupSchedulerConfigTest {
+    private val runner =
+        ApplicationContextRunner().withUserConfiguration(SchedulerTestConfig::class.java)
+
+    @EnableConfigurationProperties(CleanupProperties::class)
+    @Import(CleanupScheduler::class)
+    class SchedulerTestConfig {
+        @Bean
+        fun cleanupService(): CleanupService =
+            object : CleanupService {
+                override fun purge(): CleanupResult = CleanupResult(0, 0)
+            }
+    }
+
+    @Test
+    fun `should not register the scheduler when cleanup is disabled`() {
+        runner.withPropertyValues("fincore.ledger.cleanup.enabled=false").run { context ->
+            context.getBeanNamesForType(CleanupScheduler::class.java).size shouldBe 0
+        }
+    }
+
+    @Test
+    fun `should register the scheduler when cleanup is enabled`() {
+        runner
+            .withPropertyValues(
+                "fincore.ledger.cleanup.enabled=true",
+                "fincore.ledger.cleanup.cron=0 0 * * * *",
+            ).run { context ->
+                context.getBeanNamesForType(CleanupScheduler::class.java).size shouldBe 1
+            }
+    }
+}


### PR DESCRIPTION
## What

A scheduled housekeeping job that bounds unbounded growth of two platform tables, closing the last open ops-cluster maintenance criterion for Epic E-01.

- Hourly `@Scheduled` purge (`CleanupService`) of expired `idempotency_keys` (`expires_at < now`) and `PUBLISHED` `outbox_events` older than a configurable retention (default 30 days, keyed on `published_at`).
- Typed `@ConfigurationProperties` (`fincore.ledger.cleanup`): `enabled`, `cron`, `outbox-retention` (rejects a negative duration at startup).
- New partial index `idx_outbox_events_published` backing the published-events purge (idempotent DDL).

## Correctness (fintech, zero tolerance)

- The destructive purge is strictly predicate-scoped: `status = PUBLISHED AND published_at < cutoff`. `PENDING`/`PUBLISHING`/`FAILED`/`PERMANENTLY_FAILED` rows (un-emitted side effects) can never be deleted, proven by an integration test that asserts all four survive regardless of age. Idempotency purge removes only already-expired keys, never the live 24h replay window.
- Bulk `@Modifying(clearAutomatically = true)` deletes make re-runs idempotent (a second purge returns `(0, 0)`); concurrent purges race harmlessly to zero rows.
- Scheduling is **fail-safe-off**: `@ConditionalOnProperty(... havingValue = "true", matchIfMissing = false)` with `enabled: false` in base config, enabled only in `dev`/`prod`. The scheduler never arms by default or in any `@SpringBootTest` context (proven by a config test asserting bean absent/present).
- Touches only `idempotency_keys` and `outbox_events`; the append-only `audit_events` table is untouched.

## Tests

- Unit: `CleanupPropertiesTest` (binding defaults/override/negative-reject), `CleanupSchedulerConfigTest` (gate off/on), `CleanupServiceImplTest` (MockK delegation + counts + structured-log fields).
- Integration (`CleanupServiceIT`, CI-only): expired/old-published purged, fresh retained, unpublished-of-any-status retained, idempotent re-run.

Local gates green (test, detekt, spotless, assemble); the @DataJpaTest IT runs on CI. Gate chain: analyst, architect, critic (GO-WITH-CHANGES, fail-safe-off folded), code-reviewer (4 findings folded), security-auditor PASS, evaluator 0.93.

Closes #67