### PR TITLE
feat(decision): add RuleSynthesizer plug-in port for rule synthesis

### DIFF
--- a/libs/decision-engine/src/main/kotlin/com/fincore/decision/synth/RuleSynthesisException.kt
+++ b/libs/decision-engine/src/main/kotlin/com/fincore/decision/synth/RuleSynthesisException.kt
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.synth
+
+/** Signals that a [RuleSynthesizer] could not produce a candidate rule. */
+class RuleSynthesisException(
+    message: String,
+    cause: Throwable? = null,
+) : RuntimeException(message, cause)

--- a/libs/decision-engine/src/main/kotlin/com/fincore/decision/synth/RuleSynthesizer.kt
+++ b/libs/decision-engine/src/main/kotlin/com/fincore/decision/synth/RuleSynthesizer.kt
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.synth
+
+/**
+ * Plug-in port for synthesizing a decision rule from a natural-language intent.
+ *
+ * Implementations are provided out of tree (for example an LLM-backed adapter) and are NOT part of
+ * this open-source engine. The contract is deliberately generative and makes no determinism promise,
+ * unlike [com.fincore.decision.eval.RuleEvaluator].
+ */
+interface RuleSynthesizer {
+    /**
+     * Generate a candidate decision rule (engine DSL JSON) from [request].
+     *
+     * The returned [SynthesisResult.dsl] is an UNTRUSTED candidate: it is not guaranteed to be valid
+     * or safe DSL. Callers MUST validate it with [com.fincore.decision.parser.RuleParser] (fail-closed)
+     * and treat a thrown [com.fincore.decision.domain.DecisionDslException] as rejection before
+     * persisting or evaluating it. This port performs no validation and never evaluates or stores the
+     * candidate.
+     *
+     * @throws RuleSynthesisException if no candidate could be produced.
+     */
+    fun synthesize(request: SynthesisRequest): SynthesisResult
+}

--- a/libs/decision-engine/src/main/kotlin/com/fincore/decision/synth/SynthesisRequest.kt
+++ b/libs/decision-engine/src/main/kotlin/com/fincore/decision/synth/SynthesisRequest.kt
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.synth
+
+import com.fincore.decision.domain.EvaluationInput
+import com.fincore.decision.domain.ValueKind
+
+/**
+ * A natural-language request to synthesize a decision rule.
+ *
+ * @property intent free-text description of the rule to generate; must not be blank.
+ * @property availableAttributes optional vocabulary the rule may reference, grounding generation.
+ * @property examples optional input/outcome pairs that illustrate the desired behaviour.
+ */
+data class SynthesisRequest(
+    val intent: String,
+    val availableAttributes: List<AttributeDescriptor> = emptyList(),
+    val examples: List<SynthesisExample> = emptyList(),
+) {
+    init {
+        require(intent.isNotBlank()) { "intent must not be blank" }
+    }
+}
+
+/** An attribute the synthesizer may reference, named and typed in the engine's [ValueKind] vocabulary. */
+data class AttributeDescriptor(
+    val name: String,
+    val kind: ValueKind,
+)
+
+/** An illustrative input and its expected outcome label (null when the input should not match any rule). */
+data class SynthesisExample(
+    val input: EvaluationInput,
+    val expectedOutcomeLabel: String? = null,
+)

--- a/libs/decision-engine/src/main/kotlin/com/fincore/decision/synth/SynthesisResult.kt
+++ b/libs/decision-engine/src/main/kotlin/com/fincore/decision/synth/SynthesisResult.kt
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.synth
+
+private const val MIN_CONFIDENCE = 0.0
+private const val MAX_CONFIDENCE = 1.0
+
+/**
+ * A synthesized rule candidate.
+ *
+ * @property dsl the generated rule as engine DSL JSON; an UNTRUSTED candidate the caller must validate
+ *   with [com.fincore.decision.parser.RuleParser] before use. Must not be blank.
+ * @property confidence optional self-reported quality in 0.0..1.0; omitted when the implementation cannot
+ *   estimate it.
+ * @property rationale optional human-readable explanation of the generated rule.
+ */
+data class SynthesisResult(
+    val dsl: String,
+    val confidence: Double? = null,
+    val rationale: String? = null,
+) {
+    init {
+        require(dsl.isNotBlank()) { "dsl must not be blank" }
+        confidence?.let {
+            require(!it.isNaN() && it in MIN_CONFIDENCE..MAX_CONFIDENCE) { "confidence must be in 0.0..1.0" }
+        }
+    }
+}

--- a/libs/decision-engine/src/test/kotlin/com/fincore/decision/synth/RuleSynthesizerContractTest.kt
+++ b/libs/decision-engine/src/test/kotlin/com/fincore/decision/synth/RuleSynthesizerContractTest.kt
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.synth
+
+import com.fincore.decision.domain.DecimalValue
+import com.fincore.decision.domain.DecisionDslException
+import com.fincore.decision.domain.DecisionRule
+import com.fincore.decision.domain.EvaluationInput
+import com.fincore.decision.domain.ValueKind
+import com.fincore.decision.parser.RuleParser
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+
+private const val VALID_DSL =
+    """{"condition":{"attr":"age","op":"gte","value":18},"outcome":{"label":"APPROVE"}}"""
+private const val MALFORMED_DSL = """{"outcome":{"label":"APPROVE"}}"""
+
+private class FixedSynthesizer(
+    private val result: SynthesisResult,
+) : RuleSynthesizer {
+    override fun synthesize(request: SynthesisRequest): SynthesisResult = result
+}
+
+private class FailingSynthesizer : RuleSynthesizer {
+    override fun synthesize(request: SynthesisRequest): SynthesisResult = throw RuleSynthesisException("no candidate")
+}
+
+class RuleSynthesizerContractTest {
+    private val parser = RuleParser()
+    private val request = SynthesisRequest(intent = "approve adults")
+
+    @Test
+    fun `should expose a single synthesize method when inspected`() {
+        RuleSynthesizer::class.java.isInterface shouldBe true
+
+        val method = RuleSynthesizer::class.java.declaredMethods.single { it.name == "synthesize" }
+
+        method.returnType shouldBe SynthesisResult::class.java
+        method.parameterTypes.toList() shouldBe listOf(SynthesisRequest::class.java)
+    }
+
+    @Test
+    fun `should produce parser-valid dsl when a result is fed to the parser`() {
+        val synthesizer = FixedSynthesizer(SynthesisResult(dsl = VALID_DSL, confidence = 0.9))
+
+        val parsed = parser.parse(synthesizer.synthesize(request).dsl)
+
+        parsed.shouldBeInstanceOf<DecisionRule>()
+    }
+
+    @Test
+    fun `should let the parser reject a malformed candidate from a synthesizer`() {
+        val synthesizer = FixedSynthesizer(SynthesisResult(dsl = MALFORMED_DSL))
+
+        shouldThrow<DecisionDslException> { parser.parse(synthesizer.synthesize(request).dsl) }
+    }
+
+    @Test
+    fun `should surface a synthesis exception from a failing synthesizer`() {
+        shouldThrow<RuleSynthesisException> { FailingSynthesizer().synthesize(request) }
+    }
+
+    @Test
+    fun `should carry available attributes and examples through the request`() {
+        val grounded =
+            SynthesisRequest(
+                intent = "approve adults",
+                availableAttributes = listOf(AttributeDescriptor("age", ValueKind.DECIMAL)),
+                examples =
+                    listOf(
+                        SynthesisExample(
+                            input = EvaluationInput(mapOf("age" to DecimalValue(20.toBigDecimal()))),
+                            expectedOutcomeLabel = "APPROVE",
+                        ),
+                    ),
+            )
+
+        grounded.availableAttributes.single().kind shouldBe ValueKind.DECIMAL
+        grounded.examples.single().expectedOutcomeLabel shouldBe "APPROVE"
+    }
+}

--- a/libs/decision-engine/src/test/kotlin/com/fincore/decision/synth/SynthesisTypesTest.kt
+++ b/libs/decision-engine/src/test/kotlin/com/fincore/decision/synth/SynthesisTypesTest.kt
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.synth
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class SynthesisTypesTest {
+    @Test
+    fun `should reject a blank intent when building a request`() {
+        shouldThrow<IllegalArgumentException> { SynthesisRequest(intent = "  ") }
+    }
+
+    @Test
+    fun `should default grounding to empty lists when building a request`() {
+        val request = SynthesisRequest(intent = "approve adults")
+
+        request.availableAttributes shouldBe emptyList()
+        request.examples shouldBe emptyList()
+    }
+
+    @Test
+    fun `should reject a blank dsl when building a result`() {
+        shouldThrow<IllegalArgumentException> { SynthesisResult(dsl = "   ") }
+    }
+
+    @Test
+    fun `should reject confidence above one when building a result`() {
+        shouldThrow<IllegalArgumentException> { SynthesisResult(dsl = "stub", confidence = 1.5) }
+    }
+
+    @Test
+    fun `should reject confidence below zero when building a result`() {
+        shouldThrow<IllegalArgumentException> { SynthesisResult(dsl = "stub", confidence = -0.1) }
+    }
+
+    @Test
+    fun `should reject a NaN confidence when building a result`() {
+        shouldThrow<IllegalArgumentException> { SynthesisResult(dsl = "stub", confidence = Double.NaN) }
+    }
+
+    @Test
+    fun `should accept a null or in-range confidence when building a result`() {
+        SynthesisResult(dsl = "stub").confidence shouldBe null
+        SynthesisResult(dsl = "stub", confidence = 0.0).confidence shouldBe 0.0
+        SynthesisResult(dsl = "stub", confidence = 1.0).confidence shouldBe 1.0
+    }
+}


### PR DESCRIPTION
## What

Interface-only clean-room plug-in port `RuleSynthesizer` in `libs/decision-engine` (pure `kotlin.jvm`): a contract for synthesizing a candidate decision rule (engine DSL JSON) from a natural-language intent, with optional engine-native grounding (`AttributeDescriptor` over `ValueKind`, `SynthesisExample` over `EvaluationInput`) and a typed `RuleSynthesisException`.

No implementation, no LLM dependency, no prompts, no Spring/REST/JPA/migration. The concrete adapter is private (`fincore-llm`) per CLAUDE.md §5.2/§5.3. This is the first fincore plug-in port and sets the house pattern (mirrors the `RiskScorer`/`KycProvider` family named in §5.1).

## Trust boundary (security-critical)

The returned `dsl` is an untrusted, possibly-generative candidate. Callers MUST validate it with the existing fail-closed `RuleParser` before persisting or evaluating; the port itself performs no validation and never evaluates or stores the candidate. Proven by a positive round-trip (candidate parses to a `DecisionRule`) and a negative reject (malformed candidate raises `DecisionDslException`).

## Tests

12 pure-JVM tests (no Testcontainers): request/result invariants (blank intent/dsl, confidence range + NaN), interface shape, grounding carry-through, failure signalling, and both halves of the trust boundary.

## Gates

critic GO-WITH-CHANGES (3 folded) -> code-reviewer APPROVE-WITH-NITS (NaN-reject + readability, folded) -> security-auditor PASS (OSS-boundary clean) -> evaluator 0.93 PASS.

Closes #174