### PR TITLE
feat(decision): add partitioned append-only decision log storage

### DIFF
--- a/services/decision/src/integrationTest/kotlin/com/fincore/decision/store/persistence/DecisionLogPersistenceIT.kt
+++ b/services/decision/src/integrationTest/kotlin/com/fincore/decision/store/persistence/DecisionLogPersistenceIT.kt
@@ -1,0 +1,233 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.store.persistence
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fincore.test.containers.PostgresContainerExtension
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import java.security.MessageDigest
+import java.sql.Connection
+import java.sql.DriverManager
+import java.sql.SQLException
+import java.time.Instant
+import java.util.UUID
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@ExtendWith(PostgresContainerExtension::class)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+class DecisionLogPersistenceIT(
+    @Autowired private val ruleRepository: DecisionRuleRepository,
+    @Autowired private val versionRepository: RuleVersionRepository,
+    @Autowired private val logRepository: DecisionLogRepository,
+) {
+    private val mapper = ObjectMapper()
+    private val seededInstant = Instant.parse("2026-06-15T12:00:00Z")
+    private val unseededInstant = Instant.parse("2030-03-10T08:00:00Z")
+    private val sampleDsl = """{"condition":{"attr":"amount","op":"gte","value":100},"outcome":{"label":"approve"}}"""
+
+    @Test
+    fun `should round trip a matched decision log when persisted`() {
+        val versionId = seedRuleVersion()
+        val reasonCodes = """["LOW_RISK","KNOWN_CUSTOMER"]"""
+        val trace = """[{"node":"comparison","attr":"amount","result":true}]"""
+        val saved =
+            logRepository.save(
+                matchedLog(versionId, outcomeLabel = "approve", reasonCodes = reasonCodes, trace = trace),
+            )
+
+        val loaded = logRepository.findById(saved.id).orElseThrow()
+        loaded.matched shouldBe true
+        loaded.outcomeLabel shouldBe "approve"
+        mapper.readTree(loaded.reasonCodes) shouldBe mapper.readTree(reasonCodes)
+        mapper.readTree(loaded.trace) shouldBe mapper.readTree(trace)
+        loaded.createdAt.shouldNotBeNull()
+    }
+
+    @Test
+    fun `should store a non matching decision with null outcome when persisted`() {
+        val versionId = seedRuleVersion()
+        val trace = """[{"node":"comparison","attr":"amount","result":false}]"""
+        val saved = logRepository.save(unmatchedLog(versionId, trace = trace))
+
+        val loaded = logRepository.findById(saved.id).orElseThrow()
+        loaded.matched shouldBe false
+        loaded.outcomeLabel shouldBe null
+        loaded.reasonCodes shouldBe null
+        mapper.readTree(loaded.trace) shouldBe mapper.readTree(trace)
+        reasonCodesIsSqlNull(saved.id) shouldBe true
+    }
+
+    @Test
+    fun `should reject update and delete on a persisted decision log`() {
+        val versionId = seedRuleVersion()
+        val named = logRepository.save(matchedLog(versionId, evaluatedAt = seededInstant))
+        val default = logRepository.save(matchedLog(versionId, evaluatedAt = unseededInstant))
+
+        withConnection { connection ->
+            assertImmutable(connection, named.id)
+            assertImmutable(connection, default.id)
+        }
+    }
+
+    @Test
+    fun `should reject a non matching decision that carries an outcome label`() {
+        val versionId = seedRuleVersion()
+        withConnection { connection ->
+            shouldThrow<SQLException> {
+                insertRaw(connection, versionId, matched = false, outcomeLabel = "approve")
+            }.sqlState shouldBe CHECK_VIOLATION
+            shouldThrow<SQLException> {
+                insertRaw(connection, versionId, matched = true, outcomeLabel = null)
+            }.sqlState shouldBe CHECK_VIOLATION
+        }
+    }
+
+    @Test
+    fun `should reject an input hash that is not sha256 hex`() {
+        val versionId = seedRuleVersion()
+        withConnection { connection ->
+            shouldThrow<SQLException> {
+                insertRaw(connection, versionId, matched = true, outcomeLabel = "approve", inputHash = "g".repeat(SHA256_HEX_LENGTH))
+            }.sqlState shouldBe CHECK_VIOLATION
+        }
+    }
+
+    @Test
+    fun `should store a decision whose month has no seeded partition`() {
+        val versionId = seedRuleVersion()
+        val hash = sha256Hex("unseeded-${UUID.randomUUID()}")
+        logRepository.save(matchedLog(versionId, evaluatedAt = unseededInstant, inputHash = hash))
+
+        logRepository.findByInputHash(hash).single().evaluatedAt shouldBe unseededInstant
+    }
+
+    private fun seedRuleVersion(): UUID {
+        val rule = ruleRepository.save(DecisionRuleEntity(id = UUID.randomUUID(), ruleKey = "rule-${UUID.randomUUID()}"))
+        return versionRepository.save(RuleVersionEntity(id = UUID.randomUUID(), ruleId = rule.id, versionNo = 1, dsl = sampleDsl)).id
+    }
+
+    private fun matchedLog(
+        versionId: UUID,
+        evaluatedAt: Instant = seededInstant,
+        outcomeLabel: String = "approve",
+        reasonCodes: String? = null,
+        trace: String = "[]",
+        inputHash: String = sha256Hex(UUID.randomUUID().toString()),
+    ): DecisionLogEntity =
+        DecisionLogEntity(
+            id = UUID.randomUUID(),
+            evaluatedAt = evaluatedAt,
+            ruleVersionId = versionId,
+            inputHash = inputHash,
+            matched = true,
+            outcomeLabel = outcomeLabel,
+            reasonCodes = reasonCodes,
+            trace = trace,
+        )
+
+    private fun unmatchedLog(
+        versionId: UUID,
+        trace: String = "[]",
+    ): DecisionLogEntity =
+        DecisionLogEntity(
+            id = UUID.randomUUID(),
+            evaluatedAt = seededInstant,
+            ruleVersionId = versionId,
+            inputHash = sha256Hex(UUID.randomUUID().toString()),
+            matched = false,
+            trace = trace,
+        )
+
+    private fun assertImmutable(
+        connection: Connection,
+        id: UUID,
+    ) {
+        connection.prepareStatement("UPDATE decision.decision_logs SET input_hash = input_hash WHERE id = ?").use { statement ->
+            statement.setObject(1, id)
+            shouldThrow<SQLException> { statement.executeUpdate() }.sqlState shouldBe APPEND_ONLY
+        }
+        connection.prepareStatement("DELETE FROM decision.decision_logs WHERE id = ?").use { statement ->
+            statement.setObject(1, id)
+            shouldThrow<SQLException> { statement.executeUpdate() }.sqlState shouldBe APPEND_ONLY
+        }
+    }
+
+    @Suppress("MagicNumber") // positional JDBC parameter indices
+    private fun insertRaw(
+        connection: Connection,
+        versionId: UUID,
+        matched: Boolean,
+        outcomeLabel: String?,
+        inputHash: String = sha256Hex(UUID.randomUUID().toString()),
+    ) {
+        val sql =
+            "INSERT INTO decision.decision_logs " +
+                "(evaluated_at, rule_version_id, input_hash, matched, outcome_label, trace) " +
+                "VALUES (?::timestamptz, ?, ?, ?, ?, ?::jsonb)"
+        connection.prepareStatement(sql).use { statement ->
+            statement.setString(1, seededInstant.toString())
+            statement.setObject(2, versionId)
+            statement.setString(3, inputHash)
+            statement.setBoolean(4, matched)
+            statement.setString(5, outcomeLabel)
+            statement.setString(6, "[]")
+            statement.executeUpdate()
+        }
+    }
+
+    private fun reasonCodesIsSqlNull(id: UUID): Boolean =
+        withConnection { connection ->
+            connection.prepareStatement("SELECT reason_codes IS NULL FROM decision.decision_logs WHERE id = ?").use { statement ->
+                statement.setObject(1, id)
+                statement.executeQuery().use { rs ->
+                    check(rs.next()) { "no decision log row for id=$id" }
+                    rs.getBoolean(1)
+                }
+            }
+        }
+
+    private fun <T> withConnection(block: (Connection) -> T): T =
+        DriverManager
+            .getConnection(
+                PostgresContainerExtension.jdbcUrl,
+                PostgresContainerExtension.username,
+                PostgresContainerExtension.password,
+            ).use { connection ->
+                connection.autoCommit = true
+                block(connection)
+            }
+
+    companion object {
+        private const val APPEND_ONLY = "0A000"
+        private const val CHECK_VIOLATION = "23514"
+        private const val SHA256_HEX_LENGTH = 64
+
+        private fun sha256Hex(value: String): String =
+            MessageDigest
+                .getInstance("SHA-256")
+                .digest(value.toByteArray())
+                .joinToString("") { "%02x".format(it) }
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun datasourceProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { PostgresContainerExtension.jdbcUrl }
+            registry.add("spring.datasource.username") { PostgresContainerExtension.username }
+            registry.add("spring.datasource.password") { PostgresContainerExtension.password }
+            registry.add("spring.jpa.hibernate.ddl-auto") { "none" }
+        }
+    }
+}

--- a/services/decision/src/main/kotlin/com/fincore/decision/store/persistence/DecisionLogEntity.kt
+++ b/services/decision/src/main/kotlin/com/fincore/decision/store/persistence/DecisionLogEntity.kt
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.store.persistence
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.Immutable
+import org.hibernate.annotations.JdbcTypeCode
+import org.hibernate.type.SqlTypes
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Immutable
+@Table(name = "decision_logs", schema = "decision")
+@Suppress("LongParameterList")
+class DecisionLogEntity(
+    @Id
+    @Column(name = "id", nullable = false, updatable = false)
+    val id: UUID,
+    @Column(name = "evaluated_at", nullable = false, updatable = false)
+    val evaluatedAt: Instant,
+    @Column(name = "rule_version_id", nullable = false, updatable = false)
+    val ruleVersionId: UUID,
+    @Column(name = "input_hash", nullable = false, updatable = false)
+    val inputHash: String,
+    @Column(name = "matched", nullable = false, updatable = false)
+    val matched: Boolean,
+    @Column(name = "outcome_label", updatable = false)
+    val outcomeLabel: String? = null,
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "reason_codes", updatable = false)
+    val reasonCodes: String? = null,
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "trace", nullable = false, updatable = false)
+    val trace: String,
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: Instant? = null,
+)

--- a/services/decision/src/main/kotlin/com/fincore/decision/store/persistence/DecisionLogRepository.kt
+++ b/services/decision/src/main/kotlin/com/fincore/decision/store/persistence/DecisionLogRepository.kt
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.store.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface DecisionLogRepository : JpaRepository<DecisionLogEntity, UUID> {
+    fun findByRuleVersionId(ruleVersionId: UUID): List<DecisionLogEntity>
+
+    fun findByInputHash(inputHash: String): List<DecisionLogEntity>
+}

--- a/services/decision/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/decision/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -13,3 +13,9 @@ databaseChangeLog:
   - include:
       file: v0.2/004-rule-versions-immutability.sql
       relativeToChangelogFile: true
+  - include:
+      file: v0.2/005-decision-logs.sql
+      relativeToChangelogFile: true
+  - include:
+      file: v0.2/006-decision-logs-immutability.sql
+      relativeToChangelogFile: true

--- a/services/decision/src/main/resources/db/changelog/v0.2/005-decision-logs.sql
+++ b/services/decision/src/main/resources/db/changelog/v0.2/005-decision-logs.sql
@@ -1,0 +1,48 @@
+--liquibase formatted sql
+-- SPDX-License-Identifier: BUSL-1.1
+-- SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+--changeset fincore:005-decision-logs dbms:postgresql
+CREATE TABLE IF NOT EXISTS decision.decision_logs (
+    id              UUID        NOT NULL DEFAULT gen_random_uuid(),
+    evaluated_at    TIMESTAMPTZ NOT NULL,
+    rule_version_id UUID        NOT NULL,
+    input_hash      VARCHAR(64) NOT NULL,
+    matched         BOOLEAN     NOT NULL,
+    outcome_label   VARCHAR(128),
+    reason_codes    JSONB,
+    trace           JSONB       NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT pk_decision_logs PRIMARY KEY (id, evaluated_at),
+    CONSTRAINT fk_decision_logs_rule_version
+        FOREIGN KEY (rule_version_id) REFERENCES decision.rule_versions(id) ON DELETE RESTRICT,
+    CONSTRAINT ck_decision_logs_input_hash CHECK (input_hash ~ '^[0-9a-f]{64}$'),
+    CONSTRAINT ck_decision_logs_outcome CHECK (
+        (matched AND outcome_label IS NOT NULL)
+        OR (NOT matched AND outcome_label IS NULL AND reason_codes IS NULL)
+    )
+) PARTITION BY RANGE (evaluated_at);
+
+CREATE TABLE IF NOT EXISTS decision.decision_logs_2026_06 PARTITION OF decision.decision_logs
+    FOR VALUES FROM ('2026-06-01') TO ('2026-07-01');
+CREATE TABLE IF NOT EXISTS decision.decision_logs_2026_07 PARTITION OF decision.decision_logs
+    FOR VALUES FROM ('2026-07-01') TO ('2026-08-01');
+CREATE TABLE IF NOT EXISTS decision.decision_logs_2026_08 PARTITION OF decision.decision_logs
+    FOR VALUES FROM ('2026-08-01') TO ('2026-09-01');
+CREATE TABLE IF NOT EXISTS decision.decision_logs_2026_09 PARTITION OF decision.decision_logs
+    FOR VALUES FROM ('2026-09-01') TO ('2026-10-01');
+CREATE TABLE IF NOT EXISTS decision.decision_logs_2026_10 PARTITION OF decision.decision_logs
+    FOR VALUES FROM ('2026-10-01') TO ('2026-11-01');
+CREATE TABLE IF NOT EXISTS decision.decision_logs_2026_11 PARTITION OF decision.decision_logs
+    FOR VALUES FROM ('2026-11-01') TO ('2026-12-01');
+CREATE TABLE IF NOT EXISTS decision.decision_logs_2026_12 PARTITION OF decision.decision_logs
+    FOR VALUES FROM ('2026-12-01') TO ('2027-01-01');
+CREATE TABLE IF NOT EXISTS decision.decision_logs_2027_01 PARTITION OF decision.decision_logs
+    FOR VALUES FROM ('2027-01-01') TO ('2027-02-01');
+
+CREATE TABLE IF NOT EXISTS decision.decision_logs_default PARTITION OF decision.decision_logs DEFAULT;
+
+CREATE INDEX IF NOT EXISTS idx_decision_logs_rule_version
+    ON decision.decision_logs(rule_version_id, evaluated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_decision_logs_input_hash
+    ON decision.decision_logs(input_hash);

--- a/services/decision/src/main/resources/db/changelog/v0.2/006-decision-logs-immutability.sql
+++ b/services/decision/src/main/resources/db/changelog/v0.2/006-decision-logs-immutability.sql
@@ -1,0 +1,20 @@
+--liquibase formatted sql
+-- SPDX-License-Identifier: BUSL-1.1
+-- SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+--changeset fincore:006-decision-logs-immutability-fn dbms:postgresql runOnChange:true splitStatements:false
+CREATE OR REPLACE FUNCTION decision.reject_decision_log_mutation()
+RETURNS TRIGGER AS $$
+BEGIN
+    RAISE EXCEPTION
+        'decision.decision_logs is append-only: % is not permitted', TG_OP
+        USING ERRCODE = '0A000';
+END;
+$$ LANGUAGE plpgsql;
+
+--changeset fincore:006-decision-logs-immutability-trigger dbms:postgresql
+DROP TRIGGER IF EXISTS trg_decision_logs_immutable ON decision.decision_logs;
+CREATE TRIGGER trg_decision_logs_immutable
+    BEFORE UPDATE OR DELETE ON decision.decision_logs
+    FOR EACH ROW
+    EXECUTE FUNCTION decision.reject_decision_log_mutation();


### PR DESCRIPTION
## What

Adds `decision.decision_logs`: a month range-partitioned, append-only audit table for the Decision Engine (#163, E-05), with its JPA mapping and a Testcontainers integration test. Storage-only slice on `services/decision`, mirroring the merged rule-storage slice (#170).

## Schema (`005`, `006`)

- `decision.decision_logs` partitioned `BY RANGE (evaluated_at)`, PK `(id, evaluated_at)`, with 8 seeded monthly partitions (2026-06 .. 2027-01) plus a `DEFAULT` catch-all so a decision is never lost to a missing month partition.
- FK `rule_version_id -> decision.rule_versions(id) ON DELETE RESTRICT` (references the immutable, append-only versions).
- `CHECK` totality: `matched` implies an `outcome_label`; not-matched implies no `outcome_label` and no `reason_codes`.
- `CHECK` input-hash shape: `^[0-9a-f]{64}$` (a SHA-256 hex digest; storage enforces shape only).
- Append-only immutability trigger raising SQLSTATE `0A000` on `UPDATE`/`DELETE`, on the partitioned parent so it cascades to every partition incl. default. Whole-partition `DROP` for 7-year retention stays possible (DDL does not fire row triggers).
- All DDL idempotent (`IF NOT EXISTS`, `CREATE OR REPLACE`, `DROP TRIGGER IF EXISTS; CREATE`).

## Mapping

- `DecisionLogEntity` (`class`, `@Immutable`, insert-only, no `@Version`), JSONB `trace`/`reason_codes` via `@JdbcTypeCode(SqlTypes.JSON)`.
- `DecisionLogRepository` with `findByRuleVersionId`, `findByInputHash`.

## Tests

`DecisionLogPersistenceIT` (`@DataJpaTest` + Testcontainers, CI-only): round-trip with JSONB tree-equality, non-matched null-outcome with an explicit SQL-NULL assertion, immutability on a named AND the default partition, the totality check both directions, the hash-shape check (64-char invalid-hex fixture), and unseeded-month routing. The valid input hash is computed at runtime via `MessageDigest` (no hardcoded hex digest).

## Out of scope

REST `/evaluate` (#172, including the ReDoS guard), replay (#173), the scheduled retention partition-drop job (an ops slice). No new ADR.

Closes #171