### PR TITLE
feat(decision): publish decision-engine as a reusable library artifact

### DIFF
--- a/libs/decision-engine/build.gradle.kts
+++ b/libs/decision-engine/build.gradle.kts
@@ -3,6 +3,7 @@
 
 plugins {
     alias(libs.plugins.kotlin.jvm)
+    `maven-publish`
 }
 
 description = "FinCore Decision Engine core: typed JSON predicate DSL, parser, deterministic evaluator"
@@ -28,4 +29,40 @@ tasks.test {
 java {
     withSourcesJar()
     withJavadocJar()
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            from(components["java"])
+            groupId = "com.fincore"
+            artifactId = "decision-engine"
+            version = rootProject.version.toString()
+            pom {
+                name.set("FinCore Decision Engine")
+                description.set(
+                    "Typed JSON predicate DSL, fail-closed parser and deterministic evaluator for " +
+                        "FinCore Engine; embeddable without the decision service.",
+                )
+                url.set("https://github.com/tiana-code/fincore-engine")
+                licenses {
+                    license {
+                        name.set("Business Source License 1.1")
+                        url.set("https://github.com/tiana-code/fincore-engine/blob/main/LICENSE")
+                    }
+                }
+                developers {
+                    developer {
+                        id.set("tiana-code")
+                        name.set("Tiana")
+                    }
+                }
+                scm {
+                    connection.set("scm:git:https://github.com/tiana-code/fincore-engine.git")
+                    developerConnection.set("scm:git:ssh://git@github.com/tiana-code/fincore-engine.git")
+                    url.set("https://github.com/tiana-code/fincore-engine")
+                }
+            }
+        }
+    }
 }

--- a/libs/decision-engine/src/test/kotlin/com/fincore/decision/LibraryEmbeddingTest.kt
+++ b/libs/decision-engine/src/test/kotlin/com/fincore/decision/LibraryEmbeddingTest.kt
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision
+
+import com.fincore.decision.domain.DecimalValue
+import com.fincore.decision.domain.EvaluationInput
+import com.fincore.decision.eval.RuleEvaluator
+import com.fincore.decision.parser.RuleParser
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+private const val RULE =
+    """{"condition":{"attr":"age","op":"gte","value":18},"outcome":{"label":"APPROVE"}}"""
+
+class LibraryEmbeddingTest {
+    private val parser = RuleParser()
+    private val evaluator = RuleEvaluator()
+
+    @Test
+    fun `should approve through the public api when an adult is supplied`() {
+        val result = evaluator.evaluate(parser.parse(RULE), input("age", "20"))
+
+        result.matched shouldBe true
+        result.outcome?.label shouldBe "APPROVE"
+    }
+
+    @Test
+    fun `should not match through the public api when a minor is supplied`() {
+        val result = evaluator.evaluate(parser.parse(RULE), input("age", "16"))
+
+        result.matched shouldBe false
+        result.outcome shouldBe null
+    }
+
+    private fun input(
+        attr: String,
+        value: String,
+    ) = EvaluationInput(mapOf(attr to DecimalValue(BigDecimal(value))))
+}


### PR DESCRIPTION
## What

Make `libs/decision-engine` a publishable, embeddable library artifact `com.fincore:decision-engine`, usable without `services/decision`. Applies `maven-publish` and declares one publication `from(components["java"])` (main + sources + javadoc jars) with a credible POM: name, description, url, BSL 1.1 license, developers, scm.

This is the packaging precursor to the standalone-repo extraction (#178).

## No remote publish (CLAUDE.md §0)

No `publishing { repositories {} }` remote target and no signing are declared, so the build is structurally incapable of pushing the artifact: only `generatePomFileForMavenPublication` / `publishToMavenLocal` exist, never a `publish...ToRepository` task. No CI workflow runs a gradle publish. The real release (registry, signing, Maven Central metadata) stays an owner action.

## Embeddable

`LibraryEmbeddingTest` proves the public API is self-sufficient: from a JSON rule string + an attribute map, a caller reaches a `DecisionResult` using only `com.fincore.decision.*` types (no Spring, no service).

## Verified (no remote publish involved)

- POM: `com.fincore:decision-engine:0.1.0-SNAPSHOT`, full metadata, `<dependencies>` = kotlin-stdlib + jackson-databind only (runtime scope), zero Spring/`:services:` leak.
- Three jars built: main, `-sources`, `-javadoc`.
- Module `test`/`detekt`/`spotlessCheck`/`assemble` green.

## Gates

critic GO-WITH-CHANGES (AC-4 runtime-scope wording + spotlessApply, folded) -> code-reviewer Needs-Fix resolved (explicit publication version added; 3 LOW Maven-Central items deferred to the owner release slice) -> security-auditor PASS (no secrets, no remote publish, no POM leak, boundary clean) -> evaluator 0.91 PASS.

Closes #175