### PR TITLE
docs(api): delegate rate limiting to the edge (ADR-0013)

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -30,7 +30,7 @@ info:
     Cursor-based. Order is deterministic: created_at DESC, id DESC. Responses include `nextCursor` and `hasMore`. The cursor is opaque and integrity-protected. Use `?cursor=...&limit=...`.
 
     ## Rate limiting
-    Per-IP (100/sec) and per-user (1000/sec). 429 response includes `Retry-After`.
+    Enforced at the API gateway / edge, not by the ledger service (see ADR-0013). Per-IP (100/sec) and per-user (1000/sec); the edge returns `429` with `Retry-After`.
   version: 0.1.0
   license:
     name: BSL 1.1
@@ -1086,7 +1086,7 @@ components:
         application/problem+json:
           schema: { $ref: '#/components/schemas/Problem' }
     TooManyRequests:
-      description: Rate limited
+      description: Rate limited at the API gateway / edge, not by the ledger service (see ADR-0013)
       headers:
         Retry-After:
           schema: { type: integer }


### PR DESCRIPTION
## Decision

Resolves issue #52 by **delegating rate limiting to the API gateway / edge**, not implementing it in the ledger. Records the decision in **ADR-0013** and annotates `api/openapi.yaml` so the enforcer is unambiguous.

## Why delegate (not implement in-service)

- **Correctness under horizontal scaling is the decisive argument.** PR #147 (#68) shipped an HPA scaling the stateless ledger to 10 replicas. Per-replica in-memory counters are not global: a local 100/sec per-IP cap across 10 replicas becomes an effective ~1000/sec global cap (10x looser than advertised, and it drifts with the replica count). A correct in-service limiter would require a shared store (Redis) + trusted `X-Forwarded-For` extraction, i.e. a stateful dependency bolted onto a deliberately stateless service.
- **Separation of concerns / right layer.** The platform architecture already assigns auth, rate limit, and routing to a future `gateway` service. The edge already holds the trusted client IP and the JWT subject; a token bucket there is a config line, not a new subsystem.

## What changes

- **Committed:** `api/openapi.yaml` - the `## Rate limiting` description and the `TooManyRequests` response now state enforcement is at the gateway / edge. The `429` + `Retry-After` contract and the 100/sec / 1000/sec targets are unchanged (clients still receive 429 from the edge).
- **No code added:** no in-service rate-limit filter, config, or dependency (Redis/bucket4j/resilience4j). The ledger stays stateless.

## ADR-0013 (staged for Wiki)

The decision record `ADR-0013-Rate-Limiting-At-The-Edge.md` (decision, rationale, preserved targets, vendor-neutral reference gateway config - Spring Cloud Gateway RequestRateLimiter + Redis, with NGINX/Envoy/Kong equivalents, consequences, alternatives) is prepared under `wiki/` (gitignored per the docs-in-Wiki convention) and the `ADR-Index` row added, for the owner to publish to the GitHub Wiki. It is not part of this git diff.

## Verification

Description-only spec change; `OpenApiContractIT` compares path keys, so the contract test is unaffected (no path or schema key added/removed). Gate chain: analyst (decided the path with rationale), writer (ADR-0013 draft).

Closes #52