### PR TITLE
feat(eventbus): add Kafka/Redpanda producer and admin auto-configuration

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,9 @@ spring-boot-starter-validation = { module = "org.springframework.boot:spring-boo
 spring-boot-starter-test = { module = "org.springframework.boot:spring-boot-starter-test", version.ref = "spring-boot" }
 spring-security-test = { module = "org.springframework.security:spring-security-test" }
 
+# Spring Kafka (version managed by the Spring Boot BOM)
+spring-kafka = { module = "org.springframework.kafka:spring-kafka" }
+
 # Hibernate
 hibernate-core = { module = "org.hibernate.orm:hibernate-core", version.ref = "hibernate" }
 

--- a/libs/fincore-eventbus/build.gradle.kts
+++ b/libs/fincore-eventbus/build.gradle.kts
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.spring)
+}
+
+description = "FinCore event bus: Kafka/Redpanda producer and admin auto-configuration"
+
+kotlin {
+    jvmToolchain(21)
+}
+
+// Import the Spring Boot BOM via Gradle's native platform() so version-less Spring
+// dependencies (spring-kafka) resolve. Scoped to the dependency configurations only -
+// unlike the io.spring.dependency-management plugin, this does NOT apply the BOM to the
+// detekt configuration (which would downgrade detekt's bundled Kotlin compiler).
+val springBootBom = "org.springframework.boot:spring-boot-dependencies:${libs.versions.spring.boot.get()}"
+
+dependencies {
+    implementation(platform(springBootBom))
+    implementation(libs.kotlin.stdlib)
+    implementation(libs.kotlin.reflect)
+
+    implementation(libs.spring.boot.starter)
+    implementation(libs.spring.kafka)
+
+    testImplementation(platform(springBootBom))
+    testImplementation(libs.spring.boot.starter.test)
+    testImplementation(libs.kotest.assertions.core)
+    testImplementation(libs.kotest.runner.junit5)
+}
+
+tasks.test {
+    useJUnitPlatform()
+}
+
+sourceSets {
+    create("integrationTest") {
+        compileClasspath += sourceSets["main"].output + sourceSets["test"].output
+        runtimeClasspath += sourceSets["main"].output + sourceSets["test"].output
+    }
+}
+
+configurations["integrationTestImplementation"].extendsFrom(configurations["testImplementation"])
+configurations["integrationTestRuntimeOnly"].extendsFrom(configurations["testRuntimeOnly"])
+
+dependencies {
+    "integrationTestImplementation"(platform(springBootBom))
+    "integrationTestImplementation"(libs.testcontainers.core)
+    "integrationTestImplementation"(libs.testcontainers.redpanda)
+    "integrationTestImplementation"(libs.testcontainers.junit5)
+}
+
+val integrationTest =
+    tasks.register<Test>("integrationTest") {
+        description = "Runs integration tests (Spring config + Testcontainers Redpanda)."
+        group = "verification"
+        testClassesDirs = sourceSets["integrationTest"].output.classesDirs
+        classpath = sourceSets["integrationTest"].runtimeClasspath
+        useJUnitPlatform()
+        shouldRunAfter(tasks.named("test"))
+    }
+
+tasks.named("check") {
+    dependsOn(integrationTest)
+}
+
+java {
+    withSourcesJar()
+    withJavadocJar()
+}

--- a/libs/fincore-eventbus/src/integrationTest/kotlin/com/fincore/eventbus/EventBusIntegrationIT.kt
+++ b/libs/fincore-eventbus/src/integrationTest/kotlin/com/fincore/eventbus/EventBusIntegrationIT.kt
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.eventbus
+
+import io.kotest.matchers.shouldBe
+import org.apache.kafka.clients.admin.AdminClient
+import org.apache.kafka.clients.admin.NewTopic
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.kafka.core.KafkaAdmin
+import org.springframework.kafka.core.KafkaTemplate
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.redpanda.RedpandaContainer
+import java.time.Duration
+import java.util.Properties
+
+@Testcontainers
+class EventBusIntegrationIT {
+    private val runner =
+        ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(EventBusAutoConfiguration::class.java))
+            .withPropertyValues("fincore.eventbus.bootstrap-servers=${redpanda.bootstrapServers}")
+
+    @Test
+    fun `should publish and consume a record through the configured producer`() {
+        runner.run { context ->
+            @Suppress("UNCHECKED_CAST")
+            val template = context.getBean(KafkaTemplate::class.java) as KafkaTemplate<String, String>
+            template.send(ROUND_TRIP_TOPIC, "acc_1", "posted").get(SEND_TIMEOUT_SECONDS, java.util.concurrent.TimeUnit.SECONDS)
+
+            consumer().use { consumer ->
+                consumer.subscribe(listOf(ROUND_TRIP_TOPIC))
+                val records = consumer.poll(Duration.ofSeconds(POLL_TIMEOUT_SECONDS))
+                val record = records.records(ROUND_TRIP_TOPIC).first()
+                record.key() shouldBe "acc_1"
+                record.value() shouldBe "posted"
+            }
+        }
+    }
+
+    @Test
+    fun `should create and describe a topic through the admin client`() {
+        runner.run { context ->
+            val admin = context.getBean(KafkaAdmin::class.java)
+            AdminClient.create(admin.configurationProperties).use { client ->
+                client.createTopics(listOf(NewTopic(ADMIN_TOPIC, PARTITIONS, REPLICAS))).all().get()
+                val described =
+                    client
+                        .describeTopics(listOf(ADMIN_TOPIC))
+                        .allTopicNames()
+                        .get()[ADMIN_TOPIC]
+                described!!.partitions().size shouldBe PARTITIONS
+            }
+        }
+    }
+
+    private fun consumer(): KafkaConsumer<String, String> {
+        val props = Properties()
+        props[ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG] = redpanda.bootstrapServers
+        props[ConsumerConfig.GROUP_ID_CONFIG] = "eventbus-it"
+        props[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = "earliest"
+        props[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java
+        props[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java
+        return KafkaConsumer(props)
+    }
+
+    companion object {
+        private const val ROUND_TRIP_TOPIC = "eventbus.it.roundtrip"
+        private const val ADMIN_TOPIC = "eventbus.it.admin"
+        private const val SEND_TIMEOUT_SECONDS = 10L
+        private const val POLL_TIMEOUT_SECONDS = 10L
+        private const val PARTITIONS = 3
+        private const val REPLICAS: Short = 1
+
+        @Container
+        @JvmStatic
+        val redpanda: RedpandaContainer = RedpandaContainer("redpandadata/redpanda:v24.2.4")
+    }
+}

--- a/libs/fincore-eventbus/src/main/kotlin/com/fincore/eventbus/EventBusAutoConfiguration.kt
+++ b/libs/fincore-eventbus/src/main/kotlin/com/fincore/eventbus/EventBusAutoConfiguration.kt
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.eventbus
+
+import org.apache.kafka.clients.CommonClientConfigs
+import org.apache.kafka.clients.admin.AdminClientConfig
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.config.SaslConfigs
+import org.apache.kafka.common.serialization.StringSerializer
+import org.springframework.boot.autoconfigure.AutoConfiguration
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.kafka.core.DefaultKafkaProducerFactory
+import org.springframework.kafka.core.KafkaAdmin
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.core.ProducerFactory
+
+@AutoConfiguration
+@ConditionalOnProperty(prefix = "fincore.eventbus", name = ["bootstrap-servers"])
+@EnableConfigurationProperties(EventBusProperties::class)
+class EventBusAutoConfiguration {
+    @Bean
+    @ConditionalOnMissingBean
+    fun producerFactory(properties: EventBusProperties): ProducerFactory<String, String> =
+        DefaultKafkaProducerFactory(producerConfig(properties))
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun kafkaTemplate(producerFactory: ProducerFactory<String, String>): KafkaTemplate<String, String> = KafkaTemplate(producerFactory)
+
+    @Bean
+    @ConditionalOnMissingBean
+    fun kafkaAdmin(properties: EventBusProperties): KafkaAdmin = KafkaAdmin(adminConfig(properties))
+
+    companion object {
+        // Durability is a correctness invariant for ledger events, not a deployment knob:
+        // acks=all + enable.idempotence=true are fixed so the producer can never be silently
+        // weakened into dropping or duplicating events. Connection/security stay configurable.
+        private const val DURABLE_ACKS = "all"
+
+        fun producerConfig(properties: EventBusProperties): Map<String, Any> =
+            buildMap {
+                put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, properties.bootstrapServers)
+                put(ProducerConfig.CLIENT_ID_CONFIG, properties.clientId)
+                put(ProducerConfig.ACKS_CONFIG, DURABLE_ACKS)
+                put(ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG, true)
+                put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer::class.java)
+                put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer::class.java)
+                putAll(securityConfig(properties.security))
+            }
+
+        fun adminConfig(properties: EventBusProperties): Map<String, Any> =
+            buildMap {
+                put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, properties.bootstrapServers)
+                put(AdminClientConfig.CLIENT_ID_CONFIG, properties.clientId)
+                putAll(securityConfig(properties.security))
+            }
+
+        private fun securityConfig(security: EventBusProperties.Security): Map<String, Any> =
+            buildMap {
+                put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, security.protocol)
+                security.saslMechanism?.let { put(SaslConfigs.SASL_MECHANISM, it) }
+                security.saslJaasConfig?.let { put(SaslConfigs.SASL_JAAS_CONFIG, it) }
+            }
+    }
+}

--- a/libs/fincore-eventbus/src/main/kotlin/com/fincore/eventbus/EventBusProperties.kt
+++ b/libs/fincore-eventbus/src/main/kotlin/com/fincore/eventbus/EventBusProperties.kt
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.eventbus
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "fincore.eventbus")
+data class EventBusProperties(
+    val bootstrapServers: String,
+    val clientId: String = "fincore-eventbus",
+    val security: Security = Security(),
+) {
+    data class Security(
+        val protocol: String = "PLAINTEXT",
+        val saslMechanism: String? = null,
+        val saslJaasConfig: String? = null,
+    )
+}

--- a/libs/fincore-eventbus/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/libs/fincore-eventbus/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+com.fincore.eventbus.EventBusAutoConfiguration

--- a/libs/fincore-eventbus/src/test/kotlin/com/fincore/eventbus/EventBusAutoConfigurationTest.kt
+++ b/libs/fincore-eventbus/src/test/kotlin/com/fincore/eventbus/EventBusAutoConfigurationTest.kt
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.eventbus
+
+import io.kotest.matchers.maps.shouldContainKey
+import io.kotest.matchers.maps.shouldNotContainKey
+import io.kotest.matchers.shouldBe
+import org.apache.kafka.clients.CommonClientConfigs
+import org.apache.kafka.clients.producer.ProducerConfig
+import org.apache.kafka.common.config.SaslConfigs
+import org.apache.kafka.common.serialization.StringSerializer
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.core.DefaultKafkaProducerFactory
+import org.springframework.kafka.core.KafkaAdmin
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.core.ProducerFactory
+
+class EventBusAutoConfigurationTest {
+    private val runner =
+        ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(EventBusAutoConfiguration::class.java))
+            .withPropertyValues("fincore.eventbus.bootstrap-servers=localhost:9092")
+
+    @Test
+    fun `should assemble an idempotent producer config from defaults`() {
+        val config =
+            EventBusAutoConfiguration.producerConfig(
+                EventBusProperties(bootstrapServers = "localhost:9092", clientId = "ledger"),
+            )
+
+        config[ProducerConfig.BOOTSTRAP_SERVERS_CONFIG] shouldBe "localhost:9092"
+        config[ProducerConfig.CLIENT_ID_CONFIG] shouldBe "ledger"
+        config[ProducerConfig.ACKS_CONFIG] shouldBe "all"
+        config[ProducerConfig.ENABLE_IDEMPOTENCE_CONFIG] shouldBe true
+        config[ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG] shouldBe StringSerializer::class.java
+        config[ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG] shouldBe StringSerializer::class.java
+    }
+
+    @Test
+    fun `should add sasl keys when a secured protocol is configured`() {
+        val secured =
+            EventBusProperties(
+                bootstrapServers = "localhost:9092",
+                security =
+                    EventBusProperties.Security(
+                        protocol = "SASL_SSL",
+                        saslMechanism = "SCRAM-SHA-512",
+                        saslJaasConfig = "org.apache.kafka.common.security.scram.ScramLoginModule required;",
+                    ),
+            )
+
+        val config = EventBusAutoConfiguration.producerConfig(secured)
+
+        config[CommonClientConfigs.SECURITY_PROTOCOL_CONFIG] shouldBe "SASL_SSL"
+        config[SaslConfigs.SASL_MECHANISM] shouldBe "SCRAM-SHA-512"
+        config shouldContainKey SaslConfigs.SASL_JAAS_CONFIG
+    }
+
+    @Test
+    fun `should omit sasl keys when the default plaintext protocol is used`() {
+        val config = EventBusAutoConfiguration.producerConfig(EventBusProperties(bootstrapServers = "localhost:9092"))
+
+        config[CommonClientConfigs.SECURITY_PROTOCOL_CONFIG] shouldBe "PLAINTEXT"
+        config shouldNotContainKey SaslConfigs.SASL_MECHANISM
+        config shouldNotContainKey SaslConfigs.SASL_JAAS_CONFIG
+    }
+
+    @Test
+    fun `should register producer template and admin beans when bootstrap servers are set`() {
+        runner.run { context ->
+            context.getBean(ProducerFactory::class.java)
+            context.getBean(KafkaTemplate::class.java)
+            context.getBean(KafkaAdmin::class.java)
+        }
+    }
+
+    @Test
+    fun `should back off the template bean when the consumer defines its own`() {
+        runner.withUserConfiguration(CustomTemplateConfig::class.java).run { context ->
+            context.getBean(KafkaTemplate::class.java) shouldBe CustomTemplateConfig.CUSTOM
+        }
+    }
+
+    @Configuration
+    private class CustomTemplateConfig {
+        @Bean
+        fun kafkaTemplate(): KafkaTemplate<String, String> = CUSTOM
+
+        companion object {
+            val CUSTOM: KafkaTemplate<String, String> =
+                KafkaTemplate(
+                    DefaultKafkaProducerFactory(
+                        mapOf<String, Any>(
+                            ProducerConfig.BOOTSTRAP_SERVERS_CONFIG to "localhost:9092",
+                            ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG to StringSerializer::class.java,
+                            ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG to StringSerializer::class.java,
+                        ),
+                    ),
+                )
+        }
+    }
+}

--- a/libs/fincore-eventbus/src/test/kotlin/com/fincore/eventbus/EventBusPropertiesTest.kt
+++ b/libs/fincore-eventbus/src/test/kotlin/com/fincore/eventbus/EventBusPropertiesTest.kt
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.eventbus
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+
+class EventBusPropertiesTest {
+    private val runner =
+        ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of(EventBusAutoConfiguration::class.java))
+            .withPropertyValues("fincore.eventbus.bootstrap-servers=localhost:9092")
+
+    @Test
+    fun `should expose safe defaults when no overrides are supplied`() {
+        runner.run { context ->
+            val props = context.getBean(EventBusProperties::class.java)
+            props.bootstrapServers shouldBe "localhost:9092"
+            props.clientId shouldBe "fincore-eventbus"
+            props.security.protocol shouldBe "PLAINTEXT"
+        }
+    }
+
+    @Test
+    fun `should bind explicit overrides when supplied`() {
+        runner
+            .withPropertyValues(
+                "fincore.eventbus.bootstrap-servers=broker-a:9092,broker-b:9092",
+                "fincore.eventbus.client-id=ledger-dispatcher",
+                "fincore.eventbus.security.protocol=SASL_SSL",
+            ).run { context ->
+                val props = context.getBean(EventBusProperties::class.java)
+                props.bootstrapServers shouldBe "broker-a:9092,broker-b:9092"
+                props.clientId shouldBe "ledger-dispatcher"
+                props.security.protocol shouldBe "SASL_SSL"
+            }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,6 +23,7 @@ rootProject.name = "fincore-engine"
 include(
     ":libs:fincore-core",
     ":libs:fincore-events",
+    ":libs:fincore-eventbus",
     ":libs:fincore-test-support",
     ":libs:decision-engine",
     ":services:ledger",


### PR DESCRIPTION
## What

Second slice of E-03 (Event Bus). Adds `libs/fincore-eventbus`, a Spring auto-configuration library that any service includes to get a broker producer and admin client. The outbox dispatcher (#190) will use these beans; this slice stops at "the producer/admin client exists, is correct, and connects".

- One `spring-kafka` client serves both **Redpanda** (default dev/test) and **Apache Kafka** (prod). Redpanda speaks the Kafka protocol, so the "profile" difference is purely connection/security properties, not code.
- `EventBusProperties` (`@ConfigurationProperties("fincore.eventbus")`): `bootstrapServers` (required), `clientId`, and a `security` group (protocol + optional SASL mechanism/JAAS, sourced from env).
- `EventBusAutoConfiguration`: `ProducerFactory`/`KafkaTemplate<String,String>`/`KafkaAdmin` beans, each `@ConditionalOnMissingBean` so a consumer can override.
- **Durability is a fixed invariant, not a knob**: `acks=all` + `enable.idempotence=true` are hardcoded so a ledger event can never be silently dropped or duplicated at the producer. Connection and security stay configurable.
- The auto-config is `@ConditionalOnProperty(fincore.eventbus.bootstrap-servers)` and is on no service classpath yet, so it is inert until a service opts in (the ledger build is untouched).

## Decisions (see plan.md)

- Shared auto-config library, not a central broker service (the outbox is per-service in the modular monolith).
- Plain `spring-kafka` now; Spring Cloud Stream is its own slice (#194).
- Spring Boot BOM imported via Gradle native `platform()` rather than the `io.spring.dependency-management` plugin — the plugin applies the BOM to every configuration including detekt's, downgrading detekt's bundled Kotlin compiler.

## Gates

Local (`-x integrationTest`, Docker is unavailable in WSL): `:libs:fincore-eventbus:{test,detekt,detektTest,spotlessCheck,assemble,compileIntegrationTestKotlin}` green. The Testcontainers-Redpanda IT (publish round-trip + admin topic) runs on CI. critic GO-WITH-CHANGES (applied), code-reviewer APPROVE (nits applied), security-auditor PASS, evaluator 0.88.

Closes #189