### PR TITLE
feat(events): align event envelope with cloudevents 1.0

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -46,6 +46,7 @@ postgres-jdbc = { module = "org.postgresql:postgresql", version.ref = "postgres-
 # Jackson
 jackson-module-kotlin = { module = "com.fasterxml.jackson.module:jackson-module-kotlin", version.ref = "jackson" }
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson" }
+jackson-datatype-jsr310 = { module = "com.fasterxml.jackson.datatype:jackson-datatype-jsr310", version.ref = "jackson" }
 
 # Identifiers
 ulid-creator = { module = "com.github.f4b6a3:ulid-creator", version.ref = "ulid" }

--- a/libs/fincore-events/build.gradle.kts
+++ b/libs/fincore-events/build.gradle.kts
@@ -16,6 +16,9 @@ dependencies {
 
     testImplementation(libs.kotest.assertions.core)
     testImplementation(libs.kotest.runner.junit5)
+    testImplementation(libs.jackson.module.kotlin)
+    testImplementation(libs.jackson.databind)
+    testImplementation(libs.jackson.datatype.jsr310)
 }
 
 tasks.test {

--- a/libs/fincore-events/src/main/kotlin/com/fincore/events/EventEnvelope.kt
+++ b/libs/fincore-events/src/main/kotlin/com/fincore/events/EventEnvelope.kt
@@ -9,15 +9,26 @@ import java.util.UUID
 data class EventEnvelope<T>(
     val id: UUID,
     val source: String,
+    val specversion: String,
     val type: String,
     val time: Instant,
     val subject: String?,
-    val correlationId: String?,
-    val causationId: String?,
-    val schemaVersion: String,
+    val datacontenttype: String,
+    val correlationid: String?,
+    val causationid: String?,
     val data: T,
 ) {
+    init {
+        require(source.isNotBlank()) { "source must not be blank" }
+        require(type.isNotBlank()) { "type must not be blank" }
+        require(specversion == SPEC_VERSION) { "specversion must be $SPEC_VERSION" }
+        require(datacontenttype.isNotBlank()) { "datacontenttype must not be blank" }
+    }
+
     companion object {
+        const val SPEC_VERSION = "1.0"
+        const val DEFAULT_CONTENT_TYPE = "application/json"
+
         fun <T> of(
             source: String,
             type: EventType,
@@ -25,16 +36,18 @@ data class EventEnvelope<T>(
             subject: String? = null,
             correlationId: String? = null,
             causationId: String? = null,
+            datacontenttype: String = DEFAULT_CONTENT_TYPE,
         ): EventEnvelope<T> =
             EventEnvelope(
                 id = UUID.randomUUID(),
                 source = source,
-                type = "${type.typeName}.${type.schemaVersion}",
+                specversion = SPEC_VERSION,
+                type = type.fullType,
                 time = Instant.now(),
                 subject = subject,
-                correlationId = correlationId,
-                causationId = causationId,
-                schemaVersion = type.schemaVersion,
+                datacontenttype = datacontenttype,
+                correlationid = correlationId,
+                causationid = causationId,
                 data = data,
             )
     }

--- a/libs/fincore-events/src/test/kotlin/com/fincore/events/EventEnvelopeTest.kt
+++ b/libs/fincore-events/src/test/kotlin/com/fincore/events/EventEnvelopeTest.kt
@@ -1,0 +1,209 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.events
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class EventEnvelopeTest {
+    private data class SamplePayload(
+        val ref: String,
+        val amount: Int,
+    )
+
+    private val mapper: ObjectMapper =
+        jacksonObjectMapper()
+            .registerModule(JavaTimeModule())
+            .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+
+    private fun sampleEnvelope(): EventEnvelope<SamplePayload> =
+        EventEnvelope.of(
+            source = "ledger",
+            type = LedgerEvents.TransactionPosted,
+            data = SamplePayload(ref = "ref-1", amount = 100),
+            subject = "tx_01",
+            correlationId = "corr-1",
+        )
+
+    @Test
+    fun `should round-trip an envelope without losing any attribute when serialized then deserialized`() {
+        val original = sampleEnvelope()
+
+        val json = mapper.writeValueAsString(original)
+        val restored = mapper.readValue<EventEnvelope<SamplePayload>>(json)
+
+        restored shouldBe original
+    }
+
+    @Test
+    fun `should serialize required CloudEvents attribute names with specversion 1_0 when serialized`() {
+        val tree = mapper.readTree(mapper.writeValueAsString(sampleEnvelope()))
+
+        tree.has("id") shouldBe true
+        tree.has("source") shouldBe true
+        tree.has("specversion") shouldBe true
+        tree.has("type") shouldBe true
+        tree.has("time") shouldBe true
+        tree.has("datacontenttype") shouldBe true
+        tree.has("data") shouldBe true
+        tree.get("specversion").asText() shouldBe "1.0"
+    }
+
+    @Test
+    fun `should default datacontenttype to application json when not supplied`() {
+        sampleEnvelope().datacontenttype shouldBe "application/json"
+    }
+
+    @Test
+    fun `should build a self-versioning type from the event type when constructed`() {
+        sampleEnvelope().type shouldBe "com.fincore.ledger.transaction.posted.v1"
+    }
+
+    @Test
+    fun `should serialize tracing ids under lowercase names and round-trip them when present`() {
+        val envelope =
+            EventEnvelope.of(
+                source = "ledger",
+                type = LedgerEvents.TransactionPosted,
+                data = SamplePayload(ref = "ref-1", amount = 1),
+                correlationId = "corr-9",
+                causationId = "cause-9",
+            )
+
+        val tree = mapper.readTree(mapper.writeValueAsString(envelope))
+        tree.get("correlationid").asText() shouldBe "corr-9"
+        tree.get("causationid").asText() shouldBe "cause-9"
+
+        val restored = mapper.readValue<EventEnvelope<SamplePayload>>(mapper.writeValueAsString(envelope))
+        restored.correlationid shouldBe "corr-9"
+        restored.causationid shouldBe "cause-9"
+    }
+
+    @Test
+    fun `should round-trip time as an RFC 3339 string not an epoch array when serialized`() {
+        val fixed = Instant.parse("2026-06-17T10:15:30Z")
+        val envelope =
+            EventEnvelope(
+                id = java.util.UUID.randomUUID(),
+                source = "ledger",
+                specversion = EventEnvelope.SPEC_VERSION,
+                type = LedgerEvents.TransactionPosted.fullType,
+                time = fixed,
+                subject = null,
+                datacontenttype = EventEnvelope.DEFAULT_CONTENT_TYPE,
+                correlationid = null,
+                causationid = null,
+                data = SamplePayload(ref = "r", amount = 1),
+            )
+
+        val json = mapper.writeValueAsString(envelope)
+        json shouldContain "\"2026-06-17T10:15:30Z\""
+
+        mapper.readValue<EventEnvelope<SamplePayload>>(json).time shouldBe fixed
+    }
+
+    @Test
+    fun `should serialize an envelope to a stable canonical json form when attributes are fixed`() {
+        val envelope =
+            EventEnvelope(
+                id = java.util.UUID.fromString("00000000-0000-0000-0000-000000000001"),
+                source = "ledger",
+                specversion = EventEnvelope.SPEC_VERSION,
+                type = LedgerEvents.TransactionPosted.fullType,
+                time = Instant.parse("2026-06-17T10:15:30Z"),
+                subject = "tx_01",
+                datacontenttype = EventEnvelope.DEFAULT_CONTENT_TYPE,
+                correlationid = "corr-1",
+                causationid = null,
+                data = SamplePayload(ref = "r", amount = 1),
+            )
+
+        mapper.writeValueAsString(envelope) shouldBe
+            "{\"id\":\"00000000-0000-0000-0000-000000000001\",\"source\":\"ledger\"," +
+            "\"specversion\":\"1.0\",\"type\":\"com.fincore.ledger.transaction.posted.v1\"," +
+            "\"time\":\"2026-06-17T10:15:30Z\",\"subject\":\"tx_01\"," +
+            "\"datacontenttype\":\"application/json\",\"correlationid\":\"corr-1\"," +
+            "\"data\":{\"ref\":\"r\",\"amount\":1}}"
+    }
+
+    @Test
+    fun `should reject a blank source when constructed`() {
+        shouldThrow<IllegalArgumentException> {
+            EventEnvelope(
+                id = java.util.UUID.randomUUID(),
+                source = " ",
+                specversion = EventEnvelope.SPEC_VERSION,
+                type = LedgerEvents.TransactionPosted.fullType,
+                time = Instant.now(),
+                subject = null,
+                datacontenttype = EventEnvelope.DEFAULT_CONTENT_TYPE,
+                correlationid = null,
+                causationid = null,
+                data = SamplePayload(ref = "r", amount = 1),
+            )
+        }
+    }
+
+    @Test
+    fun `should reject a blank type when constructed`() {
+        shouldThrow<IllegalArgumentException> {
+            EventEnvelope(
+                id = java.util.UUID.randomUUID(),
+                source = "ledger",
+                specversion = EventEnvelope.SPEC_VERSION,
+                type = " ",
+                time = Instant.now(),
+                subject = null,
+                datacontenttype = EventEnvelope.DEFAULT_CONTENT_TYPE,
+                correlationid = null,
+                causationid = null,
+                data = SamplePayload(ref = "r", amount = 1),
+            )
+        }
+    }
+
+    @Test
+    fun `should reject a blank specversion when constructed`() {
+        shouldThrow<IllegalArgumentException> {
+            EventEnvelope(
+                id = java.util.UUID.randomUUID(),
+                source = "ledger",
+                specversion = " ",
+                type = LedgerEvents.TransactionPosted.fullType,
+                time = Instant.now(),
+                subject = null,
+                datacontenttype = EventEnvelope.DEFAULT_CONTENT_TYPE,
+                correlationid = null,
+                causationid = null,
+                data = SamplePayload(ref = "r", amount = 1),
+            )
+        }
+    }
+
+    @Test
+    fun `should reject a blank datacontenttype when constructed`() {
+        shouldThrow<IllegalArgumentException> {
+            EventEnvelope(
+                id = java.util.UUID.randomUUID(),
+                source = "ledger",
+                specversion = EventEnvelope.SPEC_VERSION,
+                type = LedgerEvents.TransactionPosted.fullType,
+                time = Instant.now(),
+                subject = null,
+                datacontenttype = " ",
+                correlationid = null,
+                causationid = null,
+                data = SamplePayload(ref = "r", amount = 1),
+            )
+        }
+    }
+}


### PR DESCRIPTION
## What

First slice of E-03 (Event Bus). Hardens the existing `EventEnvelope<T>` in `libs/fincore-events` into a fully CloudEvents 1.0-aligned, serializable, tested wire contract. Foundation for every published event; no broker, no Spring.

- Add CloudEvents context attributes `specversion` (constant `1.0`, guarded in `init`) and `datacontenttype` (default `application/json`).
- Lowercase the tracing extension attributes to `correlationid`/`causationid` (CloudEvents requires lowercase-alphanumeric names); the `of(...)` factory keeps camelCase params so ledger call sites are untouched.
- Drop the redundant `schemaVersion` attribute (the version already lives in `type`, e.g. `...transaction.posted.v1`).
- Validate required attributes at construction (fail-fast on blank `source`/`type`/`datacontenttype` and on a non-`1.0` `specversion`).
- Add the module's first test suite: lossless round-trip, canonical-JSON determinism, RFC 3339 `time`, lowercase tracing round-trip, and four reject tests.

## Decisions (see plan.md)

- Hand-rolled data class over the `io.cloudevents` SDK (lean, no heavy dependency, mirrors the DSL precedent).
- Generic `EventEnvelope<T>` kept (producer-side typing; the dispatcher reads pre-serialized `data`).
- Jackson stays `testImplementation` only - the module proves the round-trip but stays broker- and Spring-free (no new runtime dependency; only the test-scoped `jackson-datatype-jsr310` alias added).

## Gates

Local: `:libs:fincore-events:{test,detekt,detektTest,spotlessCheck,assemble}` green; `:services:ledger:{compileKotlin,compileIntegrationTestKotlin,compileTestKotlin}` green (backward compat). critic GO, code-reviewer APPROVE, security-auditor PASS, evaluator 0.94.

Closes #188