### PR TITLE
fix(ledger): resolve cold-start balance insert race with an atomic upsert

### DIFF
--- a/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/application/ColdStartPostersIT.kt
+++ b/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/application/ColdStartPostersIT.kt
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.application
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fincore.core.AccountId
+import com.fincore.core.Currency
+import com.fincore.core.IdempotencyKey
+import com.fincore.ledger.config.IdempotencyProperties
+import com.fincore.ledger.domain.enum.AccountType
+import com.fincore.ledger.domain.enum.EntryDirection
+import com.fincore.ledger.domain.exception.ConcurrencyConflictException
+import com.fincore.ledger.infrastructure.audit.AuditTrailWriterImpl
+import com.fincore.ledger.infrastructure.outbox.OutboxEventPublisherImpl
+import com.fincore.ledger.infrastructure.persistence.AccountBalanceRepository
+import com.fincore.ledger.infrastructure.persistence.AccountPersistenceAdapter
+import com.fincore.ledger.infrastructure.persistence.EntryRepository
+import com.fincore.ledger.infrastructure.persistence.OutboxEventRepository
+import com.fincore.ledger.infrastructure.persistence.TransactionPersistenceAdapter
+import com.fincore.ledger.infrastructure.persistence.TransactionRepository
+import com.fincore.test.containers.PostgresContainerExtension
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.util.UUID
+import java.util.concurrent.Callable
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+import java.util.concurrent.atomic.AtomicReference
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@ExtendWith(PostgresContainerExtension::class)
+@EnableConfigurationProperties(IdempotencyProperties::class)
+@Import(
+    AccountServiceImpl::class,
+    AccountPersistenceAdapter::class,
+    TransactionServiceImpl::class,
+    TransactionPoster::class,
+    TransactionPersistenceAdapter::class,
+    BalanceServiceImpl::class,
+    IdempotencyServiceImpl::class,
+    IdempotencyStore::class,
+    AuditTrailWriterImpl::class,
+    OutboxEventPublisherImpl::class,
+    ColdStartPostersIT.JacksonConfig::class,
+    MetricsTestConfig::class,
+)
+class ColdStartPostersIT(
+    @Autowired private val accountService: AccountService,
+    @Autowired private val transactionService: TransactionService,
+    @Autowired private val idempotencyService: IdempotencyService,
+    @Autowired private val balanceRepository: AccountBalanceRepository,
+    @Autowired private val transactionRepository: TransactionRepository,
+    @Autowired private val entryRepository: EntryRepository,
+    @Autowired private val outboxRepository: OutboxEventRepository,
+) {
+    @TestConfiguration
+    class JacksonConfig {
+        @Bean
+        fun objectMapper(): ObjectMapper = jacksonObjectMapper().registerModule(JavaTimeModule())
+    }
+
+    @AfterEach
+    fun cleanOutbox() {
+        outboxRepository.deleteAll()
+    }
+
+    private fun newAccount() =
+        accountService.create(CreateAccountCommand("Cold Start Account", AccountType.USER_WALLET, Currency.USD, ACTOR))
+
+    @Test
+    fun `should resolve every cold start poster without mislabel or lost update when contending on a fresh pair`() {
+        val debit = newAccount()
+        val credit = newAccount()
+        val prefix = "ref-cold-${UUID.randomUUID()}"
+        val outcome = postConcurrently(debit.id, credit.id, prefix)
+
+        outcome.unexpected.get()?.let { throw AssertionError("a poster surfaced an unexpected throwable: ${it::class.qualifiedName}", it) }
+        outcome.success.get() shouldBe POSTERS
+        outcome.conflict.get() shouldBe 0
+        val expectedDebit = BigDecimal(AMOUNT).multiply(BigDecimal(POSTERS))
+        balanceRepository
+            .findByKeyAccountId(debit.id.value)
+            .single()
+            .balance
+            .compareTo(expectedDebit) shouldBe 0
+        balanceRepository
+            .findByKeyAccountId(credit.id.value)
+            .single()
+            .balance
+            .compareTo(expectedDebit.negate()) shouldBe 0
+        transactionRepository.findAll().count { it.reference.startsWith(prefix) } shouldBe POSTERS
+        entryRepository.findAll().count { it.accountId == debit.id.value || it.accountId == credit.id.value } shouldBe 2 * POSTERS
+    }
+
+    @Test
+    fun `should insert then increment the balance row version when posting twice to a fresh pair`() {
+        val debit = newAccount()
+        val credit = newAccount()
+        post(debit.id, credit.id, "ref-seq-${UUID.randomUUID()}-1")
+        post(debit.id, credit.id, "ref-seq-${UUID.randomUUID()}-2")
+        val row = balanceRepository.findByKeyAccountId(debit.id.value).single()
+        row.version shouldBe 1
+        row.balance.compareTo(BigDecimal(AMOUNT).multiply(BigDecimal(2))) shouldBe 0
+    }
+
+    private fun postConcurrently(
+        debit: AccountId,
+        credit: AccountId,
+        prefix: String,
+    ): PosterOutcome {
+        val outcome = PosterOutcome()
+        val startGate = CountDownLatch(1)
+        Executors.newVirtualThreadPerTaskExecutor().use { executor ->
+            val futures =
+                (0 until POSTERS).map { index ->
+                    executor.submit(
+                        Callable {
+                            startGate.await()
+                            runPoster(debit, credit, "$prefix-$index", outcome)
+                        },
+                    )
+                }
+            startGate.countDown()
+            futures.forEach { it.get() }
+        }
+        return outcome
+    }
+
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
+    private fun runPoster(
+        debit: AccountId,
+        credit: AccountId,
+        reference: String,
+        outcome: PosterOutcome,
+    ) {
+        try {
+            post(debit, credit, reference)
+            outcome.success.incrementAndGet()
+        } catch (conflict: ConcurrencyConflictException) {
+            outcome.conflict.incrementAndGet()
+        } catch (other: Throwable) {
+            outcome.unexpected.compareAndSet(null, other)
+        }
+    }
+
+    private fun post(
+        debit: AccountId,
+        credit: AccountId,
+        reference: String,
+    ) {
+        idempotencyService.execute(IdempotencyKey.generate(), body(reference)) { hash ->
+            val posted = transactionService.post(command(reference, debit, credit, hash))
+            StoredResponse(CREATED, """{"id":"${posted.id}"}""")
+        }
+    }
+
+    private fun body(reference: String) = """{"reference":"$reference","currency":"USD"}"""
+
+    private fun command(
+        reference: String,
+        debit: AccountId,
+        credit: AccountId,
+        requestHash: String,
+    ) = PostTransactionCommand(
+        reference = reference,
+        description = null,
+        currency = Currency.USD,
+        entries =
+            listOf(
+                EntryLine(debit, EntryDirection.DEBIT, BigDecimal(AMOUNT)),
+                EntryLine(credit, EntryDirection.CREDIT, BigDecimal(AMOUNT).negate()),
+            ),
+        actor = ACTOR,
+        correlationId = null,
+        requestHash = requestHash,
+    )
+
+    private class PosterOutcome {
+        val success = AtomicInteger(0)
+        val conflict = AtomicInteger(0)
+        val unexpected = AtomicReference<Throwable?>(null)
+    }
+
+    companion object {
+        const val POSTERS = 100
+        const val ACTOR = "auth0|cold-start-actor"
+        const val AMOUNT = "100.00"
+        const val CREATED = 201
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun datasourceProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { PostgresContainerExtension.jdbcUrl }
+            registry.add("spring.datasource.username") { PostgresContainerExtension.username }
+            registry.add("spring.datasource.password") { PostgresContainerExtension.password }
+            registry.add("spring.jpa.hibernate.ddl-auto") { "none" }
+            registry.add("spring.datasource.hikari.maximum-pool-size") { "16" }
+            registry.add("spring.datasource.hikari.connection-timeout") { "30000" }
+        }
+    }
+}

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/application/TransactionPoster.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/application/TransactionPoster.kt
@@ -24,8 +24,6 @@ import com.fincore.ledger.domain.exception.DuplicateTransactionException
 import com.fincore.ledger.domain.exception.TransactionAlreadyReversedException
 import com.fincore.ledger.domain.exception.TransactionNotFoundException
 import com.fincore.ledger.infrastructure.outbox.OutboxEventPublisher
-import com.fincore.ledger.infrastructure.persistence.AccountBalanceEntity
-import com.fincore.ledger.infrastructure.persistence.AccountBalanceKey
 import com.fincore.ledger.infrastructure.persistence.AccountBalanceRepository
 import com.fincore.ledger.infrastructure.persistence.AccountRepository
 import com.fincore.ledger.infrastructure.persistence.EntryEntity
@@ -193,17 +191,16 @@ class TransactionPoster(
         transaction: Transaction,
         postedAt: Instant,
     ) {
-        transaction.entries.forEach { entry ->
-            val key = AccountBalanceKey(entry.accountId.value, entry.amount.currency.code)
-            val existing = balanceRepository.findById(key).orElse(null)
-            if (existing == null) {
-                balanceRepository.saveAndFlush(AccountBalanceEntity(key, entry.amount.amount, postedAt, 0))
-            } else {
-                existing.balance = existing.balance.add(entry.amount.amount)
-                existing.lastPostedAt = postedAt
-                balanceRepository.saveAndFlush(existing)
+        transaction.entries
+            .sortedWith(compareBy({ it.accountId.value }, { it.amount.currency.code }))
+            .forEach { entry ->
+                balanceRepository.upsertBalance(
+                    entry.accountId.value,
+                    entry.amount.currency.code,
+                    entry.amount.amount,
+                    postedAt,
+                )
             }
-        }
     }
 
     private fun emit(

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/AccountBalanceRepository.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/AccountBalanceRepository.kt
@@ -4,8 +4,31 @@
 package com.fincore.ledger.infrastructure.persistence
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.math.BigDecimal
+import java.time.Instant
 import java.util.UUID
 
 interface AccountBalanceRepository : JpaRepository<AccountBalanceEntity, AccountBalanceKey> {
     fun findByKeyAccountId(accountId: UUID): List<AccountBalanceEntity>
+
+    @Modifying(clearAutomatically = true)
+    @Query(
+        value =
+            "INSERT INTO ledger.account_balances(account_id,currency,balance,last_posted_at,version) " +
+                "VALUES (:accountId,:currency,:delta,:postedAt,0) " +
+                "ON CONFLICT (account_id,currency) DO UPDATE SET " +
+                "balance = account_balances.balance + EXCLUDED.balance, " +
+                "last_posted_at = EXCLUDED.last_posted_at, " +
+                "version = account_balances.version + 1",
+        nativeQuery = true,
+    )
+    fun upsertBalance(
+        @Param("accountId") accountId: UUID,
+        @Param("currency") currency: String,
+        @Param("delta") delta: BigDecimal,
+        @Param("postedAt") postedAt: Instant,
+    )
 }

--- a/services/ledger/src/test/kotlin/com/fincore/ledger/application/TransactionPosterTest.kt
+++ b/services/ledger/src/test/kotlin/com/fincore/ledger/application/TransactionPosterTest.kt
@@ -101,15 +101,14 @@ class TransactionPosterTest {
         every { transactionRepository.existsByReference("ref-1") } returns false
         every { transactionRepository.saveAndFlush(any()) } answers { firstArg() }
         every { entryRepository.saveAndFlush(any()) } answers { firstArg() }
-        every { balanceRepository.findById(any()) } returns Optional.empty()
-        every { balanceRepository.saveAndFlush(any()) } answers { firstArg() }
+        justRun { balanceRepository.upsertBalance(any(), any(), any(), any()) }
         justRun { outboxEventPublisher.publish(any(), any(), any(), any(), any()) }
 
         val result = poster.post(command())
 
         result.reference shouldBe "ref-1"
         verify(exactly = 2) { entryRepository.saveAndFlush(any()) }
-        verify(exactly = 2) { balanceRepository.saveAndFlush(any()) }
+        verify(exactly = 2) { balanceRepository.upsertBalance(any(), any(), any(), any()) }
         verify(exactly = 1) { outboxEventPublisher.publish(any(), any(), any(), any(), any()) }
         postedCount("post") shouldBe 1.0
     }
@@ -186,8 +185,7 @@ class TransactionPosterTest {
         val entrySlots = mutableListOf<EntryEntity>()
         every { transactionRepository.saveAndFlush(capture(txSlots)) } answers { firstArg() }
         every { entryRepository.saveAndFlush(capture(entrySlots)) } answers { firstArg() }
-        every { balanceRepository.findById(any()) } returns Optional.empty()
-        every { balanceRepository.saveAndFlush(any()) } answers { firstArg() }
+        justRun { balanceRepository.upsertBalance(any(), any(), any(), any()) }
         justRun { outboxEventPublisher.publish(any(), any(), any(), any(), any()) }
 
         val result = poster.postReversal(originalId, "op", "corr-1", null, null)


### PR DESCRIPTION
Fixes a P1 concurrency bug found by #56. Concurrent posters to a brand-new account (no `account_balances` row yet) all ran `findById` then INSERT the same `(account_id, currency)` PK; the loser's `DataIntegrityViolationException` was mislabeled as `DuplicateTransactionException`, and the orchestrator retry only catches `OptimisticLockingFailureException`, so a legitimate poster failed.

**Fix (owner-chosen, option a):** replace the read-modify-write in `applyBalances` with a single native `INSERT ... ON CONFLICT (account_id, currency) DO UPDATE SET balance = account_balances.balance + EXCLUDED.balance, last_posted_at = EXCLUDED.last_posted_at, version = version + 1`. PostgreSQL row-locks the conflicting tuple under READ COMMITTED (ADR-0011), so concurrent upserts serialize and accumulate without a lost update or an insert race; the cold-start and warm paths become identical. Entries are upserted in deterministic `(account_id, currency)` order to keep cross-transaction lock acquisition total. The reference-duplicate catch is retained and is now its only trigger.

- No schema migration (table, PK, and `version` column already exist).
- `@Modifying(clearAutomatically = true)` so the persistence context never serves a stale balance after the native upsert.
- New `ColdStartPostersIT`: 100 concurrent posters to a **fresh** account pair, **no warm-up**, all commit, `conflict == 0`, no `DuplicateTransactionException`, exact final balances (no lost update); plus a version-increment case.
- Existing warmed `ConcurrentPostersIT` unchanged (its assertions are inequality/sum-based, survive 0 conflicts).

Gates: critic GO (no-lost-update confirmed under READ COMMITTED + ON CONFLICT row lock), code-reviewer, evaluator 0.94, security-auditor PASS.

Closes #152