### PR TITLE
perf(decision): add evaluator p99 gate and free the connection during evaluation

### DIFF
--- a/libs/decision-engine/src/test/kotlin/com/fincore/decision/eval/EvaluatorLatencyGateTest.kt
+++ b/libs/decision-engine/src/test/kotlin/com/fincore/decision/eval/EvaluatorLatencyGateTest.kt
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.eval
+
+import com.fincore.decision.domain.DecimalValue
+import com.fincore.decision.domain.EvaluationInput
+import com.fincore.decision.parser.RuleParser
+import io.kotest.assertions.withClue
+import io.kotest.matchers.longs.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+private const val RULE_CONDITIONS = 100
+private const val WARMUP_ITERATIONS = 5_000
+private const val MEASURED_ITERATIONS = 10_000
+private const val P99_CEILING_MILLIS = 10L
+private const val NANOS_PER_MILLI = 1_000_000L
+
+class EvaluatorLatencyGateTest {
+    private val evaluator = RuleEvaluator()
+    private val rule = RuleParser().parse(buildDsl())
+    private val input = buildInput()
+
+    @Test
+    fun `should produce a matching decision for the latency gate rule`() {
+        evaluator.evaluate(rule, input).matched shouldBe true
+    }
+
+    @Test
+    fun `should evaluate a 100 condition rule within the p99 latency ceiling`() {
+        repeat(WARMUP_ITERATIONS) { evaluator.evaluate(rule, input) }
+
+        val durations = LongArray(MEASURED_ITERATIONS)
+        var matchedAll = true
+        for (i in 0 until MEASURED_ITERATIONS) {
+            val start = System.nanoTime()
+            val result = evaluator.evaluate(rule, input)
+            durations[i] = System.nanoTime() - start
+            matchedAll = matchedAll && result.matched
+        }
+
+        matchedAll shouldBe true
+        durations.sort()
+        val p99Nanos = durations[durations.size - durations.size / 100 - 1]
+        withClue("p99=${p99Nanos / NANOS_PER_MILLI}ms ceiling=${P99_CEILING_MILLIS}ms") {
+            p99Nanos shouldBeLessThan P99_CEILING_MILLIS * NANOS_PER_MILLI
+        }
+    }
+
+    private fun buildDsl(): String {
+        val conditions = (1..RULE_CONDITIONS).joinToString(",") { """{"attr":"a$it","op":"gte","value":0}""" }
+        return """{"condition":{"all":[$conditions]},"outcome":{"label":"OK"}}"""
+    }
+
+    private fun buildInput(): EvaluationInput = EvaluationInput((1..RULE_CONDITIONS).associate { "a$it" to DecimalValue(BigDecimal.ONE) })
+}

--- a/services/decision/src/main/kotlin/com/fincore/decision/store/application/DecisionLogWriter.kt
+++ b/services/decision/src/main/kotlin/com/fincore/decision/store/application/DecisionLogWriter.kt
@@ -8,6 +8,7 @@ import com.fincore.decision.domain.DecisionResult
 import com.fincore.decision.store.persistence.DecisionLogEntity
 import com.fincore.decision.store.persistence.DecisionLogRepository
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
 import java.util.UUID
 
@@ -20,6 +21,7 @@ class DecisionLogWriter(
     private val decisionLogRepository: DecisionLogRepository,
     private val objectMapper: ObjectMapper,
 ) {
+    @Transactional
     fun write(
         ruleVersionId: UUID,
         inputHash: String,

--- a/services/decision/src/main/kotlin/com/fincore/decision/store/application/EvaluationServiceImpl.kt
+++ b/services/decision/src/main/kotlin/com/fincore/decision/store/application/EvaluationServiceImpl.kt
@@ -11,7 +11,6 @@ import com.fincore.decision.store.persistence.DecisionRuleRepository
 import com.fincore.decision.store.persistence.RuleVersionEntity
 import com.fincore.decision.store.persistence.RuleVersionRepository
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 
 @Service
 class EvaluationServiceImpl(
@@ -23,7 +22,6 @@ class EvaluationServiceImpl(
     private val inputMapper: InputMapper,
     private val logWriter: DecisionLogWriter,
 ) : EvaluationService {
-    @Transactional
     override fun evaluate(
         ruleKey: String,
         attributes: Map<String, JsonNode>,

--- a/services/decision/src/test/kotlin/com/fincore/decision/store/application/EvaluationTransactionBoundaryTest.kt
+++ b/services/decision/src/test/kotlin/com/fincore/decision/store/application/EvaluationTransactionBoundaryTest.kt
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.store.application
+
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import org.junit.jupiter.api.Test
+import org.springframework.core.annotation.AnnotatedElementUtils
+import org.springframework.transaction.annotation.Transactional
+import kotlin.reflect.jvm.javaMethod
+
+class EvaluationTransactionBoundaryTest {
+    @Test
+    fun `should not wrap evaluate in a transaction so the bounded eval holds no connection`() {
+        val method = requireNotNull(EvaluationServiceImpl::evaluate.javaMethod)
+
+        AnnotatedElementUtils.findMergedAnnotation(method, Transactional::class.java).shouldBeNull()
+        AnnotatedElementUtils
+            .findMergedAnnotation(EvaluationServiceImpl::class.java, Transactional::class.java)
+            .shouldBeNull()
+    }
+
+    @Test
+    fun `should write the audit log in its own transaction`() {
+        val method = requireNotNull(DecisionLogWriter::write.javaMethod)
+
+        AnnotatedElementUtils.findMergedAnnotation(method, Transactional::class.java).shouldNotBeNull()
+    }
+}


### PR DESCRIPTION
## What

Two performance concerns for the decision engine (#176):

**(A) Evaluator p99 latency gate.** A pure, in-process JUnit gate (`EvaluatorLatencyGateTest`) parses one 100-condition `all` rule via the public `RuleParser`, warms up the JIT, then times `RuleEvaluator.evaluate` over 10k iterations (nanoTime around the call only) and asserts nearest-rank p99 < 10ms. Deterministic, no I/O; a regression ceiling on the hot path. Stable across repeated local runs with ~100x headroom.

**(B) Free the JDBC connection during evaluation.** `EvaluationServiceImpl.evaluate` was `@Transactional`, so it held a pooled connection across the up-to-200ms bounded evaluation (`open-in-view` is already `false`). The orchestrator is now non-transactional and `DecisionLogWriter.write` owns its own short transaction (a separate bean, so the proxy boundary is honored - no self-invocation). The bounded evaluation now runs with no connection bound to the thread; a connection is taken only for the brief audit-log write.

## Correctness

- **Fail-closed audit preserved:** the log write is the last call, reached only after a successful evaluation. Timeout / rule-not-found / rule-not-active all throw before any write -> no `decision_logs` row. Covered by the existing unit test (`verify(exactly = 0)`) and end-to-end by `DecisionEvaluationApiIT` (one row on success, zero on timeout).
- **No LazyInitializationException:** the only fields read after load are eager scalar columns (`RuleVersionEntity.dsl/id`, `DecisionRuleEntity.activeVersionId`); no lazy association is traversed outside a transaction.
- A reflection test (`EvaluationTransactionBoundaryTest`) pins the moved boundary so the connection-hold cannot silently regress.

## Tests

4 new tests (2 perf + 2 structural); existing `EvaluationServiceImplTest` (4) unchanged and green. `DecisionEvaluationApiIT` is the CI verifier for (B).

## Gates

critic GO (no must-fixes; verified eager columns, `all` no short-circuit, separate-bean proxy) -> code-reviewer APPROVE-WITH-NITS (member-reference reflection, trimmed KDoc, shouldBeLessThan - all folded) -> security-auditor PASS (fail-closed impossible-to-write-on-failure, no regression, connection released, boundary/secrets clean) -> evaluator 0.93 PASS.

Note: the same read-only connection-hold exists in `ReplayServiceImpl` (`@Transactional(readOnly)`, writes nothing); deferred as read-only and out of scope for #176.

Closes #176