### PR TITLE
feat(decision): rule and immutable version storage (#170)

### DIFF
--- a/services/decision/build.gradle.kts
+++ b/services/decision/build.gradle.kts
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.spring)
+    alias(libs.plugins.kotlin.jpa)
+    alias(libs.plugins.spring.boot)
+    alias(libs.plugins.spring.dependency.management)
+}
+
+description = "FinCore Decision service: rule and immutable rule-version storage"
+
+kotlin {
+    jvmToolchain(21)
+}
+
+dependencies {
+    implementation(libs.kotlin.stdlib)
+    implementation(libs.kotlin.reflect)
+    implementation(libs.jackson.module.kotlin)
+
+    implementation(libs.spring.boot.starter.data.jpa)
+    implementation(libs.liquibase.core)
+    runtimeOnly(libs.postgres.jdbc)
+
+    testImplementation(project(":libs:fincore-test-support"))
+    testImplementation(libs.spring.boot.starter.test)
+    testImplementation(libs.kotest.assertions.core)
+    testImplementation(libs.kotest.runner.junit5)
+    testImplementation(libs.mockk)
+    testImplementation(libs.testcontainers.core)
+    testImplementation(libs.testcontainers.postgres)
+    testImplementation(libs.testcontainers.junit5)
+}
+
+tasks.test {
+    useJUnitPlatform()
+}
+
+// Integration tests (Spring Boot + Testcontainers) live in src/integrationTest,
+// kept in a separate source set and task so they run apart from fast unit tests.
+sourceSets {
+    create("integrationTest") {
+        compileClasspath += sourceSets["main"].output + sourceSets["test"].output
+        runtimeClasspath += sourceSets["main"].output + sourceSets["test"].output
+    }
+}
+
+configurations["integrationTestImplementation"].extendsFrom(configurations["testImplementation"])
+configurations["integrationTestRuntimeOnly"].extendsFrom(configurations["testRuntimeOnly"])
+
+dependencies {
+    "integrationTestImplementation"(libs.postgres.jdbc)
+}
+
+val integrationTest =
+    tasks.register<Test>("integrationTest") {
+        description = "Runs integration tests (Spring Boot + Testcontainers)."
+        group = "verification"
+        testClassesDirs = sourceSets["integrationTest"].output.classesDirs
+        classpath = sourceSets["integrationTest"].runtimeClasspath
+        useJUnitPlatform()
+        shouldRunAfter(tasks.named("test"))
+    }
+
+tasks.named("check") {
+    dependsOn(integrationTest)
+}

--- a/services/decision/src/integrationTest/kotlin/com/fincore/decision/store/persistence/DecisionRuleStoragePersistenceIT.kt
+++ b/services/decision/src/integrationTest/kotlin/com/fincore/decision/store/persistence/DecisionRuleStoragePersistenceIT.kt
@@ -1,0 +1,134 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.store.persistence
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fincore.test.containers.PostgresContainerExtension
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.orm.ObjectOptimisticLockingFailureException
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import java.sql.DriverManager
+import java.sql.SQLException
+import java.util.UUID
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ExtendWith(PostgresContainerExtension::class)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+class DecisionRuleStoragePersistenceIT(
+    @Autowired private val ruleRepository: DecisionRuleRepository,
+    @Autowired private val versionRepository: RuleVersionRepository,
+) {
+    private val mapper = ObjectMapper()
+    private val sampleDsl = """{"condition":{"attr":"amount","op":"gte","value":100},"outcome":{"label":"approve"}}"""
+
+    @Test
+    fun `should round trip a rule and its active version when persisted`() {
+        val rule = ruleRepository.save(newRule())
+        ruleRepository.findByRuleKey(rule.ruleKey).shouldNotBeNull().activeVersionId shouldBe null
+
+        val version = versionRepository.save(newVersion(rule.id, 1))
+        val loadedVersion = versionRepository.findByRuleId(rule.id).single()
+        mapper.readTree(loadedVersion.dsl) shouldBe mapper.readTree(sampleDsl)
+        loadedVersion.versionNo shouldBe 1
+
+        rule.activeVersionId = version.id
+        ruleRepository.save(rule)
+        ruleRepository.findById(rule.id).orElseThrow().activeVersionId shouldBe version.id
+    }
+
+    @Test
+    fun `should reject a duplicate version number for the same rule`() {
+        val rule = ruleRepository.save(newRule())
+        versionRepository.save(newVersion(rule.id, 1))
+        shouldThrow<DataIntegrityViolationException> {
+            versionRepository.save(newVersion(rule.id, 1))
+        }
+    }
+
+    @Test
+    fun `should reject update and delete on a persisted rule version`() {
+        val rule = ruleRepository.save(newRule())
+        val versionId = versionRepository.save(newVersion(rule.id, 1)).id
+        DriverManager
+            .getConnection(
+                PostgresContainerExtension.jdbcUrl,
+                PostgresContainerExtension.username,
+                PostgresContainerExtension.password,
+            ).use { connection ->
+                connection
+                    .prepareStatement("UPDATE decision.rule_versions SET version_no = version_no + 1 WHERE id = ?")
+                    .use { statement ->
+                        statement.setObject(1, versionId)
+                        shouldThrow<SQLException> { statement.executeUpdate() }.sqlState shouldBe "0A000"
+                    }
+                connection.prepareStatement("DELETE FROM decision.rule_versions WHERE id = ?").use { statement ->
+                    statement.setObject(1, versionId)
+                    shouldThrow<SQLException> { statement.executeUpdate() }.sqlState shouldBe "0A000"
+                }
+            }
+    }
+
+    @Test
+    fun `should raise optimistic lock failure on a stale rule update`() {
+        val saved = ruleRepository.save(newRule())
+        val stale = ruleRepository.findById(saved.id).orElseThrow()
+
+        bumpRuleVersion(saved.id)
+
+        stale.activeVersionId = UUID.randomUUID()
+        shouldThrow<ObjectOptimisticLockingFailureException> { ruleRepository.save(stale) }
+    }
+
+    private fun bumpRuleVersion(ruleId: UUID) {
+        DriverManager
+            .getConnection(
+                PostgresContainerExtension.jdbcUrl,
+                PostgresContainerExtension.username,
+                PostgresContainerExtension.password,
+            ).use { connection ->
+                connection.prepareStatement("UPDATE decision.decision_rules SET version = version + 1 WHERE id = ?").use { statement ->
+                    statement.setObject(1, ruleId)
+                    statement.executeUpdate()
+                }
+            }
+    }
+
+    @Test
+    fun `should report the max version number for a rule`() {
+        val rule = ruleRepository.save(newRule())
+        versionRepository.save(newVersion(rule.id, 1))
+        versionRepository.save(newVersion(rule.id, 2))
+        versionRepository.findMaxVersionNo(rule.id) shouldBe 2
+    }
+
+    private fun newRule(): DecisionRuleEntity = DecisionRuleEntity(id = UUID.randomUUID(), ruleKey = "rule-${UUID.randomUUID()}")
+
+    private fun newVersion(
+        ruleId: UUID,
+        versionNo: Int,
+    ): RuleVersionEntity = RuleVersionEntity(id = UUID.randomUUID(), ruleId = ruleId, versionNo = versionNo, dsl = sampleDsl)
+
+    companion object {
+        @JvmStatic
+        @DynamicPropertySource
+        fun datasourceProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { PostgresContainerExtension.jdbcUrl }
+            registry.add("spring.datasource.username") { PostgresContainerExtension.username }
+            registry.add("spring.datasource.password") { PostgresContainerExtension.password }
+            registry.add("spring.jpa.hibernate.ddl-auto") { "none" }
+        }
+    }
+}

--- a/services/decision/src/main/kotlin/com/fincore/decision/store/DecisionStoreApplication.kt
+++ b/services/decision/src/main/kotlin/com/fincore/decision/store/DecisionStoreApplication.kt
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.store
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+class DecisionStoreApplication
+
+fun main(args: Array<String>) {
+    runApplication<DecisionStoreApplication>(*args)
+}

--- a/services/decision/src/main/kotlin/com/fincore/decision/store/persistence/DecisionRuleEntity.kt
+++ b/services/decision/src/main/kotlin/com/fincore/decision/store/persistence/DecisionRuleEntity.kt
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.store.persistence
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import jakarta.persistence.Version
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(name = "decision_rules", schema = "decision")
+class DecisionRuleEntity(
+    @Id
+    @Column(name = "id", nullable = false, updatable = false)
+    val id: UUID,
+    @Column(name = "rule_key", nullable = false, updatable = false)
+    val ruleKey: String,
+    @Column(name = "active_version_id")
+    var activeVersionId: UUID? = null,
+    @Version
+    @Column(name = "version", nullable = false)
+    var version: Long? = null,
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: Instant? = null,
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: Instant? = null,
+)

--- a/services/decision/src/main/kotlin/com/fincore/decision/store/persistence/DecisionRuleRepository.kt
+++ b/services/decision/src/main/kotlin/com/fincore/decision/store/persistence/DecisionRuleRepository.kt
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.store.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface DecisionRuleRepository : JpaRepository<DecisionRuleEntity, UUID> {
+    fun findByRuleKey(ruleKey: String): DecisionRuleEntity?
+}

--- a/services/decision/src/main/kotlin/com/fincore/decision/store/persistence/RuleVersionEntity.kt
+++ b/services/decision/src/main/kotlin/com/fincore/decision/store/persistence/RuleVersionEntity.kt
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.store.persistence
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.Immutable
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Immutable
+@Table(name = "rule_versions", schema = "decision")
+class RuleVersionEntity(
+    @Id
+    @Column(name = "id", nullable = false, updatable = false)
+    val id: UUID,
+    @Column(name = "rule_id", nullable = false, updatable = false)
+    val ruleId: UUID,
+    @Column(name = "version_no", nullable = false, updatable = false)
+    val versionNo: Int,
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "dsl", nullable = false, updatable = false)
+    val dsl: String,
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: Instant? = null,
+)

--- a/services/decision/src/main/kotlin/com/fincore/decision/store/persistence/RuleVersionRepository.kt
+++ b/services/decision/src/main/kotlin/com/fincore/decision/store/persistence/RuleVersionRepository.kt
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.store.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.util.UUID
+
+interface RuleVersionRepository : JpaRepository<RuleVersionEntity, UUID> {
+    fun findByRuleId(ruleId: UUID): List<RuleVersionEntity>
+
+    @Query("select max(v.versionNo) from RuleVersionEntity v where v.ruleId = :ruleId")
+    fun findMaxVersionNo(
+        @Param("ruleId") ruleId: UUID,
+    ): Int?
+}

--- a/services/decision/src/main/resources/application.yml
+++ b/services/decision/src/main/resources/application.yml
@@ -1,0 +1,13 @@
+spring:
+  application:
+    name: decision-service
+  datasource:
+    url: ${SPRING_DATASOURCE_URL:jdbc:postgresql://localhost:5432/fincore}
+    username: ${SPRING_DATASOURCE_USERNAME:fincore}
+    password: ${SPRING_DATASOURCE_PASSWORD:fincore}
+  jpa:
+    hibernate:
+      ddl-auto: none
+    open-in-view: false
+  liquibase:
+    change-log: classpath:db/changelog/db.changelog-master.yaml

--- a/services/decision/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/decision/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,0 +1,15 @@
+# SPDX-License-Identifier: BUSL-1.1
+# SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+databaseChangeLog:
+  - include:
+      file: v0.2/001-decision-schema.sql
+      relativeToChangelogFile: true
+  - include:
+      file: v0.2/002-decision-rules.sql
+      relativeToChangelogFile: true
+  - include:
+      file: v0.2/003-rule-versions.sql
+      relativeToChangelogFile: true
+  - include:
+      file: v0.2/004-rule-versions-immutability.sql
+      relativeToChangelogFile: true

--- a/services/decision/src/main/resources/db/changelog/v0.2/001-decision-schema.sql
+++ b/services/decision/src/main/resources/db/changelog/v0.2/001-decision-schema.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+-- SPDX-License-Identifier: BUSL-1.1
+-- SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+--changeset fincore:001-decision-schema dbms:postgresql
+CREATE SCHEMA IF NOT EXISTS decision;

--- a/services/decision/src/main/resources/db/changelog/v0.2/002-decision-rules.sql
+++ b/services/decision/src/main/resources/db/changelog/v0.2/002-decision-rules.sql
@@ -1,0 +1,15 @@
+--liquibase formatted sql
+-- SPDX-License-Identifier: BUSL-1.1
+-- SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+--changeset fincore:002-decision-rules dbms:postgresql
+CREATE TABLE IF NOT EXISTS decision.decision_rules (
+    id                UUID         NOT NULL DEFAULT gen_random_uuid(),
+    rule_key          VARCHAR(128) NOT NULL,
+    active_version_id UUID,
+    version           BIGINT       NOT NULL DEFAULT 0,
+    created_at        TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    updated_at        TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    CONSTRAINT pk_decision_rules PRIMARY KEY (id),
+    CONSTRAINT uq_decision_rules_rule_key UNIQUE (rule_key)
+);

--- a/services/decision/src/main/resources/db/changelog/v0.2/003-rule-versions.sql
+++ b/services/decision/src/main/resources/db/changelog/v0.2/003-rule-versions.sql
@@ -1,0 +1,32 @@
+--liquibase formatted sql
+-- SPDX-License-Identifier: BUSL-1.1
+-- SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+--changeset fincore:003-rule-versions dbms:postgresql
+CREATE TABLE IF NOT EXISTS decision.rule_versions (
+    id          UUID        NOT NULL DEFAULT gen_random_uuid(),
+    rule_id     UUID        NOT NULL,
+    version_no  INTEGER     NOT NULL,
+    dsl         JSONB       NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT pk_rule_versions PRIMARY KEY (id),
+    CONSTRAINT fk_rule_versions_rule
+        FOREIGN KEY (rule_id) REFERENCES decision.decision_rules(id),
+    CONSTRAINT uq_rule_versions_rule_version UNIQUE (rule_id, version_no)
+);
+CREATE INDEX IF NOT EXISTS idx_rule_versions_rule
+    ON decision.rule_versions(rule_id);
+
+--changeset fincore:003-decision-rules-active-version-fk dbms:postgresql runOnChange:true splitStatements:false
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint
+        WHERE conname = 'fk_decision_rules_active_version'
+          AND conrelid = 'decision.decision_rules'::regclass
+    ) THEN
+        ALTER TABLE decision.decision_rules
+            ADD CONSTRAINT fk_decision_rules_active_version
+            FOREIGN KEY (active_version_id) REFERENCES decision.rule_versions(id);
+    END IF;
+END $$;

--- a/services/decision/src/main/resources/db/changelog/v0.2/004-rule-versions-immutability.sql
+++ b/services/decision/src/main/resources/db/changelog/v0.2/004-rule-versions-immutability.sql
@@ -1,0 +1,20 @@
+--liquibase formatted sql
+-- SPDX-License-Identifier: BUSL-1.1
+-- SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+--changeset fincore:004-rule-versions-immutability-fn dbms:postgresql runOnChange:true splitStatements:false
+CREATE OR REPLACE FUNCTION decision.reject_rule_version_mutation()
+RETURNS TRIGGER AS $$
+BEGIN
+    RAISE EXCEPTION
+        'decision.rule_versions is append-only: % is not permitted', TG_OP
+        USING ERRCODE = '0A000';
+END;
+$$ LANGUAGE plpgsql;
+
+--changeset fincore:004-rule-versions-immutability-trigger dbms:postgresql
+DROP TRIGGER IF EXISTS trg_rule_versions_immutable ON decision.rule_versions;
+CREATE TRIGGER trg_rule_versions_immutable
+    BEFORE UPDATE OR DELETE ON decision.rule_versions
+    FOR EACH ROW
+    EXECUTE FUNCTION decision.reject_rule_version_mutation();

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,4 +26,5 @@ include(
     ":libs:fincore-test-support",
     ":libs:decision-engine",
     ":services:ledger",
+    ":services:decision",
 )


### PR DESCRIPTION
Second slice of E-05 Decision Engine (#163). New storage-only module `services/decision`.

## What
- `decision` schema: `decision_rules` (mutable aggregate, optimistic-locked active-version pointer) and `rule_versions` (append-only, monotonic `version_no`, JSONB `dsl`).
- Rule versions are immutable at the database level via a `BEFORE UPDATE OR DELETE` trigger (SQLSTATE `0A000`), not only JPA `@Immutable`.
- Idempotent Liquibase formatted SQL; the cyclic active-version FK added in a separate guarded (`pg_constraint`, schema-qualified) changeset.
- JPA entities with a nullable `@Version` so Spring Data persists new aggregates and merges existing ones with a real optimistic-lock check; `@CreationTimestamp`/`@UpdateTimestamp` for timestamps.
- Module scoped to data-jpa + liquibase + postgres only (no web/security/openapi).

## Tests
`@DataJpaTest` + Testcontainers IT (`@Transactional(NOT_SUPPORTED)` for real commit boundaries): round-trip + null active pointer, duplicate `version_no` rejection, append-only enforcement via raw JDBC (asserts `0A000`), stale-update optimistic lock, max version lookup. JSONB compared as a tree. integrationTest runs on CI (no Docker locally).

## Gate-chain
analyst spec -> critic GO-WITH-CHANGES (6 must-fixes applied) -> code-reviewer REQUEST-CHANGES (fixed: nullable @Version persist/merge + optimistic-lock correctness, schema-qualified cyclic-FK guard, val immutability) -> security-auditor PASS -> evaluator ~0.90.

Closes #170
