### PR TITLE
feat(decision): decision engine core (json dsl parser + deterministic evaluator)

### DIFF
--- a/libs/decision-engine/build.gradle.kts
+++ b/libs/decision-engine/build.gradle.kts
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+}
+
+description = "FinCore Decision Engine core: typed JSON predicate DSL, parser, deterministic evaluator"
+
+kotlin {
+    jvmToolchain(21)
+}
+
+dependencies {
+    implementation(libs.kotlin.stdlib)
+    implementation(libs.jackson.databind)
+
+    testImplementation(libs.kotest.assertions.core)
+    testImplementation(libs.kotest.property)
+    testImplementation(libs.kotest.runner.junit5)
+    testImplementation(libs.mockk)
+}
+
+tasks.test {
+    useJUnitPlatform()
+}
+
+java {
+    withSourcesJar()
+    withJavadocJar()
+}

--- a/libs/decision-engine/src/main/kotlin/com/fincore/decision/domain/AttrValue.kt
+++ b/libs/decision-engine/src/main/kotlin/com/fincore/decision/domain/AttrValue.kt
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.domain
+
+import java.math.BigDecimal
+
+enum class ValueKind { STRING, DECIMAL, BOOLEAN }
+
+sealed interface AttrValue {
+    val kind: ValueKind
+
+    fun semanticallyEquals(other: AttrValue): Boolean =
+        when {
+            this is DecimalValue && other is DecimalValue -> value.compareTo(other.value) == 0
+            this is StringValue && other is StringValue -> value == other.value
+            this is BoolValue && other is BoolValue -> value == other.value
+            else -> false
+        }
+}
+
+data class StringValue(
+    val value: String,
+) : AttrValue {
+    override val kind: ValueKind get() = ValueKind.STRING
+}
+
+data class DecimalValue(
+    val value: BigDecimal,
+) : AttrValue {
+    override val kind: ValueKind get() = ValueKind.DECIMAL
+}
+
+data class BoolValue(
+    val value: Boolean,
+) : AttrValue {
+    override val kind: ValueKind get() = ValueKind.BOOLEAN
+}

--- a/libs/decision-engine/src/main/kotlin/com/fincore/decision/domain/Condition.kt
+++ b/libs/decision-engine/src/main/kotlin/com/fincore/decision/domain/Condition.kt
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.domain
+
+import java.util.Objects
+
+sealed interface Operand
+
+data class SingleOperand(
+    val value: AttrValue,
+) : Operand
+
+data class ListOperand(
+    val values: List<AttrValue>,
+    val kind: ValueKind,
+) : Operand
+
+sealed interface Condition
+
+data class Comparison(
+    val attr: String,
+    val operator: ComparisonOperator,
+    val operand: Operand,
+) : Condition
+
+class MatchesComparison(
+    val attr: String,
+    val pattern: String,
+) : Condition {
+    val regex: Regex by lazy { Regex(pattern) }
+
+    override fun equals(other: Any?): Boolean =
+        this === other || (other is MatchesComparison && attr == other.attr && pattern == other.pattern)
+
+    override fun hashCode(): Int = Objects.hash(attr, pattern)
+
+    override fun toString(): String = "MatchesComparison(attr=$attr, pattern=$pattern)"
+
+    companion object {
+        const val TOKEN = "matches"
+    }
+}
+
+data class LogicalGroup(
+    val operator: LogicalOperator,
+    val children: List<Condition>,
+) : Condition

--- a/libs/decision-engine/src/main/kotlin/com/fincore/decision/domain/DecisionDslException.kt
+++ b/libs/decision-engine/src/main/kotlin/com/fincore/decision/domain/DecisionDslException.kt
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.domain
+
+enum class DslErrorCode {
+    UNKNOWN_OPERATOR,
+    UNKNOWN_LOGICAL_KEY,
+    EMPTY_LOGICAL_GROUP,
+    TYPE_MISMATCH,
+    INVALID_PATTERN,
+    MISSING_FIELD,
+}
+
+class DecisionDslException(
+    val code: DslErrorCode,
+    override val message: String,
+    cause: Throwable? = null,
+) : RuntimeException(message, cause)

--- a/libs/decision-engine/src/main/kotlin/com/fincore/decision/domain/DecisionResult.kt
+++ b/libs/decision-engine/src/main/kotlin/com/fincore/decision/domain/DecisionResult.kt
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.domain
+
+enum class TraceDetail { EVALUATED, ATTRIBUTE_ABSENT }
+
+data class ConditionTrace(
+    val description: String,
+    val result: Boolean,
+    val detail: TraceDetail = TraceDetail.EVALUATED,
+    val children: List<ConditionTrace> = emptyList(),
+)
+
+data class DecisionResult(
+    val matched: Boolean,
+    val outcome: DecisionOutcome?,
+    val trace: List<ConditionTrace>,
+)

--- a/libs/decision-engine/src/main/kotlin/com/fincore/decision/domain/DecisionRule.kt
+++ b/libs/decision-engine/src/main/kotlin/com/fincore/decision/domain/DecisionRule.kt
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.domain
+
+data class DecisionOutcome(
+    val label: String,
+    val reasonCodes: List<String> = emptyList(),
+)
+
+data class DecisionRule(
+    val condition: Condition,
+    val outcome: DecisionOutcome,
+)

--- a/libs/decision-engine/src/main/kotlin/com/fincore/decision/domain/EvaluationInput.kt
+++ b/libs/decision-engine/src/main/kotlin/com/fincore/decision/domain/EvaluationInput.kt
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.domain
+
+@JvmInline
+value class EvaluationInput(
+    val attributes: Map<String, AttrValue>,
+) {
+    fun get(attr: String): AttrValue? = attributes[attr]
+}

--- a/libs/decision-engine/src/main/kotlin/com/fincore/decision/domain/Operators.kt
+++ b/libs/decision-engine/src/main/kotlin/com/fincore/decision/domain/Operators.kt
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.domain
+
+enum class ComparisonOperator(
+    val token: String,
+) {
+    EQ("eq"),
+    NEQ("neq"),
+    LT("lt"),
+    LTE("lte"),
+    GT("gt"),
+    GTE("gte"),
+    IN("in"),
+    NOT_IN("not_in"),
+    ;
+
+    companion object {
+        fun fromToken(token: String): ComparisonOperator? = entries.find { it.token == token }
+    }
+}
+
+enum class LogicalOperator(
+    val key: String,
+) {
+    ALL("all"),
+    ANY("any"),
+    NONE("none"),
+}

--- a/libs/decision-engine/src/main/kotlin/com/fincore/decision/eval/RuleEvaluator.kt
+++ b/libs/decision-engine/src/main/kotlin/com/fincore/decision/eval/RuleEvaluator.kt
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.eval
+
+import com.fincore.decision.domain.AttrValue
+import com.fincore.decision.domain.Comparison
+import com.fincore.decision.domain.ComparisonOperator
+import com.fincore.decision.domain.Condition
+import com.fincore.decision.domain.ConditionTrace
+import com.fincore.decision.domain.DecimalValue
+import com.fincore.decision.domain.DecisionResult
+import com.fincore.decision.domain.DecisionRule
+import com.fincore.decision.domain.EvaluationInput
+import com.fincore.decision.domain.ListOperand
+import com.fincore.decision.domain.LogicalGroup
+import com.fincore.decision.domain.LogicalOperator
+import com.fincore.decision.domain.MatchesComparison
+import com.fincore.decision.domain.Operand
+import com.fincore.decision.domain.SingleOperand
+import com.fincore.decision.domain.StringValue
+import com.fincore.decision.domain.TraceDetail
+
+class RuleEvaluator {
+    fun evaluate(
+        rule: DecisionRule,
+        input: EvaluationInput,
+    ): DecisionResult {
+        val evaluated = evalCondition(rule.condition, input)
+        return DecisionResult(
+            matched = evaluated.result,
+            outcome = if (evaluated.result) rule.outcome else null,
+            trace = listOf(evaluated.trace),
+        )
+    }
+
+    private fun evalCondition(
+        condition: Condition,
+        input: EvaluationInput,
+    ): EvalResult =
+        when (condition) {
+            is LogicalGroup -> evalLogical(condition, input)
+            is Comparison -> evalComparison(condition, input)
+            is MatchesComparison -> evalMatches(condition, input)
+        }
+
+    private fun evalLogical(
+        group: LogicalGroup,
+        input: EvaluationInput,
+    ): EvalResult {
+        val childResults = group.children.map { evalCondition(it, input) }
+        val anyTrue = childResults.any { it.result }
+        val result =
+            when (group.operator) {
+                LogicalOperator.ALL -> childResults.all { it.result }
+                LogicalOperator.ANY -> anyTrue
+                LogicalOperator.NONE -> !anyTrue
+            }
+        return EvalResult(result, ConditionTrace(group.operator.key, result, children = childResults.map { it.trace }))
+    }
+
+    private fun evalComparison(
+        comparison: Comparison,
+        input: EvaluationInput,
+    ): EvalResult {
+        val attrValue =
+            input.get(comparison.attr)
+                ?: return absent(comparison.attr, comparison.operator.token)
+        val result = applyOperator(comparison.operator, attrValue, comparison.operand)
+        return evaluated("${comparison.attr} ${comparison.operator.token}", result)
+    }
+
+    private fun evalMatches(
+        comparison: MatchesComparison,
+        input: EvaluationInput,
+    ): EvalResult {
+        val attrValue =
+            input.get(comparison.attr)
+                ?: return absent(comparison.attr, MatchesComparison.TOKEN)
+        val result = attrValue is StringValue && comparison.regex.matches(attrValue.value)
+        return evaluated("${comparison.attr} ${MatchesComparison.TOKEN}", result)
+    }
+
+    private fun applyOperator(
+        operator: ComparisonOperator,
+        attrValue: AttrValue,
+        operand: Operand,
+    ): Boolean =
+        when (operator) {
+            ComparisonOperator.EQ -> equalsOperand(attrValue, operand)
+            ComparisonOperator.NEQ -> !equalsOperand(attrValue, operand)
+            ComparisonOperator.LT -> compareDecimal(attrValue, operand) { it < 0 }
+            ComparisonOperator.LTE -> compareDecimal(attrValue, operand) { it <= 0 }
+            ComparisonOperator.GT -> compareDecimal(attrValue, operand) { it > 0 }
+            ComparisonOperator.GTE -> compareDecimal(attrValue, operand) { it >= 0 }
+            ComparisonOperator.IN -> memberOf(attrValue, operand)
+            ComparisonOperator.NOT_IN -> !memberOf(attrValue, operand)
+        }
+
+    private fun equalsOperand(
+        attrValue: AttrValue,
+        operand: Operand,
+    ): Boolean = operand is SingleOperand && attrValue.semanticallyEquals(operand.value)
+
+    private inline fun compareDecimal(
+        attrValue: AttrValue,
+        operand: Operand,
+        predicate: (Int) -> Boolean,
+    ): Boolean {
+        if (attrValue !is DecimalValue || operand !is SingleOperand || operand.value !is DecimalValue) return false
+        return predicate(attrValue.value.compareTo(operand.value.value))
+    }
+
+    private fun memberOf(
+        attrValue: AttrValue,
+        operand: Operand,
+    ): Boolean = operand is ListOperand && operand.values.any { it.semanticallyEquals(attrValue) }
+
+    private fun absent(
+        attr: String,
+        operatorToken: String,
+    ): EvalResult = EvalResult(false, ConditionTrace("$attr $operatorToken", false, TraceDetail.ATTRIBUTE_ABSENT))
+
+    private fun evaluated(
+        description: String,
+        result: Boolean,
+    ): EvalResult = EvalResult(result, ConditionTrace(description, result))
+
+    private data class EvalResult(
+        val result: Boolean,
+        val trace: ConditionTrace,
+    )
+}

--- a/libs/decision-engine/src/main/kotlin/com/fincore/decision/parser/RuleParser.kt
+++ b/libs/decision-engine/src/main/kotlin/com/fincore/decision/parser/RuleParser.kt
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.parser
+
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fincore.decision.domain.AttrValue
+import com.fincore.decision.domain.BoolValue
+import com.fincore.decision.domain.Comparison
+import com.fincore.decision.domain.ComparisonOperator
+import com.fincore.decision.domain.Condition
+import com.fincore.decision.domain.DecimalValue
+import com.fincore.decision.domain.DecisionDslException
+import com.fincore.decision.domain.DecisionOutcome
+import com.fincore.decision.domain.DecisionRule
+import com.fincore.decision.domain.DslErrorCode
+import com.fincore.decision.domain.ListOperand
+import com.fincore.decision.domain.LogicalGroup
+import com.fincore.decision.domain.LogicalOperator
+import com.fincore.decision.domain.MatchesComparison
+import com.fincore.decision.domain.Operand
+import com.fincore.decision.domain.SingleOperand
+import com.fincore.decision.domain.StringValue
+import java.util.regex.Pattern
+import java.util.regex.PatternSyntaxException
+
+private const val CONDITION = "condition"
+private const val OUTCOME = "outcome"
+private const val ATTR = "attr"
+private const val OP = "op"
+private const val VALUE = "value"
+private const val LABEL = "label"
+private const val REASON_CODES = "reasonCodes"
+
+class RuleParser(
+    private val mapper: ObjectMapper = ObjectMapper(),
+) {
+    fun parse(json: String): DecisionRule {
+        val tree =
+            try {
+                mapper.readTree(json)
+            } catch (ex: JsonProcessingException) {
+                throw DecisionDslException(DslErrorCode.MISSING_FIELD, "malformed JSON rule", ex)
+            }
+        if (tree == null || tree.isNull) {
+            fail(DslErrorCode.MISSING_FIELD, "rule JSON is empty")
+        }
+        return parseRule(tree)
+    }
+
+    private fun parseRule(root: JsonNode): DecisionRule {
+        if (!root.isObject) fail(DslErrorCode.MISSING_FIELD, "rule must be an object")
+        val conditionNode = root.get(CONDITION) ?: fail(DslErrorCode.MISSING_FIELD, "rule requires 'condition'")
+        val outcomeNode = root.get(OUTCOME) ?: fail(DslErrorCode.MISSING_FIELD, "rule requires 'outcome'")
+        return DecisionRule(parseCondition(conditionNode), parseOutcome(outcomeNode))
+    }
+
+    private fun parseOutcome(node: JsonNode): DecisionOutcome {
+        val label =
+            node.get(LABEL)?.takeIf { it.isTextual }?.textValue()
+                ?: fail(DslErrorCode.MISSING_FIELD, "outcome requires a string 'label'")
+        val reasons = node.get(REASON_CODES)?.takeIf { it.isArray }?.mapNotNull { it.textValue() } ?: emptyList()
+        return DecisionOutcome(label, reasons)
+    }
+
+    private fun parseCondition(node: JsonNode): Condition {
+        if (!node.isObject) fail(DslErrorCode.MISSING_FIELD, "condition must be an object")
+        val logicalKey = LogicalOperator.entries.firstOrNull { node.has(it.key) }
+        if (logicalKey != null) return parseLogical(node, logicalKey)
+        if (node.has(ATTR) || node.has(OP)) return parseComparison(node)
+        fail(DslErrorCode.UNKNOWN_LOGICAL_KEY, "condition has no known logical key or comparison fields")
+    }
+
+    private fun parseLogical(
+        node: JsonNode,
+        operator: LogicalOperator,
+    ): Condition {
+        val array = node.get(operator.key)
+        if (array == null || !array.isArray) fail(DslErrorCode.MISSING_FIELD, "logical '${operator.key}' must be an array")
+        if (array.isEmpty) fail(DslErrorCode.EMPTY_LOGICAL_GROUP, "logical '${operator.key}' must not be empty")
+        return LogicalGroup(operator, array.map { parseCondition(it) })
+    }
+
+    private fun parseComparison(node: JsonNode): Condition {
+        val attr =
+            node.get(ATTR)?.takeIf { it.isTextual }?.textValue()
+                ?: fail(DslErrorCode.MISSING_FIELD, "comparison requires a string 'attr'")
+        val opToken =
+            node.get(OP)?.takeIf { it.isTextual }?.textValue()
+                ?: fail(DslErrorCode.MISSING_FIELD, "comparison requires a string 'op'")
+        val valueNode = node.get(VALUE) ?: fail(DslErrorCode.MISSING_FIELD, "comparison requires 'value'")
+        if (opToken == MatchesComparison.TOKEN) return buildMatches(attr, valueNode)
+        val operator =
+            ComparisonOperator.fromToken(opToken)
+                ?: fail(DslErrorCode.UNKNOWN_OPERATOR, "unknown operator '$opToken'")
+        return buildComparison(attr, operator, valueNode)
+    }
+
+    private fun buildComparison(
+        attr: String,
+        operator: ComparisonOperator,
+        valueNode: JsonNode,
+    ): Condition =
+        when (operator) {
+            ComparisonOperator.IN, ComparisonOperator.NOT_IN -> Comparison(attr, operator, parseListOperand(valueNode))
+            ComparisonOperator.LT, ComparisonOperator.LTE, ComparisonOperator.GT, ComparisonOperator.GTE ->
+                Comparison(attr, operator, parseOrderedOperand(operator, valueNode))
+            else -> Comparison(attr, operator, SingleOperand(parseScalar(valueNode)))
+        }
+
+    private fun buildMatches(
+        attr: String,
+        valueNode: JsonNode,
+    ): Condition {
+        if (!valueNode.isTextual) fail(DslErrorCode.TYPE_MISMATCH, "'matches' requires a string pattern")
+        val pattern = valueNode.textValue()
+        validatePattern(pattern)
+        return MatchesComparison(attr, pattern)
+    }
+
+    private fun validatePattern(pattern: String) {
+        try {
+            Pattern.compile(pattern)
+        } catch (ex: PatternSyntaxException) {
+            throw DecisionDslException(DslErrorCode.INVALID_PATTERN, "invalid regex pattern", ex)
+        }
+    }
+
+    private fun parseOrderedOperand(
+        operator: ComparisonOperator,
+        valueNode: JsonNode,
+    ): Operand {
+        if (!valueNode.isNumber) fail(DslErrorCode.TYPE_MISMATCH, "'${operator.token}' requires a numeric value")
+        return SingleOperand(DecimalValue(valueNode.decimalValue()))
+    }
+
+    private fun parseListOperand(valueNode: JsonNode): Operand {
+        if (!valueNode.isArray || valueNode.isEmpty) {
+            fail(DslErrorCode.TYPE_MISMATCH, "'in'/'not_in' requires a non-empty array")
+        }
+        val values = valueNode.map { parseScalar(it) }
+        val kind = values.first().kind
+        if (values.any { it.kind != kind }) fail(DslErrorCode.TYPE_MISMATCH, "'in'/'not_in' members must share one kind")
+        return ListOperand(values, kind)
+    }
+
+    private fun parseScalar(node: JsonNode): AttrValue =
+        when {
+            node.isTextual -> StringValue(node.textValue())
+            node.isBoolean -> BoolValue(node.booleanValue())
+            node.isNumber -> DecimalValue(node.decimalValue())
+            else -> fail(DslErrorCode.TYPE_MISMATCH, "unsupported value type")
+        }
+
+    private fun fail(
+        code: DslErrorCode,
+        message: String,
+    ): Nothing = throw DecisionDslException(code, message)
+}

--- a/libs/decision-engine/src/test/kotlin/com/fincore/decision/eval/DecisionDeterminismPropertyTest.kt
+++ b/libs/decision-engine/src/test/kotlin/com/fincore/decision/eval/DecisionDeterminismPropertyTest.kt
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.eval
+
+import com.fincore.decision.support.RuleGenerators
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.checkAll
+
+class DecisionDeterminismPropertyTest :
+    FreeSpec({
+
+        val evaluator = RuleEvaluator()
+
+        "should yield an identical result when evaluating the same rule and input twice" {
+            checkAll(RuleGenerators.rules(), RuleGenerators.inputs()) { rule, input ->
+                evaluator.evaluate(rule, input) shouldBe evaluator.evaluate(rule, input)
+            }
+        }
+    })

--- a/libs/decision-engine/src/test/kotlin/com/fincore/decision/eval/OperatorAlgebraPropertyTest.kt
+++ b/libs/decision-engine/src/test/kotlin/com/fincore/decision/eval/OperatorAlgebraPropertyTest.kt
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.eval
+
+import com.fincore.decision.domain.Comparison
+import com.fincore.decision.domain.ComparisonOperator
+import com.fincore.decision.domain.Condition
+import com.fincore.decision.domain.DecisionOutcome
+import com.fincore.decision.domain.DecisionRule
+import com.fincore.decision.domain.EvaluationInput
+import com.fincore.decision.domain.ListOperand
+import com.fincore.decision.domain.LogicalGroup
+import com.fincore.decision.domain.LogicalOperator
+import com.fincore.decision.domain.ValueKind
+import com.fincore.decision.support.RuleGenerators
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.list
+import io.kotest.property.checkAll
+
+class OperatorAlgebraPropertyTest :
+    FreeSpec({
+
+        val evaluator = RuleEvaluator()
+        val outcome = DecisionOutcome("matched")
+
+        fun matched(
+            condition: Condition,
+            input: EvaluationInput,
+        ): Boolean = evaluator.evaluate(DecisionRule(condition, outcome), input).matched
+
+        "should equal not-any when evaluating none over the same children" {
+            checkAll(Arb.list(RuleGenerators.conditions(1), 1..2), RuleGenerators.inputs()) { children, input ->
+                matched(LogicalGroup(LogicalOperator.NONE, children), input) shouldBe
+                    !matched(LogicalGroup(LogicalOperator.ANY, children), input)
+            }
+        }
+
+        "should equal all when evaluating not-any over negated children" {
+            checkAll(Arb.list(RuleGenerators.conditions(1), 1..2), RuleGenerators.inputs()) { children, input ->
+                val negated = children.map { LogicalGroup(LogicalOperator.NONE, listOf(it)) }
+                matched(LogicalGroup(LogicalOperator.ALL, children), input) shouldBe
+                    !matched(LogicalGroup(LogicalOperator.ANY, negated), input)
+            }
+        }
+
+        "should be true iff a member when evaluating in, and not_in is its exact negation for a present attribute" {
+            checkAll(RuleGenerators.decimal(), Arb.list(RuleGenerators.decimal(), 1..2)) { attr, members ->
+                val input = EvaluationInput(mapOf("a" to attr))
+                val expected = members.any { it.semanticallyEquals(attr) }
+                matched(Comparison("a", ComparisonOperator.IN, ListOperand(members, ValueKind.DECIMAL)), input) shouldBe
+                    expected
+                matched(Comparison("a", ComparisonOperator.NOT_IN, ListOperand(members, ValueKind.DECIMAL)), input) shouldBe
+                    !expected
+            }
+        }
+    })

--- a/libs/decision-engine/src/test/kotlin/com/fincore/decision/eval/RuleEvaluatorTest.kt
+++ b/libs/decision-engine/src/test/kotlin/com/fincore/decision/eval/RuleEvaluatorTest.kt
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.eval
+
+import com.fincore.decision.domain.AttrValue
+import com.fincore.decision.domain.BoolValue
+import com.fincore.decision.domain.DecimalValue
+import com.fincore.decision.domain.DecisionResult
+import com.fincore.decision.domain.EvaluationInput
+import com.fincore.decision.domain.StringValue
+import com.fincore.decision.domain.TraceDetail
+import com.fincore.decision.parser.RuleParser
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+class RuleEvaluatorTest {
+    private val parser = RuleParser()
+    private val evaluator = RuleEvaluator()
+
+    private val nestedRule =
+        """
+        {"condition":{"all":[
+            {"attr":"amount","op":"gte","value":100},
+            {"any":[{"attr":"country","op":"in","value":["A","B"]},{"attr":"vip","op":"eq","value":true}]}
+        ]},"outcome":{"label":"approve"}}
+        """.trimIndent()
+
+    private fun eval(
+        json: String,
+        input: Map<String, AttrValue>,
+    ): DecisionResult = evaluator.evaluate(parser.parse(json), EvaluationInput(input))
+
+    @Test
+    fun `should match when nested all and any conditions are satisfied`() {
+        val result =
+            eval(
+                nestedRule,
+                mapOf("amount" to DecimalValue(BigDecimal("100")), "country" to StringValue("A"), "vip" to BoolValue(false)),
+            )
+        result.matched shouldBe true
+        result.outcome?.label shouldBe "approve"
+    }
+
+    @Test
+    fun `should not match when the ordered condition fails`() {
+        val result =
+            eval(
+                nestedRule,
+                mapOf("amount" to DecimalValue(BigDecimal.ONE), "country" to StringValue("A"), "vip" to BoolValue(true)),
+            )
+        result.matched shouldBe false
+        result.outcome shouldBe null
+        result.trace
+            .first()
+            .children
+            .first()
+            .result shouldBe false
+    }
+
+    @Test
+    fun `should treat decimal scale as equal when comparing 2_0 against 2_00`() {
+        val json = """{"condition":{"attr":"x","op":"eq","value":2.0},"outcome":{"label":"y"}}"""
+        eval(json, mapOf("x" to DecimalValue(BigDecimal("2.00")))).matched shouldBe true
+    }
+
+    @Test
+    fun `should degrade to false with attribute-absent trace when the attribute is missing`() {
+        val json = """{"condition":{"attr":"score","op":"gt","value":1},"outcome":{"label":"y"}}"""
+        val result = eval(json, emptyMap())
+        result.matched shouldBe false
+        result.trace.first().detail shouldBe TraceDetail.ATTRIBUTE_ABSENT
+    }
+
+    @Test
+    fun `should evaluate false when a present attribute has the wrong kind`() {
+        val json = """{"condition":{"attr":"amount","op":"gt","value":1},"outcome":{"label":"y"}}"""
+        val result = eval(json, mapOf("amount" to StringValue("big")))
+        result.matched shouldBe false
+        result.trace.first().detail shouldBe TraceDetail.EVALUATED
+    }
+
+    @Test
+    fun `should match full pattern when matches uses anchored semantics`() {
+        val json = """{"condition":{"attr":"name","op":"matches","value":"a.+"},"outcome":{"label":"y"}}"""
+        eval(json, mapOf("name" to StringValue("abc"))).matched shouldBe true
+        eval(json, mapOf("name" to StringValue("xabc"))).matched shouldBe false
+    }
+
+    @Test
+    fun `should produce equal results when evaluating twice`() {
+        val result = eval(nestedRule, mapOf("amount" to DecimalValue(BigDecimal("100")), "vip" to BoolValue(true)))
+        eval(nestedRule, mapOf("amount" to DecimalValue(BigDecimal("100")), "vip" to BoolValue(true))) shouldBe result
+    }
+}

--- a/libs/decision-engine/src/test/kotlin/com/fincore/decision/parser/RuleParserTest.kt
+++ b/libs/decision-engine/src/test/kotlin/com/fincore/decision/parser/RuleParserTest.kt
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.parser
+
+import com.fincore.decision.domain.DecisionDslException
+import com.fincore.decision.domain.DslErrorCode
+import com.fincore.decision.domain.MatchesComparison
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class RuleParserTest {
+    private val parser = RuleParser()
+
+    @Test
+    fun `should reject unknown operator when op is not recognized`() {
+        val ex =
+            shouldThrow<DecisionDslException> {
+                parser.parse("""{"condition":{"attr":"a","op":"like","value":1},"outcome":{"label":"x"}}""")
+            }
+        ex.code shouldBe DslErrorCode.UNKNOWN_OPERATOR
+    }
+
+    @Test
+    fun `should reject empty logical group when child list is empty`() {
+        val ex =
+            shouldThrow<DecisionDslException> {
+                parser.parse("""{"condition":{"all":[]},"outcome":{"label":"x"}}""")
+            }
+        ex.code shouldBe DslErrorCode.EMPTY_LOGICAL_GROUP
+    }
+
+    @Test
+    fun `should reject type mismatch when ordered operator has a string value`() {
+        val ex =
+            shouldThrow<DecisionDslException> {
+                parser.parse("""{"condition":{"attr":"a","op":"gt","value":"x"},"outcome":{"label":"x"}}""")
+            }
+        ex.code shouldBe DslErrorCode.TYPE_MISMATCH
+    }
+
+    @Test
+    fun `should reject invalid pattern when matches regex is malformed`() {
+        val ex =
+            shouldThrow<DecisionDslException> {
+                parser.parse("""{"condition":{"attr":"a","op":"matches","value":"["},"outcome":{"label":"x"}}""")
+            }
+        ex.code shouldBe DslErrorCode.INVALID_PATTERN
+    }
+
+    @Test
+    fun `should reject missing field when condition is absent`() {
+        val ex =
+            shouldThrow<DecisionDslException> {
+                parser.parse("""{"outcome":{"label":"x"}}""")
+            }
+        ex.code shouldBe DslErrorCode.MISSING_FIELD
+    }
+
+    @Test
+    fun `should produce equal rules when parsing the same matches rule twice after forcing the lazy regex`() {
+        val json = """{"condition":{"attr":"name","op":"matches","value":"a.*"},"outcome":{"label":"x"}}"""
+        val first = parser.parse(json)
+        (first.condition as MatchesComparison).regex.matches("abc") shouldBe true
+        first shouldBe parser.parse(json)
+    }
+}

--- a/libs/decision-engine/src/test/kotlin/com/fincore/decision/support/RuleGenerators.kt
+++ b/libs/decision-engine/src/test/kotlin/com/fincore/decision/support/RuleGenerators.kt
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.support
+
+import com.fincore.decision.domain.AttrValue
+import com.fincore.decision.domain.BoolValue
+import com.fincore.decision.domain.Comparison
+import com.fincore.decision.domain.ComparisonOperator
+import com.fincore.decision.domain.Condition
+import com.fincore.decision.domain.DecimalValue
+import com.fincore.decision.domain.DecisionOutcome
+import com.fincore.decision.domain.DecisionRule
+import com.fincore.decision.domain.EvaluationInput
+import com.fincore.decision.domain.ListOperand
+import com.fincore.decision.domain.LogicalGroup
+import com.fincore.decision.domain.LogicalOperator
+import com.fincore.decision.domain.Operand
+import com.fincore.decision.domain.SingleOperand
+import com.fincore.decision.domain.StringValue
+import com.fincore.decision.domain.ValueKind
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.arbitrary
+import io.kotest.property.arbitrary.boolean
+import io.kotest.property.arbitrary.element
+import io.kotest.property.arbitrary.int
+
+object RuleGenerators {
+    private val attrNames = listOf("amount", "country", "vip", "score")
+    private val stringPool = listOf("a", "b", "c")
+    private val comparisonOps = ComparisonOperator.entries
+
+    fun decimal(): Arb<AttrValue> = arbitrary { DecimalValue(Arb.int(0..100).bind().toBigDecimal()) }
+
+    fun attrValues(): Arb<AttrValue> =
+        arbitrary {
+            when (Arb.int(0..2).bind()) {
+                0 -> StringValue(Arb.element(stringPool).bind())
+                1 -> DecimalValue(Arb.int(0..100).bind().toBigDecimal())
+                else -> BoolValue(Arb.boolean().bind())
+            }
+        }
+
+    fun conditions(depth: Int): Arb<Condition> =
+        arbitrary {
+            if (depth <= 0 || !Arb.boolean().bind()) comparison().bind() else logicalGroup(depth).bind()
+        }
+
+    fun rules(): Arb<DecisionRule> = arbitrary { DecisionRule(conditions(2).bind(), DecisionOutcome("matched")) }
+
+    fun inputs(): Arb<EvaluationInput> =
+        arbitrary {
+            val attributes =
+                attrNames
+                    .mapNotNull { name ->
+                        if (Arb.boolean().bind()) name to attrValues().bind() else null
+                    }.toMap()
+            EvaluationInput(attributes)
+        }
+
+    private fun comparison(): Arb<Condition> =
+        arbitrary {
+            val attr = Arb.element(attrNames).bind()
+            val operator = Arb.element(comparisonOps).bind()
+            Comparison(attr, operator, operand(operator).bind())
+        }
+
+    private fun logicalGroup(depth: Int): Arb<Condition> =
+        arbitrary {
+            val operator = Arb.element(LogicalOperator.entries).bind()
+            val count = Arb.int(1..2).bind()
+            LogicalGroup(operator, (0 until count).map { conditions(depth - 1).bind() })
+        }
+
+    private fun operand(operator: ComparisonOperator): Arb<Operand> =
+        arbitrary {
+            when (operator) {
+                ComparisonOperator.IN, ComparisonOperator.NOT_IN ->
+                    ListOperand((0 until Arb.int(1..2).bind()).map { decimal().bind() }, ValueKind.DECIMAL)
+                ComparisonOperator.LT, ComparisonOperator.LTE, ComparisonOperator.GT, ComparisonOperator.GTE ->
+                    SingleOperand(decimal().bind())
+                else -> SingleOperand(attrValues().bind())
+            }
+        }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,5 +24,6 @@ include(
     ":libs:fincore-core",
     ":libs:fincore-events",
     ":libs:fincore-test-support",
+    ":libs:decision-engine",
     ":services:ledger",
 )


### PR DESCRIPTION
First slice of E-05 Decision Engine (#163). New pure-Kotlin module `libs/decision-engine`.

## What
- Typed, immutable JSON predicate DSL (sealed AST: comparison, matches, logical all/any/none).
- Fail-closed parser: walks a Jackson tree into the typed model, one typed `DecisionDslException` with a `DslErrorCode`, regex validated and the pattern carried as source on the node (no Jackson or regex type on the public API).
- Total, pure, deterministic evaluator returning a `DecisionResult` with a source-ordered reason trace. No clock, randomness, or locale; `BigDecimal`-only numerics with `compareTo` equality; missing attribute degrades to false (`ATTRIBUTE_ABSENT`), present wrong-kind evaluates false (`EVALUATED`), `matches` is full-match.

## Tests
21 unit and property tests (0 skipped, 0 failures): parser validation (AC-1..4, 6), evaluator behavior (AC-5..8 + wrong-kind + anchored matches), determinism property (AC-9), operator algebra (AC-10/11). Instruction coverage ~83%. All pure JVM, no Testcontainers.

## Gate-chain
analyst spec -> architect plan -> critic GO-WITH-CHANGES (4 must-fixes applied) -> code-reviewer APPROVE after fixes -> security-auditor PASS -> evaluator 0.93.

## Deferred
ReDoS hardening for untrusted (HTTP-supplied) patterns is carried forward to the REST ingestion slice #172; this core has no untrusted-input path.

Closes #168
Closes #169
Closes #177
