### PR TITLE
feat(eventbus): add lease-based outbox dispatcher worker

### DIFF
--- a/libs/fincore-eventbus/build.gradle.kts
+++ b/libs/fincore-eventbus/build.gradle.kts
@@ -24,7 +24,9 @@ dependencies {
     implementation(libs.kotlin.reflect)
 
     implementation(libs.spring.boot.starter)
-    implementation(libs.spring.kafka)
+    // spring-kafka is exposed: the auto-configuration's @Bean methods return KafkaTemplate/KafkaAdmin,
+    // so a consuming service (the ledger dispatcher) compiles against these types.
+    api(libs.spring.kafka)
 
     testImplementation(platform(springBootBom))
     testImplementation(libs.spring.boot.starter.test)

--- a/services/ledger/build.gradle.kts
+++ b/services/ledger/build.gradle.kts
@@ -19,6 +19,7 @@ kotlin {
 dependencies {
     implementation(project(":libs:fincore-core"))
     implementation(project(":libs:fincore-events"))
+    implementation(project(":libs:fincore-eventbus"))
 
     implementation(libs.kotlin.stdlib)
     implementation(libs.kotlin.reflect)

--- a/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/application/outbox/OutboxClaimStoreIT.kt
+++ b/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/application/outbox/OutboxClaimStoreIT.kt
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.application.outbox
+
+import com.fincore.events.OutboxStatus
+import com.fincore.ledger.infrastructure.persistence.OutboxEventEntity
+import com.fincore.ledger.infrastructure.persistence.OutboxEventRepository
+import com.fincore.test.containers.PostgresContainerExtension
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionTemplate
+import java.time.Duration
+import java.time.Instant
+import java.util.UUID
+import java.util.concurrent.CopyOnWriteArrayList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@ExtendWith(PostgresContainerExtension::class)
+@Import(OutboxClaimStore::class)
+class OutboxClaimStoreIT(
+    @Autowired private val claimStore: OutboxClaimStore,
+    @Autowired private val repository: OutboxEventRepository,
+    @Autowired private val transactionManager: PlatformTransactionManager,
+) {
+    private val leaseTimeout: Duration = Duration.ofMinutes(5)
+
+    @AfterEach
+    fun cleanUp() {
+        repository.deleteAll()
+    }
+
+    @Test
+    fun `should mark claimed rows publishing and stamp the lease when claimed`() {
+        val ids = seedPending(2, "claim")
+
+        val claimed = claimStore.claim(MAX_ATTEMPTS, leaseTimeout, BATCH)
+
+        claimed shouldHaveSize 2
+        ids.forEach { id ->
+            val row = repository.findById(id).orElseThrow()
+            row.status shouldBe OutboxStatus.PUBLISHING
+            row.leasedAt.shouldNotBeNull()
+        }
+    }
+
+    @Test
+    fun `should not re-claim a freshly leased publishing row when claimed again`() {
+        seedPending(2, "fresh")
+
+        claimStore.claim(MAX_ATTEMPTS, leaseTimeout, BATCH)
+        val second = claimStore.claim(MAX_ATTEMPTS, leaseTimeout, BATCH)
+
+        second.shouldBeEmpty()
+    }
+
+    @Test
+    fun `should re-claim an orphaned publishing row whose lease expired when claimed`() {
+        val orphan = seedRow(OutboxStatus.PUBLISHING, attempts = 0, leasedAt = Instant.now().minus(Duration.ofMinutes(10)))
+
+        val claimed = claimStore.claim(MAX_ATTEMPTS, leaseTimeout, BATCH)
+
+        claimed.map { it.id } shouldBe listOf(orphan)
+    }
+
+    @Test
+    fun `should mark a row published when settled successfully`() {
+        val id = seedRow(OutboxStatus.PUBLISHING, attempts = 0, leasedAt = Instant.now())
+
+        claimStore.markPublished(id)
+
+        val row = repository.findById(id).orElseThrow()
+        row.status shouldBe OutboxStatus.PUBLISHED
+        row.publishedAt.shouldNotBeNull()
+        row.leasedAt shouldBe null
+    }
+
+    @Test
+    fun `should transition to failed when retry attempts remain`() {
+        val id = seedRow(OutboxStatus.PUBLISHING, attempts = 0, leasedAt = Instant.now())
+
+        claimStore.markFailed(id, attempts = 1, maxAttempts = 3, error = "broker down")
+
+        val row = repository.findById(id).orElseThrow()
+        row.status shouldBe OutboxStatus.FAILED
+        row.attempts shouldBe 1
+        row.lastError shouldBe "broker down"
+        row.leasedAt shouldBe null
+    }
+
+    @Test
+    fun `should transition to permanently failed when retry attempts are exhausted`() {
+        val id = seedRow(OutboxStatus.PUBLISHING, attempts = 2, leasedAt = Instant.now())
+
+        claimStore.markFailed(id, attempts = 3, maxAttempts = 3, error = "still down")
+
+        repository.findById(id).orElseThrow().status shouldBe OutboxStatus.PERMANENTLY_FAILED
+    }
+
+    @Test
+    fun `should not return the same row to two concurrent claims under skip locked`() {
+        seedPending(2 * BATCH, "concurrent")
+        val template = TransactionTemplate(transactionManager)
+        val aLocked = CountDownLatch(1)
+        val bDone = CountDownLatch(1)
+        val idsA = CopyOnWriteArrayList<UUID>()
+        val idsB = CopyOnWriteArrayList<UUID>()
+        val holderFailure = AtomicReference<Throwable>()
+
+        val holder =
+            Thread {
+                template.executeWithoutResult {
+                    idsA.addAll(lockBatchIds())
+                    aLocked.countDown()
+                    bDone.await(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                }
+            }
+        holder.setUncaughtExceptionHandler { _, ex -> holderFailure.set(ex) }
+        holder.start()
+        aLocked.await(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        template.executeWithoutResult { idsB.addAll(lockBatchIds()) }
+        bDone.countDown()
+        holder.join(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS))
+
+        holderFailure.get().shouldBeNull()
+        idsA shouldHaveSize BATCH
+        idsB shouldHaveSize BATCH
+        idsA.toSet().intersect(idsB.toSet()).shouldBeEmpty()
+    }
+
+    @Test
+    fun `should claim a failed row below max attempts but skip one at max attempts`() {
+        val claimable = seedRow(OutboxStatus.FAILED, attempts = MAX_ATTEMPTS - 1, leasedAt = null)
+        seedRow(OutboxStatus.FAILED, attempts = MAX_ATTEMPTS, leasedAt = null)
+
+        val claimed = claimStore.claim(MAX_ATTEMPTS, leaseTimeout, BATCH)
+
+        claimed.map { it.id } shouldBe listOf(claimable)
+    }
+
+    private fun lockBatchIds(): List<UUID> =
+        repository.lockClaimableBatch(MAX_ATTEMPTS, Instant.now().minus(leaseTimeout), BATCH).map { it.id }
+
+    private fun seedPending(
+        count: Int,
+        prefix: String,
+    ): List<UUID> = (1..count).map { seedRow(OutboxStatus.PENDING, attempts = 0, leasedAt = null, aggregateId = "$prefix-$it") }
+
+    private fun seedRow(
+        status: OutboxStatus,
+        attempts: Int,
+        leasedAt: Instant?,
+        aggregateId: String = "tx_1",
+    ): UUID =
+        repository
+            .save(
+                OutboxEventEntity(
+                    id = UUID.randomUUID(),
+                    aggregateType = "Transaction",
+                    aggregateId = aggregateId,
+                    eventType = "com.fincore.ledger.transaction.posted.v1",
+                    payload = "{\"id\":\"e1\"}",
+                    status = status,
+                    createdAt = Instant.now(),
+                    publishedAt = null,
+                    attempts = attempts,
+                    lastError = null,
+                    leasedAt = leasedAt,
+                ),
+            ).id
+
+    companion object {
+        private const val BATCH = 3
+        private const val MAX_ATTEMPTS = 10
+        private const val TIMEOUT_SECONDS = 10L
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun datasourceProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { PostgresContainerExtension.jdbcUrl }
+            registry.add("spring.datasource.username") { PostgresContainerExtension.username }
+            registry.add("spring.datasource.password") { PostgresContainerExtension.password }
+            registry.add("spring.datasource.hikari.maximum-pool-size") { "5" }
+            registry.add("spring.jpa.hibernate.ddl-auto") { "none" }
+        }
+    }
+}

--- a/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/application/outbox/OutboxDispatcherIT.kt
+++ b/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/application/outbox/OutboxDispatcherIT.kt
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.application.outbox
+
+import com.fincore.eventbus.EventBusAutoConfiguration
+import com.fincore.events.OutboxStatus
+import com.fincore.ledger.config.OutboxDispatcherProperties
+import com.fincore.ledger.infrastructure.persistence.OutboxEventEntity
+import com.fincore.ledger.infrastructure.persistence.OutboxEventRepository
+import com.fincore.test.containers.PostgresContainerExtension
+import com.fincore.test.containers.RedpandaContainerExtension
+import io.kotest.matchers.shouldBe
+import org.apache.kafka.clients.consumer.ConsumerConfig
+import org.apache.kafka.clients.consumer.KafkaConsumer
+import org.apache.kafka.common.serialization.StringDeserializer
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import java.time.Duration
+import java.time.Instant
+import java.util.Properties
+import java.util.UUID
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@ExtendWith(PostgresContainerExtension::class, RedpandaContainerExtension::class)
+@Import(OutboxClaimStore::class, EventBusAutoConfiguration::class)
+class OutboxDispatcherIT(
+    @Autowired private val claimStore: OutboxClaimStore,
+    @Autowired private val repository: OutboxEventRepository,
+    @Autowired private val kafkaTemplate: KafkaTemplate<String, String>,
+) {
+    private val dispatcher =
+        OutboxDispatcher(
+            claimStore,
+            kafkaTemplate,
+            OutboxDispatcherProperties(enabled = true, sendTimeout = Duration.ofSeconds(SEND_TIMEOUT_SECONDS)),
+        )
+
+    @AfterEach
+    fun cleanUp() {
+        repository.deleteAll()
+    }
+
+    @Test
+    fun `should publish a pending event to the broker and mark it published`() {
+        val payload = "{\"id\":\"env-1\",\"type\":\"com.fincore.ledger.transaction.posted.v1\"}"
+        val id = seedPending("tx_42", payload)
+
+        val summary = dispatcher.dispatch()
+
+        summary shouldBe DispatchSummary(published = 1, failed = 0)
+        val row = repository.findById(id).orElseThrow()
+        row.status shouldBe OutboxStatus.PUBLISHED
+
+        consumer().use { consumer ->
+            consumer.subscribe(listOf("fincore.transaction"))
+            val record = poll(consumer)
+            record.key() shouldBe "tx_42"
+            record.value() shouldBe payload
+        }
+    }
+
+    private fun poll(consumer: KafkaConsumer<String, String>): org.apache.kafka.clients.consumer.ConsumerRecord<String, String> {
+        val deadline = Instant.now().plusSeconds(POLL_TIMEOUT_SECONDS)
+        while (Instant.now().isBefore(deadline)) {
+            val records = consumer.poll(Duration.ofSeconds(1))
+            if (!records.isEmpty) return records.records("fincore.transaction").first()
+        }
+        error("no record received within ${POLL_TIMEOUT_SECONDS}s")
+    }
+
+    private fun seedPending(
+        aggregateId: String,
+        payload: String,
+    ): UUID =
+        repository
+            .save(
+                OutboxEventEntity(
+                    id = UUID.randomUUID(),
+                    aggregateType = "Transaction",
+                    aggregateId = aggregateId,
+                    eventType = "com.fincore.ledger.transaction.posted.v1",
+                    payload = payload,
+                    status = OutboxStatus.PENDING,
+                    createdAt = Instant.now(),
+                    publishedAt = null,
+                    attempts = 0,
+                    lastError = null,
+                    leasedAt = null,
+                ),
+            ).id
+
+    private fun consumer(): KafkaConsumer<String, String> {
+        val props = Properties()
+        props[ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG] = RedpandaContainerExtension.bootstrapServers
+        props[ConsumerConfig.GROUP_ID_CONFIG] = "dispatcher-it"
+        props[ConsumerConfig.AUTO_OFFSET_RESET_CONFIG] = "earliest"
+        props[ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java
+        props[ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG] = StringDeserializer::class.java
+        return KafkaConsumer(props)
+    }
+
+    companion object {
+        private const val SEND_TIMEOUT_SECONDS = 10L
+        private const val POLL_TIMEOUT_SECONDS = 15L
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun properties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { PostgresContainerExtension.jdbcUrl }
+            registry.add("spring.datasource.username") { PostgresContainerExtension.username }
+            registry.add("spring.datasource.password") { PostgresContainerExtension.password }
+            registry.add("spring.jpa.hibernate.ddl-auto") { "none" }
+            registry.add("fincore.eventbus.bootstrap-servers") { RedpandaContainerExtension.bootstrapServers }
+        }
+    }
+}

--- a/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/application/outbox/OutboxDispatcherIT.kt
+++ b/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/application/outbox/OutboxDispatcherIT.kt
@@ -3,6 +3,7 @@
 
 package com.fincore.ledger.application.outbox
 
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.fincore.eventbus.EventBusAutoConfiguration
 import com.fincore.events.OutboxStatus
 import com.fincore.ledger.config.OutboxDispatcherProperties
@@ -68,7 +69,8 @@ class OutboxDispatcherIT(
             consumer.subscribe(listOf("fincore.transaction"))
             val record = poll(consumer)
             record.key() shouldBe "tx_42"
-            record.value() shouldBe payload
+            // payload is stored as JSONB and read back normalized, so compare as JSON trees, not strings.
+            ObjectMapper().readTree(record.value()) shouldBe ObjectMapper().readTree(payload)
         }
     }
 

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/LedgerApplication.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/LedgerApplication.kt
@@ -5,12 +5,17 @@ package com.fincore.ledger
 
 import com.fincore.ledger.config.CleanupProperties
 import com.fincore.ledger.config.IdempotencyProperties
+import com.fincore.ledger.config.OutboxDispatcherProperties
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.runApplication
 
 @SpringBootApplication
-@EnableConfigurationProperties(IdempotencyProperties::class, CleanupProperties::class)
+@EnableConfigurationProperties(
+    IdempotencyProperties::class,
+    CleanupProperties::class,
+    OutboxDispatcherProperties::class,
+)
 class LedgerApplication
 
 fun main(args: Array<String>) {

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/application/outbox/ClaimedEvent.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/application/outbox/ClaimedEvent.kt
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.application.outbox
+
+import java.util.UUID
+
+data class ClaimedEvent(
+    val id: UUID,
+    val aggregateType: String,
+    val aggregateId: String,
+    val eventType: String,
+    val payload: String,
+    val attempts: Int,
+)
+
+data class DispatchSummary(
+    val published: Int,
+    val failed: Int,
+)

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/application/outbox/OutboxClaimStore.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/application/outbox/OutboxClaimStore.kt
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.application.outbox
+
+import com.fincore.events.OutboxStatus
+import com.fincore.ledger.infrastructure.persistence.OutboxEventRepository
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.time.Duration
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Transactional boundary for the dispatcher. Claim and settle are separate short transactions so the
+ * broker publish (in [OutboxDispatcher]) never runs inside a DB transaction (CLAUDE.md 8.10).
+ */
+@Component
+class OutboxClaimStore(
+    private val repository: OutboxEventRepository,
+) {
+    @Transactional
+    fun claim(
+        maxAttempts: Int,
+        leaseTimeout: Duration,
+        batchSize: Int,
+    ): List<ClaimedEvent> {
+        val now = Instant.now()
+        val orphanDeadline = now.minus(leaseTimeout)
+        return repository.lockClaimableBatch(maxAttempts, orphanDeadline, batchSize).map { entity ->
+            entity.status = OutboxStatus.PUBLISHING
+            entity.leasedAt = now
+            ClaimedEvent(
+                id = entity.id,
+                aggregateType = entity.aggregateType,
+                aggregateId = entity.aggregateId,
+                eventType = entity.eventType,
+                payload = entity.payload,
+                attempts = entity.attempts,
+            )
+        }
+    }
+
+    @Transactional
+    fun markPublished(id: UUID) {
+        repository.markPublished(id, OutboxStatus.PUBLISHED, Instant.now())
+    }
+
+    @Transactional
+    fun markFailed(
+        id: UUID,
+        attempts: Int,
+        maxAttempts: Int,
+        error: String?,
+    ) {
+        val status = if (attempts >= maxAttempts) OutboxStatus.PERMANENTLY_FAILED else OutboxStatus.FAILED
+        repository.markSettledFailure(id, status, attempts, error)
+    }
+}

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/application/outbox/OutboxDispatcher.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/application/outbox/OutboxDispatcher.kt
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.application.outbox
+
+import com.fincore.ledger.config.OutboxDispatcherProperties
+import org.slf4j.LoggerFactory
+import org.springframework.kafka.core.KafkaTemplate
+import java.util.concurrent.TimeUnit
+
+/**
+ * Relays claimed outbox events to the broker. Orchestration only - not transactional. Each event is
+ * published outside any transaction; settling its outcome is delegated to [OutboxClaimStore].
+ */
+class OutboxDispatcher(
+    private val claimStore: OutboxClaimStore,
+    private val kafkaTemplate: KafkaTemplate<String, String>,
+    private val properties: OutboxDispatcherProperties,
+) {
+    private val log = LoggerFactory.getLogger(javaClass)
+
+    fun dispatch(): DispatchSummary {
+        val claimed = claimStore.claim(properties.maxAttempts, properties.leaseTimeout, properties.batchSize)
+        var published = 0
+        for (event in claimed) {
+            if (publish(event)) published++
+        }
+        if (claimed.isNotEmpty()) {
+            log
+                .atInfo()
+                .addKeyValue("claimed", claimed.size)
+                .addKeyValue("published", published)
+                .addKeyValue("failed", claimed.size - published)
+                .log("outbox dispatch cycle completed")
+        }
+        return DispatchSummary(published, claimed.size - published)
+    }
+
+    @Suppress("TooGenericExceptionCaught")
+    private fun publish(event: ClaimedEvent): Boolean =
+        try {
+            val topic = "${properties.topicPrefix}.${event.aggregateType.lowercase()}"
+            kafkaTemplate
+                .send(topic, event.aggregateId, event.payload)
+                .get(properties.sendTimeout.toMillis(), TimeUnit.MILLISECONDS)
+            claimStore.markPublished(event.id)
+            true
+        } catch (ex: Exception) {
+            claimStore.markFailed(event.id, event.attempts + 1, properties.maxAttempts, ex.message)
+            false
+        }
+}

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/config/OutboxDispatchConfig.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/config/OutboxDispatchConfig.kt
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.config
+
+import com.fincore.ledger.application.outbox.OutboxClaimStore
+import com.fincore.ledger.application.outbox.OutboxDispatcher
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.scheduling.annotation.EnableScheduling
+import org.springframework.scheduling.annotation.Scheduled
+
+@Configuration
+@EnableScheduling
+@ConditionalOnProperty(
+    prefix = "fincore.ledger.dispatcher",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = false,
+)
+class OutboxDispatchConfig(
+    claimStore: OutboxClaimStore,
+    kafkaTemplate: KafkaTemplate<String, String>,
+    properties: OutboxDispatcherProperties,
+) {
+    private val dispatcher = OutboxDispatcher(claimStore, kafkaTemplate, properties)
+
+    @Bean
+    fun outboxDispatcher(): OutboxDispatcher = dispatcher
+
+    @Scheduled(fixedDelayString = "\${fincore.ledger.dispatcher.poll-delay}")
+    fun poll() {
+        dispatcher.dispatch()
+    }
+}

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/config/OutboxDispatcherProperties.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/config/OutboxDispatcherProperties.kt
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.validation.annotation.Validated
+import java.time.Duration
+
+@Validated
+@ConfigurationProperties(prefix = "fincore.ledger.dispatcher")
+data class OutboxDispatcherProperties(
+    val enabled: Boolean = false,
+    val pollDelay: Duration = defaultPollDelay,
+    val batchSize: Int = DEFAULT_BATCH_SIZE,
+    val maxAttempts: Int = DEFAULT_MAX_ATTEMPTS,
+    val leaseTimeout: Duration = defaultLeaseTimeout,
+    val sendTimeout: Duration = defaultSendTimeout,
+    val topicPrefix: String = "fincore",
+) {
+    init {
+        require(batchSize > 0) { "fincore.ledger.dispatcher.batch-size must be positive" }
+        require(maxAttempts > 0) { "fincore.ledger.dispatcher.max-attempts must be positive" }
+        require(!pollDelay.isNegative && !pollDelay.isZero) { "fincore.ledger.dispatcher.poll-delay must be positive" }
+        require(!leaseTimeout.isNegative && !leaseTimeout.isZero) {
+            "fincore.ledger.dispatcher.lease-timeout must be positive"
+        }
+        require(!sendTimeout.isNegative && !sendTimeout.isZero) { "fincore.ledger.dispatcher.send-timeout must be positive" }
+    }
+
+    private companion object {
+        const val DEFAULT_BATCH_SIZE = 100
+        const val DEFAULT_MAX_ATTEMPTS = 10
+        val defaultPollDelay: Duration = Duration.ofSeconds(1)
+        val defaultLeaseTimeout: Duration = Duration.ofMinutes(5)
+        val defaultSendTimeout: Duration = Duration.ofSeconds(10)
+    }
+}

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/OutboxEventEntity.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/OutboxEventEntity.kt
@@ -42,4 +42,6 @@ class OutboxEventEntity(
     var attempts: Int,
     @Column(name = "last_error")
     var lastError: String?,
+    @Column(name = "leased_at")
+    var leasedAt: Instant? = null,
 )

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/OutboxEventMapper.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/OutboxEventMapper.kt
@@ -5,11 +5,14 @@ package com.fincore.ledger.infrastructure.persistence
 
 import com.fincore.events.OutboxEvent
 import org.mapstruct.Mapper
+import org.mapstruct.Mapping
 import org.mapstruct.ReportingPolicy
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.ERROR)
 interface OutboxEventMapper {
     fun toDomain(entity: OutboxEventEntity): OutboxEvent
 
+    // leasedAt is a dispatcher-managed lease column, not part of the write-path domain event.
+    @Mapping(target = "leasedAt", ignore = true)
     fun toEntity(domain: OutboxEvent): OutboxEventEntity
 }

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/OutboxEventRepository.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/OutboxEventRepository.kt
@@ -18,4 +18,47 @@ interface OutboxEventRepository : JpaRepository<OutboxEventEntity, UUID> {
         @Param("status") status: OutboxStatus,
         @Param("cutoff") cutoff: Instant,
     ): Int
+
+    @Query(
+        nativeQuery = true,
+        value = """
+            SELECT id, aggregate_type, aggregate_id, event_type, payload, status,
+                   attempts, last_error, created_at, published_at, leased_at
+            FROM platform.outbox_events
+            WHERE status = 'PENDING'
+               OR (status = 'FAILED' AND attempts < :maxAttempts)
+               OR (status = 'PUBLISHING' AND leased_at < :orphanDeadline)
+            ORDER BY created_at
+            LIMIT :batchSize
+            FOR UPDATE SKIP LOCKED
+        """,
+    )
+    fun lockClaimableBatch(
+        @Param("maxAttempts") maxAttempts: Int,
+        @Param("orphanDeadline") orphanDeadline: Instant,
+        @Param("batchSize") batchSize: Int,
+    ): List<OutboxEventEntity>
+
+    @Modifying(clearAutomatically = true)
+    @Query(
+        "update OutboxEventEntity e set e.status = :status, e.publishedAt = :publishedAt, e.leasedAt = null " +
+            "where e.id = :id",
+    )
+    fun markPublished(
+        @Param("id") id: UUID,
+        @Param("status") status: OutboxStatus,
+        @Param("publishedAt") publishedAt: Instant,
+    ): Int
+
+    @Modifying(clearAutomatically = true)
+    @Query(
+        "update OutboxEventEntity e set e.status = :status, e.attempts = :attempts, " +
+            "e.lastError = :lastError, e.leasedAt = null where e.id = :id",
+    )
+    fun markSettledFailure(
+        @Param("id") id: UUID,
+        @Param("status") status: OutboxStatus,
+        @Param("attempts") attempts: Int,
+        @Param("lastError") lastError: String?,
+    ): Int
 }

--- a/services/ledger/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/ledger/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -37,3 +37,6 @@ databaseChangeLog:
   - include:
       file: v0.1/020-outbox-events-published-index.sql
       relativeToChangelogFile: true
+  - include:
+      file: v0.1/021-outbox-events-leased-at.sql
+      relativeToChangelogFile: true

--- a/services/ledger/src/main/resources/db/changelog/v0.1/021-outbox-events-leased-at.sql
+++ b/services/ledger/src/main/resources/db/changelog/v0.1/021-outbox-events-leased-at.sql
@@ -1,0 +1,10 @@
+--liquibase formatted sql
+-- SPDX-License-Identifier: BUSL-1.1
+-- SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+--changeset fincore:021-outbox-events-leased-at dbms:postgresql
+ALTER TABLE platform.outbox_events
+    ADD COLUMN IF NOT EXISTS leased_at TIMESTAMPTZ;
+CREATE INDEX IF NOT EXISTS idx_outbox_events_claimable
+    ON platform.outbox_events(status, created_at)
+    WHERE status IN ('PENDING', 'FAILED', 'PUBLISHING');

--- a/services/ledger/src/test/kotlin/com/fincore/ledger/application/outbox/OutboxDispatcherTest.kt
+++ b/services/ledger/src/test/kotlin/com/fincore/ledger/application/outbox/OutboxDispatcherTest.kt
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.application.outbox
+
+import com.fincore.ledger.config.OutboxDispatcherProperties
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.support.SendResult
+import java.time.Duration
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+
+class OutboxDispatcherTest {
+    private val claimStore = mockk<OutboxClaimStore>(relaxed = true)
+    private val kafkaTemplate = mockk<KafkaTemplate<String, String>>()
+    private val properties =
+        OutboxDispatcherProperties(
+            enabled = true,
+            batchSize = 10,
+            maxAttempts = 5,
+            sendTimeout = Duration.ofSeconds(2),
+            topicPrefix = "fincore",
+        )
+    private val dispatcher = OutboxDispatcher(claimStore, kafkaTemplate, properties)
+
+    @Test
+    fun `should publish each event to the prefixed aggregate topic keyed by aggregate id`() {
+        val id = UUID.randomUUID()
+        val event = ClaimedEvent(id, "Transaction", "tx_7", "type", "{\"id\":\"e1\"}", attempts = 0)
+        every { claimStore.claim(any(), any(), any()) } returns listOf(event)
+        every { kafkaTemplate.send("fincore.transaction", "tx_7", "{\"id\":\"e1\"}") } returns completed()
+
+        val summary = dispatcher.dispatch()
+
+        summary shouldBe DispatchSummary(published = 1, failed = 0)
+        verify { kafkaTemplate.send("fincore.transaction", "tx_7", "{\"id\":\"e1\"}") }
+        verify { claimStore.markPublished(id) }
+    }
+
+    @Test
+    fun `should continue the batch and settle a failed publish when one event throws`() {
+        val badId = UUID.randomUUID()
+        val okId = UUID.randomUUID()
+        val bad = ClaimedEvent(badId, "Transaction", "tx_bad", "type", "{}", attempts = 0)
+        val ok = ClaimedEvent(okId, "Transaction", "tx_ok", "type", "{}", attempts = 0)
+        every { claimStore.claim(any(), any(), any()) } returns listOf(bad, ok)
+        every { kafkaTemplate.send("fincore.transaction", "tx_bad", any()) } returns
+            CompletableFuture.failedFuture(RuntimeException("broker down"))
+        every { kafkaTemplate.send("fincore.transaction", "tx_ok", any()) } returns completed()
+
+        val summary = dispatcher.dispatch()
+
+        summary shouldBe DispatchSummary(published = 1, failed = 1)
+        verify { claimStore.markPublished(okId) }
+        verify { claimStore.markFailed(badId, 1, 5, any()) }
+    }
+
+    @Test
+    fun `should not register a dispatcher bean when the dispatcher is disabled`() {
+        ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of())
+            .withUserConfiguration(com.fincore.ledger.config.OutboxDispatchConfig::class.java)
+            .run { context ->
+                context.getBeanNamesForType(OutboxDispatcher::class.java).size shouldBe 0
+            }
+    }
+
+    private fun completed(): CompletableFuture<SendResult<String, String>> = CompletableFuture.completedFuture(mockk(relaxed = true))
+}

--- a/services/ledger/src/test/kotlin/com/fincore/ledger/config/OutboxDispatcherPropertiesTest.kt
+++ b/services/ledger/src/test/kotlin/com/fincore/ledger/config/OutboxDispatcherPropertiesTest.kt
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.config
+
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+import org.springframework.context.annotation.Configuration
+import java.time.Duration
+
+class OutboxDispatcherPropertiesTest {
+    private val runner =
+        ApplicationContextRunner().withUserConfiguration(EnablePropertiesConfig::class.java)
+
+    @Test
+    fun `should expose safe opt-in-off defaults when no overrides are supplied`() {
+        runner.run { context ->
+            val props = context.getBean(OutboxDispatcherProperties::class.java)
+            props.enabled shouldBe false
+            props.batchSize shouldBe 100
+            props.maxAttempts shouldBe 10
+            props.pollDelay shouldBe Duration.ofSeconds(1)
+            props.leaseTimeout shouldBe Duration.ofMinutes(5)
+            props.sendTimeout shouldBe Duration.ofSeconds(10)
+            props.topicPrefix shouldBe "fincore"
+        }
+    }
+
+    @Test
+    fun `should bind explicit overrides when supplied`() {
+        runner
+            .withPropertyValues(
+                "fincore.ledger.dispatcher.enabled=true",
+                "fincore.ledger.dispatcher.batch-size=50",
+                "fincore.ledger.dispatcher.max-attempts=3",
+                "fincore.ledger.dispatcher.lease-timeout=2m",
+                "fincore.ledger.dispatcher.topic-prefix=ledger",
+            ).run { context ->
+                val props = context.getBean(OutboxDispatcherProperties::class.java)
+                props.enabled shouldBe true
+                props.batchSize shouldBe 50
+                props.maxAttempts shouldBe 3
+                props.leaseTimeout shouldBe Duration.ofMinutes(2)
+                props.topicPrefix shouldBe "ledger"
+            }
+    }
+
+    @Test
+    fun `should reject a non-positive batch size`() {
+        runner.withPropertyValues("fincore.ledger.dispatcher.batch-size=0").run { context ->
+            context.startupFailure.shouldNotBeNull()
+        }
+    }
+
+    @Test
+    fun `should reject a non-positive max attempts`() {
+        runner.withPropertyValues("fincore.ledger.dispatcher.max-attempts=0").run { context ->
+            context.startupFailure.shouldNotBeNull()
+        }
+    }
+
+    @Configuration
+    @EnableConfigurationProperties(OutboxDispatcherProperties::class)
+    private class EnablePropertiesConfig
+}


### PR DESCRIPTION
## What

The core slice of E-03 (Event Bus): the relay that moves `PENDING` rows from `platform.outbox_events` to the broker. Wires `libs/fincore-eventbus` into the ledger.

A scheduled worker runs three phases that never hold a DB transaction across the broker call (CLAUDE.md 8.10):

1. **Claim** (`@Transactional`, `OutboxClaimStore`): native `SELECT ... FOR UPDATE SKIP LOCKED` of claimable rows (`PENDING`, retryable `FAILED`, or orphaned `PUBLISHING` past its lease), mark them `PUBLISHING` with `leased_at=now()`, return detached snapshots. SKIP LOCKED makes it multi-replica safe.
2. **Publish** (no transaction, `OutboxDispatcher`): send the envelope payload to `<prefix>.<aggregateType>` keyed by `aggregateId`, bounded by a send timeout.
3. **Settle** (separate `@Transactional` per row): `PUBLISHED` on success; on failure `attempts++` and `FAILED` while attempts remain, else `PERMANENTLY_FAILED`.

One slow or failing event never aborts the batch. A crash between publish and settle leaves the row `PUBLISHING`; the lease timeout makes it reclaimable, so delivery is **at-least-once with no silent loss** (duplicates are deduped by the consumer in #192).

## Notes

- Migration `021` adds `leased_at` + a partial claim index (idempotent `ADD COLUMN IF NOT EXISTS`).
- The dispatcher is **off by default**: its beans are `@ConditionalOnProperty(fincore.ledger.dispatcher.enabled=true)`, so the ledger needs no broker and existing startup/ITs are unchanged.
- `spring-kafka` is now exposed as `api` from `libs/fincore-eventbus` (its `@Bean` methods return `KafkaTemplate`).

## Decisions (see plan.md)

- Claim via native `SELECT ... FOR UPDATE SKIP LOCKED` returning managed entities (dirty-flush to `PUBLISHING`); settle via JPQL `@Modifying` by id (the detached snapshot is never re-attached).
- `FAILED` is the retryable state (`attempts < maxAttempts`); broker auto-creates topics (Redpanda default, proven in #189); explicit provisioning is #191.

## Gates

Local (`-x integrationTest`, Docker down in WSL): `:services:ledger:{test,detekt,detektTest,spotlessCheck,assemble,compileIntegrationTestKotlin}` green. ITs run on CI: `OutboxClaimStoreIT` (Postgres - incl. a real two-thread SKIP LOCKED no-double-claim test, orphan reclaim, the state machine) and `OutboxDispatcherIT` (Postgres + Redpanda - publish round-trip). critic GO-WITH-CHANGES (applied), code-reviewer APPROVE (nits applied), security-auditor PASS, evaluator 0.91.

Closes #190