### PR TITLE
feat(decision): add rule management rest api with oauth2 scopes

### DIFF
--- a/services/decision/build.gradle.kts
+++ b/services/decision/build.gradle.kts
@@ -9,23 +9,30 @@ plugins {
     alias(libs.plugins.spring.dependency.management)
 }
 
-description = "FinCore Decision service: rule and immutable rule-version storage"
+description = "FinCore Decision service: rule storage and rule management REST API"
 
 kotlin {
     jvmToolchain(21)
 }
 
 dependencies {
+    implementation(project(":libs:decision-engine"))
     implementation(libs.kotlin.stdlib)
     implementation(libs.kotlin.reflect)
     implementation(libs.jackson.module.kotlin)
 
     implementation(libs.spring.boot.starter.data.jpa)
+    implementation(libs.spring.boot.starter.web)
+    implementation(libs.spring.boot.starter.validation)
+    implementation(libs.spring.boot.starter.security)
+    implementation(libs.spring.boot.starter.oauth2.resource.server)
+    implementation(libs.springdoc.openapi.starter)
     implementation(libs.liquibase.core)
     runtimeOnly(libs.postgres.jdbc)
 
     testImplementation(project(":libs:fincore-test-support"))
     testImplementation(libs.spring.boot.starter.test)
+    testImplementation(libs.spring.security.test)
     testImplementation(libs.kotest.assertions.core)
     testImplementation(libs.kotest.runner.junit5)
     testImplementation(libs.mockk)

--- a/services/decision/src/integrationTest/kotlin/com/fincore/decision/store/api/DecisionRuleApiIT.kt
+++ b/services/decision/src/integrationTest/kotlin/com/fincore/decision/store/api/DecisionRuleApiIT.kt
@@ -1,0 +1,174 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.store.api
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fincore.decision.store.persistence.RuleVersionRepository
+import com.fincore.test.containers.PostgresContainerExtension
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.ints.shouldBeGreaterThan
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.boot.test.web.client.TestRestTemplate
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.http.HttpEntity
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpMethod
+import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatusCode
+import org.springframework.http.MediaType
+import org.springframework.security.oauth2.jwt.Jwt
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ExtendWith(PostgresContainerExtension::class)
+@Import(DecisionRuleApiIT.TestSecurity::class)
+class DecisionRuleApiIT(
+    @Autowired private val rest: TestRestTemplate,
+    @Autowired private val objectMapper: ObjectMapper,
+    @Autowired private val versionRepository: RuleVersionRepository,
+) {
+    private val dsl = """{"condition":{"attr":"amount","op":"gte","value":100},"outcome":{"label":"approve"}}"""
+
+    @TestConfiguration
+    class TestSecurity {
+        @Bean
+        fun jwtDecoder(): JwtDecoder =
+            JwtDecoder { token ->
+                val scope = if (token == WRITER) "decision:read decision:write" else "decision:read"
+                Jwt
+                    .withTokenValue(token)
+                    .header("alg", "none")
+                    .subject("api-user")
+                    .claim("scope", scope)
+                    .issuedAt(Instant.now())
+                    .expiresAt(Instant.now().plusSeconds(EXPIRY_SECONDS))
+                    .build()
+            }
+    }
+
+    @Test
+    fun `should serve the openapi document with the decision rule operations`() {
+        val response = rest.getForEntity("/v3/api-docs", String::class.java)
+        response.statusCode shouldBe HttpStatus.OK
+        response.body.orEmpty() shouldContain "/v1/decision/rules"
+    }
+
+    @Test
+    fun `should reject an unauthenticated read with 401`() {
+        rest.getForEntity("/v1/decision/rules/anything", String::class.java).statusCode shouldBe HttpStatus.UNAUTHORIZED
+    }
+
+    @Test
+    fun `should reject a publish carrying only the read scope with 403`() {
+        val key = newKey()
+        createRule(key)
+        val response = rest.exchange(versionsUrl(key), HttpMethod.POST, HttpEntity(dsl, headers(READER)), String::class.java)
+        response.statusCode shouldBe HttpStatus.FORBIDDEN
+    }
+
+    @Test
+    fun `should publish versions monotonically and move the active pointer when republished`() {
+        val key = newKey()
+        createRule(key)
+
+        publishVersion(key).statusCode shouldBe HttpStatus.CREATED
+        readActiveVersionNo(key) shouldBe 1
+        publishVersion(key).statusCode shouldBe HttpStatus.CREATED
+        readActiveVersionNo(key) shouldBe 2
+    }
+
+    @Test
+    fun `should assign one version number per concurrent publish and never return 500`() {
+        val key = newKey()
+        val ruleId = createRule(key)
+        val statuses = publishConcurrently(key)
+
+        // Every concurrent publish is a typed outcome: 201 success, 409 duplicate version_no, or 503
+        // optimistic-lock retry on the active pointer. Never a 500. The unique (rule_id, version_no) and the
+        // @Version pointer lock are the guards, so stored versions equal the successes and are all distinct.
+        statuses.none { it == HttpStatus.INTERNAL_SERVER_ERROR } shouldBe true
+        statuses.all { it in TYPED_OUTCOMES } shouldBe true
+        statuses shouldContain HttpStatus.CREATED
+        val versions = versionRepository.findByRuleId(ruleId)
+        versions.map { it.versionNo }.toSet().size shouldBe versions.size
+        versions.size shouldBe statuses.count { it == HttpStatus.CREATED }
+        versions.size shouldBeGreaterThan 0
+    }
+
+    private fun publishConcurrently(key: String): List<HttpStatusCode> {
+        val pool = Executors.newFixedThreadPool(THREADS)
+        val start = CountDownLatch(1)
+        val tasks =
+            (1..THREADS).map {
+                pool.submit<HttpStatusCode> {
+                    start.await()
+                    publishVersion(key).statusCode
+                }
+            }
+        start.countDown()
+        val statuses = tasks.map { it.get(TASK_TIMEOUT_SECONDS, TimeUnit.SECONDS) }
+        pool.shutdown()
+        return statuses
+    }
+
+    private fun createRule(key: String): UUID {
+        val response = rest.postForEntity("/v1/decision/rules", HttpEntity("""{"ruleKey":"$key"}""", headers(WRITER)), String::class.java)
+        response.statusCode shouldBe HttpStatus.CREATED
+        return UUID.fromString(objectMapper.readTree(response.body).get("id").asText())
+    }
+
+    private fun publishVersion(key: String) = rest.postForEntity(versionsUrl(key), HttpEntity(dsl, headers(WRITER)), String::class.java)
+
+    private fun readActiveVersionNo(key: String): Int {
+        val response = rest.exchange("/v1/decision/rules/$key", HttpMethod.GET, HttpEntity<Unit>(headers(READER)), String::class.java)
+        response.statusCode shouldBe HttpStatus.OK
+        return objectMapper
+            .readTree(response.body)
+            .get("activeVersion")
+            .get("versionNo")
+            .asInt()
+    }
+
+    private fun headers(token: String): HttpHeaders =
+        HttpHeaders().apply {
+            contentType = MediaType.APPLICATION_JSON
+            setBearerAuth(token)
+        }
+
+    private fun versionsUrl(key: String): String = "/v1/decision/rules/$key/versions"
+
+    private fun newKey(): String = "rule-${UUID.randomUUID()}"
+
+    companion object {
+        private val TYPED_OUTCOMES = setOf(HttpStatus.CREATED, HttpStatus.CONFLICT, HttpStatus.SERVICE_UNAVAILABLE)
+        private const val WRITER = "writer"
+        private const val READER = "reader"
+        private const val THREADS = 6
+        private const val EXPIRY_SECONDS = 300L
+        private const val TASK_TIMEOUT_SECONDS = 20L
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun datasourceProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { PostgresContainerExtension.jdbcUrl }
+            registry.add("spring.datasource.username") { PostgresContainerExtension.username }
+            registry.add("spring.datasource.password") { PostgresContainerExtension.password }
+            registry.add("spring.jpa.hibernate.ddl-auto") { "none" }
+        }
+    }
+}

--- a/services/decision/src/main/kotlin/com/fincore/decision/store/api/DecisionRuleController.kt
+++ b/services/decision/src/main/kotlin/com/fincore/decision/store/api/DecisionRuleController.kt
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.store.api
+
+import com.fincore.decision.store.api.dto.request.CreateRuleRequest
+import com.fincore.decision.store.api.dto.response.RuleDetailResponse
+import com.fincore.decision.store.api.dto.response.RuleResponse
+import com.fincore.decision.store.api.dto.response.VersionResponse
+import com.fincore.decision.store.api.mapper.DecisionApiMapper
+import com.fincore.decision.store.application.RuleAdminService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.net.URI
+
+@Tag(name = "Decision rules", description = "Create rules, publish immutable rule versions, and read them")
+@RestController
+@RequestMapping("/v1/decision/rules")
+class DecisionRuleController(
+    private val ruleAdminService: RuleAdminService,
+    private val mapper: DecisionApiMapper,
+) {
+    @Operation(summary = "Create a decision rule", description = "Creates a named rule with no active version yet.")
+    @PostMapping
+    fun create(
+        @Valid @RequestBody request: CreateRuleRequest,
+    ): ResponseEntity<RuleResponse> {
+        val response = mapper.toResponse(ruleAdminService.createRule(request.ruleKey))
+        return ResponseEntity.created(URI.create("/v1/decision/rules/${response.ruleKey}")).body(response)
+    }
+
+    // No Idempotency-Key here by design: versions are append-only and monotonic, so a retried publish creates
+    // a new, immutable version rather than corrupting state. The full idempotency subsystem is a later slice.
+    @Operation(summary = "Publish a rule version", description = "Validates the DSL document and stores it as the new active version.")
+    @PostMapping("/{ruleKey}/versions", consumes = [MediaType.APPLICATION_JSON_VALUE])
+    fun publishVersion(
+        @PathVariable ruleKey: String,
+        @RequestBody dslJson: String,
+    ): ResponseEntity<VersionResponse> {
+        val response = mapper.toResponse(ruleAdminService.publishVersion(ruleKey, dslJson))
+        return ResponseEntity.created(URI.create("/v1/decision/rules/$ruleKey")).body(response)
+    }
+
+    @Operation(summary = "Get a decision rule", description = "Returns the rule and its active version DSL, or 404.")
+    @GetMapping("/{ruleKey}")
+    fun get(
+        @PathVariable ruleKey: String,
+    ): RuleDetailResponse = mapper.toDetail(ruleAdminService.getRule(ruleKey))
+}

--- a/services/decision/src/main/kotlin/com/fincore/decision/store/api/dto/request/CreateRuleRequest.kt
+++ b/services/decision/src/main/kotlin/com/fincore/decision/store/api/dto/request/CreateRuleRequest.kt
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.store.api.dto.request
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
+
+data class CreateRuleRequest(
+    @field:NotBlank
+    @field:Size(min = 1, max = 128)
+    @field:Pattern(regexp = "^[A-Za-z0-9_.:-]+$")
+    val ruleKey: String,
+)

--- a/services/decision/src/main/kotlin/com/fincore/decision/store/api/dto/response/RuleDetailResponse.kt
+++ b/services/decision/src/main/kotlin/com/fincore/decision/store/api/dto/response/RuleDetailResponse.kt
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.store.api.dto.response
+
+import com.fasterxml.jackson.databind.JsonNode
+
+data class RuleDetailResponse(
+    val id: String,
+    val ruleKey: String,
+    val activeVersion: ActiveVersionResponse?,
+)
+
+data class ActiveVersionResponse(
+    val versionNo: Int,
+    val dsl: JsonNode,
+)

--- a/services/decision/src/main/kotlin/com/fincore/decision/store/api/dto/response/RuleResponse.kt
+++ b/services/decision/src/main/kotlin/com/fincore/decision/store/api/dto/response/RuleResponse.kt
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.store.api.dto.response
+
+data class RuleResponse(
+    val id: String,
+    val ruleKey: String,
+)

--- a/services/decision/src/main/kotlin/com/fincore/decision/store/api/dto/response/VersionResponse.kt
+++ b/services/decision/src/main/kotlin/com/fincore/decision/store/api/dto/response/VersionResponse.kt
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.store.api.dto.response
+
+data class VersionResponse(
+    val id: String,
+    val versionNo: Int,
+)

--- a/services/decision/src/main/kotlin/com/fincore/decision/store/api/error/ProblemType.kt
+++ b/services/decision/src/main/kotlin/com/fincore/decision/store/api/error/ProblemType.kt
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.store.api.error
+
+import org.springframework.http.HttpStatus
+import java.net.URI
+
+enum class ProblemType(
+    val slug: String,
+    val status: HttpStatus,
+    val code: String,
+    val title: String,
+) {
+    RULE_NOT_FOUND("rule-not-found", HttpStatus.NOT_FOUND, "RULE_NOT_FOUND", "rule not found"),
+    DUPLICATE_RULE_KEY("duplicate-rule-key", HttpStatus.CONFLICT, "DUPLICATE_RULE_KEY", "rule key already exists"),
+    INVALID_DSL("invalid-dsl", HttpStatus.UNPROCESSABLE_ENTITY, "INVALID_DSL", "invalid decision rule document"),
+    DSL_TOO_LARGE("dsl-too-large", HttpStatus.UNPROCESSABLE_ENTITY, "DSL_TOO_LARGE", "decision rule document too large"),
+    VERSION_CONFLICT("version-conflict", HttpStatus.CONFLICT, "VERSION_CONFLICT", "concurrent version publish conflict"),
+    CONCURRENCY_CONFLICT("concurrency-conflict", HttpStatus.SERVICE_UNAVAILABLE, "CONCURRENCY_CONFLICT", "concurrency conflict, retry"),
+    VALIDATION_FAILED("validation-failed", HttpStatus.BAD_REQUEST, "VALIDATION_FAILED", "invalid request"),
+    MALFORMED_REQUEST("malformed-request", HttpStatus.BAD_REQUEST, "MALFORMED_REQUEST", "invalid request"),
+    INVALID_REQUEST("invalid-request", HttpStatus.BAD_REQUEST, "INVALID_REQUEST", "invalid request"),
+    INTERNAL_ERROR("internal-error", HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", "internal error"),
+    ;
+
+    val type: URI get() = URI.create(BASE_URI + slug)
+
+    companion object {
+        const val BASE_URI = "https://fincore.dev/errors/"
+    }
+}

--- a/services/decision/src/main/kotlin/com/fincore/decision/store/api/mapper/DecisionApiMapper.kt
+++ b/services/decision/src/main/kotlin/com/fincore/decision/store/api/mapper/DecisionApiMapper.kt
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.store.api.mapper
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fincore.decision.store.api.dto.response.ActiveVersionResponse
+import com.fincore.decision.store.api.dto.response.RuleDetailResponse
+import com.fincore.decision.store.api.dto.response.RuleResponse
+import com.fincore.decision.store.api.dto.response.VersionResponse
+import com.fincore.decision.store.application.RuleDetailView
+import com.fincore.decision.store.application.RuleView
+import com.fincore.decision.store.application.VersionView
+import org.springframework.stereotype.Component
+
+// Hand-written, not MapStruct: the conversions are UUID/document-string to String/JsonNode plus a nullable
+// active-version assembly, the same MapStruct-unfriendly shape the ledger LedgerApiMapper documented; a hand
+// mapper avoids pulling kapt into this module for a trivial mapping.
+@Component
+class DecisionApiMapper(
+    private val objectMapper: ObjectMapper,
+) {
+    fun toResponse(view: RuleView): RuleResponse = RuleResponse(view.id.toString(), view.ruleKey)
+
+    fun toResponse(view: VersionView): VersionResponse = VersionResponse(view.id.toString(), view.versionNo)
+
+    fun toDetail(view: RuleDetailView): RuleDetailResponse =
+        RuleDetailResponse(
+            id = view.id.toString(),
+            ruleKey = view.ruleKey,
+            activeVersion =
+                view.activeVersion?.let {
+                    ActiveVersionResponse(it.versionNo, objectMapper.readTree(it.dsl))
+                },
+        )
+}

--- a/services/decision/src/main/kotlin/com/fincore/decision/store/application/RuleAdminService.kt
+++ b/services/decision/src/main/kotlin/com/fincore/decision/store/application/RuleAdminService.kt
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.store.application
+
+import java.util.UUID
+
+interface RuleAdminService {
+    fun createRule(ruleKey: String): RuleView
+
+    fun publishVersion(
+        ruleKey: String,
+        dslJson: String,
+    ): VersionView
+
+    fun getRule(ruleKey: String): RuleDetailView
+}
+
+data class RuleView(
+    val id: UUID,
+    val ruleKey: String,
+)
+
+data class VersionView(
+    val id: UUID,
+    val versionNo: Int,
+)
+
+data class RuleDetailView(
+    val id: UUID,
+    val ruleKey: String,
+    val activeVersion: ActiveVersionView?,
+)
+
+data class ActiveVersionView(
+    val versionNo: Int,
+    val dsl: String,
+)

--- a/services/decision/src/main/kotlin/com/fincore/decision/store/application/RuleAdminServiceImpl.kt
+++ b/services/decision/src/main/kotlin/com/fincore/decision/store/application/RuleAdminServiceImpl.kt
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.store.application
+
+import com.fincore.decision.domain.DecisionDslException
+import com.fincore.decision.parser.RuleParser
+import com.fincore.decision.store.config.DecisionApiProperties
+import com.fincore.decision.store.exception.DslTooLargeException
+import com.fincore.decision.store.exception.DuplicateRuleKeyException
+import com.fincore.decision.store.exception.InvalidRuleDslException
+import com.fincore.decision.store.exception.RuleNotFoundException
+import com.fincore.decision.store.exception.VersionConflictException
+import com.fincore.decision.store.persistence.DecisionRuleEntity
+import com.fincore.decision.store.persistence.DecisionRuleRepository
+import com.fincore.decision.store.persistence.RuleVersionEntity
+import com.fincore.decision.store.persistence.RuleVersionRepository
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+
+@Service
+class RuleAdminServiceImpl(
+    private val ruleRepository: DecisionRuleRepository,
+    private val versionRepository: RuleVersionRepository,
+    private val ruleParser: RuleParser,
+    private val properties: DecisionApiProperties,
+) : RuleAdminService {
+    @Transactional
+    override fun createRule(ruleKey: String): RuleView {
+        if (ruleRepository.findByRuleKey(ruleKey) != null) throw DuplicateRuleKeyException(ruleKey)
+        val saved =
+            try {
+                ruleRepository.saveAndFlush(DecisionRuleEntity(id = UUID.randomUUID(), ruleKey = ruleKey))
+            } catch (ex: DataIntegrityViolationException) {
+                throw DuplicateRuleKeyException(ruleKey, ex)
+            }
+        return RuleView(saved.id, saved.ruleKey)
+    }
+
+    @Transactional
+    override fun publishVersion(
+        ruleKey: String,
+        dslJson: String,
+    ): VersionView {
+        validate(dslJson)
+        val rule = loadRule(ruleKey)
+        val nextNo = (versionRepository.findMaxVersionNo(rule.id) ?: 0) + 1
+        val version =
+            try {
+                versionRepository.saveAndFlush(
+                    RuleVersionEntity(id = UUID.randomUUID(), ruleId = rule.id, versionNo = nextNo, dsl = dslJson),
+                )
+            } catch (ex: DataIntegrityViolationException) {
+                throw VersionConflictException(ruleKey, ex)
+            }
+        rule.activeVersionId = version.id
+        ruleRepository.saveAndFlush(rule)
+        return VersionView(version.id, version.versionNo)
+    }
+
+    @Transactional(readOnly = true)
+    override fun getRule(ruleKey: String): RuleDetailView {
+        val rule = loadRule(ruleKey)
+        val active =
+            rule.activeVersionId
+                ?.let { versionRepository.findById(it).orElse(null) }
+                ?.let { ActiveVersionView(it.versionNo, it.dsl) }
+        return RuleDetailView(rule.id, rule.ruleKey, active)
+    }
+
+    private fun validate(dslJson: String) {
+        if (dslJson.length > properties.maxDslChars) throw DslTooLargeException(properties.maxDslChars)
+        try {
+            ruleParser.parse(dslJson)
+        } catch (ex: DecisionDslException) {
+            throw InvalidRuleDslException(ex.code, ex.message, ex)
+        }
+    }
+
+    private fun loadRule(ruleKey: String): DecisionRuleEntity =
+        ruleRepository.findByRuleKey(ruleKey) ?: throw RuleNotFoundException(ruleKey)
+}

--- a/services/decision/src/main/kotlin/com/fincore/decision/store/config/DecisionApiProperties.kt
+++ b/services/decision/src/main/kotlin/com/fincore/decision/store/config/DecisionApiProperties.kt
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.store.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "fincore.decision.api")
+data class DecisionApiProperties(
+    val maxDslChars: Int = DEFAULT_MAX_DSL_CHARS,
+) {
+    private companion object {
+        const val DEFAULT_MAX_DSL_CHARS = 8192
+    }
+}

--- a/services/decision/src/main/kotlin/com/fincore/decision/store/config/DecisionEngineConfig.kt
+++ b/services/decision/src/main/kotlin/com/fincore/decision/store/config/DecisionEngineConfig.kt
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.store.config
+
+import com.fincore.decision.parser.RuleParser
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@EnableConfigurationProperties(DecisionApiProperties::class)
+class DecisionEngineConfig {
+    @Bean
+    fun ruleParser(): RuleParser = RuleParser()
+}

--- a/services/decision/src/main/kotlin/com/fincore/decision/store/config/OpenApiConfig.kt
+++ b/services/decision/src/main/kotlin/com/fincore/decision/store/config/OpenApiConfig.kt
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.store.config
+
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.info.License
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class OpenApiConfig {
+    @Bean
+    fun decisionOpenApi(): OpenAPI =
+        OpenAPI().info(
+            Info()
+                .title("FinCore Decision API")
+                .version("0.2.0")
+                .license(
+                    License()
+                        .name("BUSL-1.1")
+                        .url("https://github.com/tiana-code/fincore-engine/blob/main/LICENSE"),
+                ),
+        )
+}

--- a/services/decision/src/main/kotlin/com/fincore/decision/store/config/SecurityConfig.kt
+++ b/services/decision/src/main/kotlin/com/fincore/decision/store/config/SecurityConfig.kt
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.store.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter
+import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter
+import org.springframework.security.web.SecurityFilterChain
+
+@Configuration
+@EnableWebSecurity
+class SecurityConfig {
+    @Bean
+    fun filterChain(http: HttpSecurity): SecurityFilterChain =
+        http
+            .csrf { it.disable() }
+            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            .authorizeHttpRequests {
+                it
+                    .requestMatchers(*PUBLIC_PATHS)
+                    .permitAll()
+                    .requestMatchers(HttpMethod.GET, DECISION_PATHS)
+                    .hasAuthority(SCOPE_READ)
+                    .requestMatchers(DECISION_PATHS)
+                    .hasAuthority(SCOPE_WRITE)
+                    .anyRequest()
+                    .authenticated()
+            }.oauth2ResourceServer { resource ->
+                resource.jwt { it.jwtAuthenticationConverter(jwtAuthenticationConverter()) }
+            }.build()
+
+    private fun jwtAuthenticationConverter(): JwtAuthenticationConverter =
+        JwtAuthenticationConverter().apply {
+            setJwtGrantedAuthoritiesConverter(JwtGrantedAuthoritiesConverter())
+        }
+
+    private companion object {
+        const val DECISION_PATHS = "/v1/**"
+        const val SCOPE_READ = "SCOPE_decision:read"
+        const val SCOPE_WRITE = "SCOPE_decision:write"
+        val PUBLIC_PATHS =
+            arrayOf(
+                "/v3/api-docs/**",
+                "/swagger-ui/**",
+                "/swagger-ui.html",
+                "/actuator/health",
+                "/actuator/health/**",
+            )
+    }
+}

--- a/services/decision/src/main/kotlin/com/fincore/decision/store/exception/DecisionExceptions.kt
+++ b/services/decision/src/main/kotlin/com/fincore/decision/store/exception/DecisionExceptions.kt
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.store.exception
+
+import com.fincore.decision.domain.DslErrorCode
+
+class RuleNotFoundException(
+    ruleKey: String,
+) : RuntimeException("rule not found: $ruleKey")
+
+class DuplicateRuleKeyException(
+    ruleKey: String,
+    cause: Throwable? = null,
+) : RuntimeException("rule already exists: $ruleKey", cause)
+
+class InvalidRuleDslException(
+    val dslCode: DslErrorCode,
+    message: String,
+    cause: Throwable? = null,
+) : RuntimeException(message, cause)
+
+class DslTooLargeException(
+    val maxChars: Int,
+) : RuntimeException("rule document exceeds the maximum of $maxChars characters")
+
+class VersionConflictException(
+    ruleKey: String,
+    cause: Throwable? = null,
+) : RuntimeException("concurrent version publish conflict for rule: $ruleKey", cause)

--- a/services/decision/src/main/kotlin/com/fincore/decision/store/exception/GlobalExceptionHandler.kt
+++ b/services/decision/src/main/kotlin/com/fincore/decision/store/exception/GlobalExceptionHandler.kt
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.store.exception
+
+import com.fincore.decision.store.api.error.ProblemType
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.http.HttpHeaders
+import org.springframework.http.ProblemDetail
+import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.orm.ObjectOptimisticLockingFailureException
+import org.springframework.validation.FieldError
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import java.net.URI
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+    @ExceptionHandler(RuleNotFoundException::class)
+    fun handleRuleNotFound(
+        ex: RuleNotFoundException,
+        request: HttpServletRequest,
+    ): ProblemDetail = problem(ProblemType.RULE_NOT_FOUND, ex.message, request)
+
+    @ExceptionHandler(DuplicateRuleKeyException::class)
+    fun handleDuplicateRuleKey(
+        ex: DuplicateRuleKeyException,
+        request: HttpServletRequest,
+    ): ProblemDetail = problem(ProblemType.DUPLICATE_RULE_KEY, ex.message, request)
+
+    @ExceptionHandler(InvalidRuleDslException::class)
+    fun handleInvalidDsl(
+        ex: InvalidRuleDslException,
+        request: HttpServletRequest,
+    ): ProblemDetail =
+        problem(ProblemType.INVALID_DSL, ex.message, request).apply {
+            setProperty("dslCode", ex.dslCode.name)
+        }
+
+    @ExceptionHandler(DslTooLargeException::class)
+    fun handleDslTooLarge(
+        ex: DslTooLargeException,
+        request: HttpServletRequest,
+    ): ProblemDetail = problem(ProblemType.DSL_TOO_LARGE, ex.message, request)
+
+    @ExceptionHandler(VersionConflictException::class)
+    fun handleVersionConflict(
+        ex: VersionConflictException,
+        request: HttpServletRequest,
+    ): ProblemDetail = problem(ProblemType.VERSION_CONFLICT, ex.message, request)
+
+    @ExceptionHandler(ObjectOptimisticLockingFailureException::class)
+    fun handleOptimisticLock(request: HttpServletRequest): ResponseEntity<ProblemDetail> {
+        val body = problem(ProblemType.CONCURRENCY_CONFLICT, "concurrent update, retry", request)
+        return ResponseEntity
+            .status(ProblemType.CONCURRENCY_CONFLICT.status)
+            .header(HttpHeaders.RETRY_AFTER, RETRY_AFTER_SECONDS)
+            .body(body)
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleValidation(
+        ex: MethodArgumentNotValidException,
+        request: HttpServletRequest,
+    ): ProblemDetail =
+        problem(ProblemType.VALIDATION_FAILED, "Request validation failed", request).apply {
+            setProperty("errors", ex.bindingResult.fieldErrors.map(::toFieldError))
+        }
+
+    @ExceptionHandler(HttpMessageNotReadableException::class)
+    fun handleUnreadable(request: HttpServletRequest): ProblemDetail =
+        problem(ProblemType.MALFORMED_REQUEST, "Request body is missing or malformed", request)
+
+    @ExceptionHandler(IllegalArgumentException::class)
+    fun handleIllegalArgument(
+        ex: IllegalArgumentException,
+        request: HttpServletRequest,
+    ): ProblemDetail = problem(ProblemType.INVALID_REQUEST, ex.message, request)
+
+    @ExceptionHandler(Exception::class)
+    fun handleUnexpected(request: HttpServletRequest): ProblemDetail =
+        problem(ProblemType.INTERNAL_ERROR, "An unexpected error occurred", request)
+
+    private fun toFieldError(error: FieldError): Map<String, String> =
+        mapOf(
+            "field" to error.field,
+            "message" to (error.defaultMessage ?: "invalid"),
+        )
+
+    private fun problem(
+        type: ProblemType,
+        detail: String?,
+        request: HttpServletRequest,
+    ): ProblemDetail =
+        ProblemDetail.forStatusAndDetail(type.status, detail ?: type.title).apply {
+            this.title = type.title
+            this.type = type.type
+            this.instance = URI.create(request.requestURI)
+            setProperty("code", type.code)
+        }
+
+    private companion object {
+        const val RETRY_AFTER_SECONDS = "1"
+    }
+}

--- a/services/decision/src/main/resources/application.yml
+++ b/services/decision/src/main/resources/application.yml
@@ -11,3 +11,13 @@ spring:
     open-in-view: false
   liquibase:
     change-log: classpath:db/changelog/db.changelog-master.yaml
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: ${KEYCLOAK_ISSUER_URI}
+
+fincore:
+  decision:
+    api:
+      max-dsl-chars: 8192

--- a/services/decision/src/test/kotlin/com/fincore/decision/store/api/DecisionRuleControllerTest.kt
+++ b/services/decision/src/test/kotlin/com/fincore/decision/store/api/DecisionRuleControllerTest.kt
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.store.api
+
+import com.fincore.decision.domain.DslErrorCode
+import com.fincore.decision.store.api.mapper.DecisionApiMapper
+import com.fincore.decision.store.application.ActiveVersionView
+import com.fincore.decision.store.application.RuleAdminService
+import com.fincore.decision.store.application.RuleDetailView
+import com.fincore.decision.store.application.RuleView
+import com.fincore.decision.store.config.SecurityConfig
+import com.fincore.decision.store.exception.DslTooLargeException
+import com.fincore.decision.store.exception.DuplicateRuleKeyException
+import com.fincore.decision.store.exception.GlobalExceptionHandler
+import com.fincore.decision.store.exception.InvalidRuleDslException
+import com.fincore.decision.store.exception.RuleNotFoundException
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.util.UUID
+
+@WebMvcTest(DecisionRuleController::class)
+@Import(SecurityConfig::class, DecisionApiMapper::class, GlobalExceptionHandler::class, DecisionRuleControllerTest.Mocks::class)
+class DecisionRuleControllerTest(
+    @Autowired private val mockMvc: MockMvc,
+    @Autowired private val ruleAdminService: RuleAdminService,
+) {
+    @TestConfiguration
+    class Mocks {
+        @Bean fun ruleAdminService(): RuleAdminService = mockk()
+
+        @Bean fun jwtDecoder(): JwtDecoder = mockk()
+    }
+
+    @BeforeEach
+    fun resetMocks() {
+        clearMocks(ruleAdminService)
+    }
+
+    @Test
+    fun `should reject an unauthenticated create with 401`() {
+        mockMvc
+            .perform(post("/v1/decision/rules").contentType(MediaType.APPLICATION_JSON).content("""{"ruleKey":"k"}"""))
+            .andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    fun `should reject a create carrying only the read scope with 403`() {
+        mockMvc
+            .perform(
+                post("/v1/decision/rules")
+                    .with(jwt().authorities(SimpleGrantedAuthority(SCOPE_READ)))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"ruleKey":"k"}"""),
+            ).andExpect(status().isForbidden)
+    }
+
+    @Test
+    fun `should create a rule when the write scope is present`() {
+        every { ruleAdminService.createRule("k") } returns RuleView(UUID.randomUUID(), "k")
+
+        mockMvc
+            .perform(
+                post("/v1/decision/rules")
+                    .with(jwt().authorities(SimpleGrantedAuthority(SCOPE_WRITE)))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"ruleKey":"k"}"""),
+            ).andExpect(status().isCreated)
+            .andExpect(jsonPath("$.ruleKey").value("k"))
+    }
+
+    @Test
+    fun `should reject a blank rule key with a 400 problem document`() {
+        mockMvc
+            .perform(
+                post("/v1/decision/rules")
+                    .with(jwt().authorities(SimpleGrantedAuthority(SCOPE_WRITE)))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"ruleKey":""}"""),
+            ).andExpect(status().isBadRequest)
+            .andExpect(content().contentTypeCompatibleWith(PROBLEM_JSON))
+            .andExpect(jsonPath("$.code").value("VALIDATION_FAILED"))
+    }
+
+    @Test
+    fun `should map a duplicate rule key to a 409 problem document`() {
+        every { ruleAdminService.createRule("k") } throws DuplicateRuleKeyException("k")
+
+        mockMvc
+            .perform(
+                post("/v1/decision/rules")
+                    .with(jwt().authorities(SimpleGrantedAuthority(SCOPE_WRITE)))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"ruleKey":"k"}"""),
+            ).andExpect(status().isConflict)
+            .andExpect(content().contentTypeCompatibleWith(PROBLEM_JSON))
+            .andExpect(jsonPath("$.code").value("DUPLICATE_RULE_KEY"))
+    }
+
+    @Test
+    fun `should map an invalid dsl to a 422 problem document carrying the dsl code`() {
+        every { ruleAdminService.publishVersion("k", any()) } throws
+            InvalidRuleDslException(DslErrorCode.UNKNOWN_OPERATOR, "unknown operator")
+
+        mockMvc
+            .perform(
+                post("/v1/decision/rules/k/versions")
+                    .with(jwt().authorities(SimpleGrantedAuthority(SCOPE_WRITE)))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"condition":{"attr":"a","op":"bad","value":1},"outcome":{"label":"x"}}"""),
+            ).andExpect(status().isUnprocessableEntity)
+            .andExpect(jsonPath("$.code").value("INVALID_DSL"))
+            .andExpect(jsonPath("$.dslCode").value("UNKNOWN_OPERATOR"))
+    }
+
+    @Test
+    fun `should map an oversized dsl to a 422 problem document`() {
+        every { ruleAdminService.publishVersion("k", any()) } throws DslTooLargeException(MAX_DSL)
+
+        mockMvc
+            .perform(
+                post("/v1/decision/rules/k/versions")
+                    .with(jwt().authorities(SimpleGrantedAuthority(SCOPE_WRITE)))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"condition":{"attr":"a","op":"eq","value":1},"outcome":{"label":"x"}}"""),
+            ).andExpect(status().isUnprocessableEntity)
+            .andExpect(jsonPath("$.code").value("DSL_TOO_LARGE"))
+    }
+
+    @Test
+    fun `should map a missing rule to a 404 problem document when publishing`() {
+        every { ruleAdminService.publishVersion("k", any()) } throws RuleNotFoundException("k")
+
+        mockMvc
+            .perform(
+                post("/v1/decision/rules/k/versions")
+                    .with(jwt().authorities(SimpleGrantedAuthority(SCOPE_WRITE)))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"condition":{"attr":"a","op":"eq","value":1},"outcome":{"label":"x"}}"""),
+            ).andExpect(status().isNotFound)
+            .andExpect(jsonPath("$.code").value("RULE_NOT_FOUND"))
+    }
+
+    @Test
+    fun `should return the active version with the read scope when the rule is read`() {
+        every { ruleAdminService.getRule("k") } returns
+            RuleDetailView(
+                UUID.randomUUID(),
+                "k",
+                ActiveVersionView(1, """{"condition":{"attr":"a","op":"eq","value":1},"outcome":{"label":"approve"}}"""),
+            )
+
+        mockMvc
+            .perform(get("/v1/decision/rules/k").with(jwt().authorities(SimpleGrantedAuthority(SCOPE_READ))))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.ruleKey").value("k"))
+            .andExpect(jsonPath("$.activeVersion.versionNo").value(1))
+            .andExpect(jsonPath("$.activeVersion.dsl.outcome.label").value("approve"))
+    }
+
+    @Test
+    fun `should return a null active version when the rule has none`() {
+        every { ruleAdminService.getRule("k") } returns RuleDetailView(UUID.randomUUID(), "k", null)
+
+        mockMvc
+            .perform(get("/v1/decision/rules/k").with(jwt().authorities(SimpleGrantedAuthority(SCOPE_READ))))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.activeVersion").doesNotExist())
+    }
+
+    @Test
+    fun `should map a missing rule to a 404 problem document when read`() {
+        every { ruleAdminService.getRule("x") } throws RuleNotFoundException("x")
+
+        mockMvc
+            .perform(get("/v1/decision/rules/x").with(jwt().authorities(SimpleGrantedAuthority(SCOPE_READ))))
+            .andExpect(status().isNotFound)
+            .andExpect(content().contentTypeCompatibleWith(PROBLEM_JSON))
+            .andExpect(jsonPath("$.code").value("RULE_NOT_FOUND"))
+    }
+
+    private companion object {
+        const val SCOPE_READ = "SCOPE_decision:read"
+        const val SCOPE_WRITE = "SCOPE_decision:write"
+        const val PROBLEM_JSON = "application/problem+json"
+        const val MAX_DSL = 8192
+    }
+}

--- a/services/decision/src/test/kotlin/com/fincore/decision/store/application/RuleAdminServiceImplTest.kt
+++ b/services/decision/src/test/kotlin/com/fincore/decision/store/application/RuleAdminServiceImplTest.kt
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.store.application
+
+import com.fincore.decision.domain.DslErrorCode
+import com.fincore.decision.parser.RuleParser
+import com.fincore.decision.store.config.DecisionApiProperties
+import com.fincore.decision.store.exception.DslTooLargeException
+import com.fincore.decision.store.exception.DuplicateRuleKeyException
+import com.fincore.decision.store.exception.InvalidRuleDslException
+import com.fincore.decision.store.exception.RuleNotFoundException
+import com.fincore.decision.store.exception.VersionConflictException
+import com.fincore.decision.store.persistence.DecisionRuleEntity
+import com.fincore.decision.store.persistence.DecisionRuleRepository
+import com.fincore.decision.store.persistence.RuleVersionEntity
+import com.fincore.decision.store.persistence.RuleVersionRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.junit.jupiter.api.Test
+import org.springframework.dao.DataIntegrityViolationException
+import java.util.Optional
+import java.util.UUID
+
+class RuleAdminServiceImplTest {
+    private val ruleRepository = mockk<DecisionRuleRepository>()
+    private val versionRepository = mockk<RuleVersionRepository>()
+    private val service = RuleAdminServiceImpl(ruleRepository, versionRepository, RuleParser(), DecisionApiProperties())
+    private val validDsl = """{"condition":{"attr":"amount","op":"gte","value":100},"outcome":{"label":"approve"}}"""
+
+    @Test
+    fun `should create a rule when the key is new`() {
+        every { ruleRepository.findByRuleKey("k") } returns null
+        val slot = slot<DecisionRuleEntity>()
+        every { ruleRepository.saveAndFlush(capture(slot)) } answers { slot.captured }
+
+        service.createRule("k").ruleKey shouldBe "k"
+    }
+
+    @Test
+    fun `should reject creating a rule when the key already exists`() {
+        every { ruleRepository.findByRuleKey("k") } returns mockk()
+
+        shouldThrow<DuplicateRuleKeyException> { service.createRule("k") }
+    }
+
+    @Test
+    fun `should map a unique violation to a duplicate key conflict when two creates race`() {
+        every { ruleRepository.findByRuleKey("k") } returns null
+        every { ruleRepository.saveAndFlush(any()) } throws DataIntegrityViolationException("dup")
+
+        shouldThrow<DuplicateRuleKeyException> { service.createRule("k") }
+    }
+
+    @Test
+    fun `should publish the first version and point the rule at it when published`() {
+        val rule = DecisionRuleEntity(id = UUID.randomUUID(), ruleKey = "k")
+        every { ruleRepository.findByRuleKey("k") } returns rule
+        every { versionRepository.findMaxVersionNo(rule.id) } returns null
+        val slot = slot<RuleVersionEntity>()
+        every { versionRepository.saveAndFlush(capture(slot)) } answers { slot.captured }
+        every { ruleRepository.saveAndFlush(rule) } returns rule
+
+        val view = service.publishVersion("k", validDsl)
+
+        view.versionNo shouldBe 1
+        rule.activeVersionId shouldBe slot.captured.id
+    }
+
+    @Test
+    fun `should assign the next monotonic version number when a later version is published`() {
+        val rule = DecisionRuleEntity(id = UUID.randomUUID(), ruleKey = "k")
+        every { ruleRepository.findByRuleKey("k") } returns rule
+        every { versionRepository.findMaxVersionNo(rule.id) } returns 1
+        val slot = slot<RuleVersionEntity>()
+        every { versionRepository.saveAndFlush(capture(slot)) } answers { slot.captured }
+        every { ruleRepository.saveAndFlush(rule) } returns rule
+
+        service.publishVersion("k", validDsl).versionNo shouldBe 2
+    }
+
+    @Test
+    fun `should reject an invalid dsl with its error code when published`() {
+        shouldThrow<InvalidRuleDslException> {
+            service.publishVersion("k", """{"outcome":{"label":"approve"}}""")
+        }.dslCode shouldBe DslErrorCode.MISSING_FIELD
+    }
+
+    @Test
+    fun `should reject a dsl document over the size cap before parsing`() {
+        val tiny = RuleAdminServiceImpl(ruleRepository, versionRepository, RuleParser(), DecisionApiProperties(maxDslChars = 2))
+
+        shouldThrow<DslTooLargeException> { tiny.publishVersion("k", validDsl) }
+    }
+
+    @Test
+    fun `should reject publishing a version for an unknown rule`() {
+        every { ruleRepository.findByRuleKey("missing") } returns null
+
+        shouldThrow<RuleNotFoundException> { service.publishVersion("missing", validDsl) }
+    }
+
+    @Test
+    fun `should map a unique violation to a version conflict when two publishes race`() {
+        val rule = DecisionRuleEntity(id = UUID.randomUUID(), ruleKey = "k")
+        every { ruleRepository.findByRuleKey("k") } returns rule
+        every { versionRepository.findMaxVersionNo(rule.id) } returns null
+        every { versionRepository.saveAndFlush(any()) } throws DataIntegrityViolationException("dup")
+
+        shouldThrow<VersionConflictException> { service.publishVersion("k", validDsl) }
+    }
+
+    @Test
+    fun `should return the active version dsl when the rule is read`() {
+        val versionId = UUID.randomUUID()
+        val rule = DecisionRuleEntity(id = UUID.randomUUID(), ruleKey = "k", activeVersionId = versionId)
+        every { ruleRepository.findByRuleKey("k") } returns rule
+        every { versionRepository.findById(versionId) } returns
+            Optional.of(RuleVersionEntity(id = versionId, ruleId = rule.id, versionNo = 2, dsl = validDsl))
+
+        val detail = service.getRule("k")
+
+        detail.activeVersion?.versionNo shouldBe 2
+        detail.activeVersion?.dsl shouldBe validDsl
+    }
+
+    @Test
+    fun `should return a null active version when the rule has no version`() {
+        val rule = DecisionRuleEntity(id = UUID.randomUUID(), ruleKey = "k")
+        every { ruleRepository.findByRuleKey("k") } returns rule
+
+        service.getRule("k").activeVersion shouldBe null
+    }
+
+    @Test
+    fun `should reject reading an unknown rule`() {
+        every { ruleRepository.findByRuleKey("x") } returns null
+
+        shouldThrow<RuleNotFoundException> { service.getRule("x") }
+    }
+}


### PR DESCRIPTION
## What

Slice 1 of 2 splitting #172. Turns the storage-only `services/decision` module into a secured OAuth2 web service exposing **rule management**. The evaluate endpoint, the bounded-time ReDoS matcher, and the per-evaluation `decision_logs` write follow in slice 172b (which closes #172).

## Endpoints (`/v1/decision/rules`)

- `POST` create a rule (`decision:write`). Duplicate key -> 409, blank key -> 400.
- `POST /{ruleKey}/versions` publish an immutable DSL version (`decision:write`). The document is validated fail-closed through the `libs/decision-engine` `RuleParser`; invalid DSL -> 422 carrying the `DslErrorCode`, nothing stored. The next monotonic `version_no` is assigned and the version is activated on success.
- `GET /{ruleKey}` read the rule and its active version DSL (`decision:read`). Unknown key -> 404.

## Security and contract

- OAuth2 JWT resource server, stateless, CSRF off; `decision:read` for GET, `decision:write` for mutations; missing token -> 401, wrong scope -> 403.
- RFC 7807 `application/problem+json` for every error family, with a stable `code` and (for DSL failures) a `dslCode`.
- OpenAPI document served; `issuer-uri` is lazy (context boots without a live IdP, mirroring ledger).

## Concurrency

`publishVersion` uses `saveAndFlush` so a concurrent duplicate `version_no` surfaces as a typed **409** inside the transaction, and the active-pointer optimistic lock surfaces as a **503** retry, never a 500. The Testcontainers IT runs 6 concurrent publishes and asserts every response is one of {201, 409, 503}, stored versions equal the successes and are distinct, and at least one succeeds.

## ReDoS carry-forward

This slice only compiles patterns during validation (cheap, no backtracking) and runs no `Regex.matches` against caller input. The bounded-time matcher (the actual ReDoS mitigation, a match-time guard) is a hard carry-forward to slice 172b before the evaluate endpoint matches any pattern.

## Notes

- Hand-written `DecisionApiMapper` (UUID/`JsonNode` conversions, ledger `LedgerApiMapper` precedent; avoids kapt).
- Idempotency-Key is deliberately deferred for publish (append-only/monotonic versions; documented in code).
- No new ADR; the DSL ADR remains ADR-0016.

Part of #172