### PR TITLE
test(ledger): enforce 90% domain coverage gate

### DIFF
--- a/services/ledger/build.gradle.kts
+++ b/services/ledger/build.gradle.kts
@@ -81,6 +81,39 @@ val integrationTest =
         shouldRunAfter(tasks.named("test"))
     }
 
+// Domain coverage gate (#53): enforce a minimum on com.fincore.ledger.domain only, from the
+// fast unit `test` exec data (no Docker/integrationTest). The rule is aggregate over the whole
+// domain bundle, so a single Kotlin synthetic branch cannot swing it; both counters sit at 1.000
+// today with margin. See docs/plans/domain-coverage-gate/plan.md (DR-7).
+tasks.named<JacocoCoverageVerification>("jacocoTestCoverageVerification") {
+    dependsOn(tasks.test)
+    classDirectories.setFrom(
+        files(
+            classDirectories.files.map { dir ->
+                fileTree(dir) {
+                    include("**/com/fincore/ledger/domain/**")
+                    exclude("**/*MapperImpl*", "**/config/**")
+                }
+            },
+        ),
+    )
+    violationRules {
+        rule {
+            limit {
+                counter = "LINE"
+                value = "COVEREDRATIO"
+                minimum = "0.90".toBigDecimal()
+            }
+            limit {
+                counter = "BRANCH"
+                value = "COVEREDRATIO"
+                minimum = "0.90".toBigDecimal()
+            }
+        }
+    }
+}
+
 tasks.named("check") {
     dependsOn(integrationTest)
+    dependsOn(tasks.named("jacocoTestCoverageVerification"))
 }

--- a/services/ledger/src/test/kotlin/com/fincore/ledger/domain/DomainExceptionsTest.kt
+++ b/services/ledger/src/test/kotlin/com/fincore/ledger/domain/DomainExceptionsTest.kt
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.domain
+
+import com.fincore.core.AccountId
+import com.fincore.core.TransactionId
+import com.fincore.ledger.domain.exception.AccountNotFoundException
+import com.fincore.ledger.domain.exception.ConcurrencyConflictException
+import com.fincore.ledger.domain.exception.CurrencyConsistencyViolationException
+import com.fincore.ledger.domain.exception.DomainException
+import com.fincore.ledger.domain.exception.DoubleEntryViolationException
+import com.fincore.ledger.domain.exception.DuplicateTransactionException
+import com.fincore.ledger.domain.exception.IdempotencyConflictException
+import com.fincore.ledger.domain.exception.TransactionAlreadyReversedException
+import com.fincore.ledger.domain.exception.TransactionNotFoundException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+
+class DomainExceptionsTest {
+    @Test
+    fun `AccountNotFoundException should carry the id and be a DomainException`() {
+        val id = AccountId.generate()
+        val ex = AccountNotFoundException(id)
+
+        ex.shouldBeInstanceOf<DomainException>()
+        ex.message.shouldContain(id.toString())
+    }
+
+    @Test
+    fun `TransactionNotFoundException should carry the id and be a DomainException`() {
+        val id = TransactionId.generate()
+        val ex = TransactionNotFoundException(id)
+
+        ex.shouldBeInstanceOf<DomainException>()
+        ex.message.shouldContain(id.toString())
+    }
+
+    @Test
+    fun `IdempotencyConflictException should be a DomainException with a fixed message`() {
+        val ex = IdempotencyConflictException()
+
+        ex.shouldBeInstanceOf<DomainException>()
+        ex.message shouldBe "Idempotency key reused with a different request payload"
+    }
+
+    @Test
+    fun `ConcurrencyConflictException should wrap the cause and be a RuntimeException not a DomainException`() {
+        val cause = IllegalStateException("optimistic lock")
+        val ex: Throwable = ConcurrencyConflictException(cause)
+
+        ex.shouldBeInstanceOf<RuntimeException>()
+        (ex is DomainException) shouldBe false
+        ex.cause shouldBe cause
+    }
+
+    @Test
+    fun `DuplicateTransactionException should default its cause to null when none is supplied`() {
+        val ex = DuplicateTransactionException("ref-1")
+
+        ex.shouldBeInstanceOf<DomainException>()
+        ex.message.shouldContain("ref-1")
+        ex.cause shouldBe null
+    }
+
+    @Test
+    fun `DuplicateTransactionException should keep the supplied cause`() {
+        val cause = IllegalStateException("unique violation")
+        val ex = DuplicateTransactionException("ref-2", cause)
+
+        ex.cause shouldBe cause
+    }
+
+    @Test
+    fun `TransactionAlreadyReversedException should default its cause to null when none is supplied`() {
+        val id = TransactionId.generate()
+        val ex = TransactionAlreadyReversedException(id)
+
+        ex.shouldBeInstanceOf<DomainException>()
+        ex.message.shouldContain(id.toString())
+        ex.cause shouldBe null
+    }
+
+    @Test
+    fun `TransactionAlreadyReversedException should keep the supplied cause`() {
+        val cause = IllegalStateException("already reversed")
+        val ex = TransactionAlreadyReversedException(TransactionId.generate(), cause)
+
+        ex.cause shouldBe cause
+    }
+
+    @Test
+    fun `CurrencyConsistencyViolationException should carry its message and be a DomainException`() {
+        val ex = CurrencyConsistencyViolationException("currency mismatch")
+
+        ex.shouldBeInstanceOf<DomainException>()
+        ex.message shouldBe "currency mismatch"
+    }
+
+    @Test
+    fun `DoubleEntryViolationException should carry its message and be a DomainException`() {
+        val ex = DoubleEntryViolationException("net is not zero")
+
+        ex.shouldBeInstanceOf<DomainException>()
+        ex.message shouldBe "net is not zero"
+    }
+
+    @Test
+    fun `DomainException should construct when the message is non-blank`() {
+        val ex = DomainException("something went wrong")
+
+        ex.message shouldBe "something went wrong"
+        ex.cause shouldBe null
+    }
+
+    @Test
+    fun `DomainException should reject a blank message`() {
+        shouldThrow<IllegalArgumentException> {
+            DomainException("   ")
+        }
+    }
+}

--- a/services/ledger/src/test/kotlin/com/fincore/ledger/domain/EnumSanityTest.kt
+++ b/services/ledger/src/test/kotlin/com/fincore/ledger/domain/EnumSanityTest.kt
@@ -5,6 +5,9 @@ package com.fincore.ledger.domain
 
 import com.fincore.ledger.domain.enum.AccountStatus
 import com.fincore.ledger.domain.enum.AccountType
+import com.fincore.ledger.domain.enum.AuditAction
+import com.fincore.ledger.domain.enum.AuditResourceType
+import com.fincore.ledger.domain.enum.AuditResult
 import com.fincore.ledger.domain.enum.EntryDirection
 import com.fincore.ledger.domain.enum.TransactionStatus
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
@@ -57,10 +60,44 @@ class EnumSanityTest {
     }
 
     @Test
+    fun `AuditAction should contain exactly the five audited operations`() {
+        AuditAction.entries.map { it.name } shouldContainExactlyInAnyOrder
+            listOf(
+                "ACCOUNT_CREATE",
+                "ACCOUNT_RENAME",
+                "ACCOUNT_STATUS_CHANGE",
+                "TRANSACTION_POST",
+                "TRANSACTION_REVERSE",
+            )
+    }
+
+    @Test
+    fun `AuditResult should contain exactly SUCCESS FAILURE DENIED`() {
+        AuditResult.entries.map { it.name } shouldContainExactlyInAnyOrder
+            listOf(
+                "SUCCESS",
+                "FAILURE",
+                "DENIED",
+            )
+    }
+
+    @Test
+    fun `AuditResourceType should contain exactly ACCOUNT TRANSACTION`() {
+        AuditResourceType.entries.map { it.name } shouldContainExactlyInAnyOrder
+            listOf(
+                "ACCOUNT",
+                "TRANSACTION",
+            )
+    }
+
+    @Test
     fun `each enum value name should equal its toString so no custom toString breaks DB column round-trip`() {
         AccountType.entries.forEach { it.name shouldBe it.toString() }
         AccountStatus.entries.forEach { it.name shouldBe it.toString() }
         TransactionStatus.entries.forEach { it.name shouldBe it.toString() }
         EntryDirection.entries.forEach { it.name shouldBe it.toString() }
+        AuditAction.entries.forEach { it.name shouldBe it.toString() }
+        AuditResult.entries.forEach { it.name shouldBe it.toString() }
+        AuditResourceType.entries.forEach { it.name shouldBe it.toString() }
     }
 }


### PR DESCRIPTION
## What
Wires a JaCoCo coverage-verification gate scoped to `com.fincore.ledger.domain` and closes the residual domain test gap.

- `jacocoTestCoverageVerification` measures only `com.fincore.ledger.domain.**`, reading the fast unit `test` exec data (no Docker / no integrationTest), bound to `check` via `dependsOn` so it is not opt-in. Excludes `**/*MapperImpl*` and `**/config/**`.
- LINE and BRANCH floors both 0.90 (matches the epic's literal "branch+line coverage of 90%").
- `DomainExceptionsTest` (new): constructs every `domain/exception/*` type and drives the `DomainException` blank-message `require` on both paths.
- `EnumSanityTest`: added `AuditAction` / `AuditResult` / `AuditResourceType` (they live under `domain.enum`, so they are in the gate bundle).

## Evidence
Domain bundle measured **LINE 123/123 = 1.000, BRANCH 47/47 = 1.000** (non-vacuous). Local gate green: test + jacocoTestCoverageVerification + detekt + spotlessCheck + assemble. `jacocoTestCoverageVerification` confirmed in the `:services:ledger:check` task graph.

## Gates
critic GO-WITH-CHANGES (3 audit enums folded), code-reviewer APPROVE-WITH-NITS (folded), evaluator 0.95, security-auditor PASS.

Closes #53