### PR TITLE
feat(ledger): add outbox metrics gauges

### DIFF
--- a/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/infrastructure/persistence/OutboxMetricsRepositoryIT.kt
+++ b/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/infrastructure/persistence/OutboxMetricsRepositoryIT.kt
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.infrastructure.persistence
+
+import com.fincore.events.OutboxStatus
+import com.fincore.test.containers.PostgresContainerExtension
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import java.util.UUID
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@ExtendWith(PostgresContainerExtension::class)
+class OutboxMetricsRepositoryIT(
+    @Autowired private val repository: OutboxEventRepository,
+) {
+    @AfterEach
+    fun cleanUp() {
+        repository.deleteAll()
+    }
+
+    @Test
+    fun `should count rows by status`() {
+        seed(OutboxStatus.PENDING, Instant.parse("2026-06-18T10:00:00Z"))
+        seed(OutboxStatus.PENDING, Instant.parse("2026-06-18T10:05:00Z"))
+        seed(OutboxStatus.FAILED, Instant.parse("2026-06-18T10:00:00Z"))
+
+        repository.countByStatus(OutboxStatus.PENDING) shouldBe 2L
+        repository.countByStatus(OutboxStatus.FAILED) shouldBe 1L
+        repository.countByStatus(OutboxStatus.PERMANENTLY_FAILED) shouldBe 0L
+    }
+
+    @Test
+    fun `should return the oldest created-at for a status and null when none`() {
+        val oldest = Instant.parse("2026-06-18T10:00:00Z")
+        seed(OutboxStatus.PENDING, Instant.parse("2026-06-18T10:05:00Z"))
+        seed(OutboxStatus.PENDING, oldest)
+
+        repository.oldestCreatedAt(OutboxStatus.PENDING) shouldBe oldest
+        repository.oldestCreatedAt(OutboxStatus.PUBLISHED).shouldBeNull()
+    }
+
+    private fun seed(
+        status: OutboxStatus,
+        createdAt: Instant,
+    ) {
+        repository.save(
+            OutboxEventEntity(
+                id = UUID.randomUUID(),
+                aggregateType = "Transaction",
+                aggregateId = UUID.randomUUID().toString(),
+                eventType = "com.fincore.ledger.transaction.posted.v1",
+                payload = "{\"id\":\"e1\"}",
+                status = status,
+                createdAt = createdAt,
+                publishedAt = null,
+                attempts = 0,
+                lastError = null,
+                leasedAt = null,
+            ),
+        )
+    }
+
+    companion object {
+        @JvmStatic
+        @DynamicPropertySource
+        fun datasourceProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { PostgresContainerExtension.jdbcUrl }
+            registry.add("spring.datasource.username") { PostgresContainerExtension.username }
+            registry.add("spring.datasource.password") { PostgresContainerExtension.password }
+            registry.add("spring.jpa.hibernate.ddl-auto") { "none" }
+        }
+    }
+}

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/application/OutboxMetrics.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/application/OutboxMetrics.kt
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.application
+
+import com.fincore.events.OutboxStatus
+import com.fincore.ledger.infrastructure.persistence.OutboxEventRepository
+import io.micrometer.core.instrument.Gauge
+import io.micrometer.core.instrument.MeterRegistry
+import org.springframework.stereotype.Component
+import java.time.Duration
+import java.time.Instant
+
+@Component
+class OutboxMetrics(
+    registry: MeterRegistry,
+    repository: OutboxEventRepository,
+) {
+    init {
+        OutboxStatus.entries.forEach { status ->
+            Gauge
+                .builder(METRIC_EVENTS, repository) { it.countByStatus(status).toDouble() }
+                .tag(TAG_STATUS, status.name)
+                .register(registry)
+        }
+        Gauge
+            .builder(METRIC_LAG_SECONDS, repository) { lagSeconds(it.oldestCreatedAt(OutboxStatus.PENDING), Instant.now()) }
+            .register(registry)
+    }
+
+    companion object {
+        const val METRIC_EVENTS = "fincore.outbox.events"
+        const val METRIC_LAG_SECONDS = "fincore.outbox.lag.seconds"
+        const val TAG_STATUS = "status"
+        private const val NO_LAG = 0.0
+        private const val MILLIS_PER_SECOND = 1000.0
+
+        fun lagSeconds(
+            oldestPending: Instant?,
+            now: Instant,
+        ): Double =
+            if (oldestPending == null) {
+                NO_LAG
+            } else {
+                Duration.between(oldestPending, now).toMillis().toDouble() / MILLIS_PER_SECOND
+            }
+    }
+}

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/OutboxEventRepository.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/OutboxEventRepository.kt
@@ -61,4 +61,11 @@ interface OutboxEventRepository : JpaRepository<OutboxEventEntity, UUID> {
         @Param("attempts") attempts: Int,
         @Param("lastError") lastError: String?,
     ): Int
+
+    fun countByStatus(status: OutboxStatus): Long
+
+    @Query("select min(e.createdAt) from OutboxEventEntity e where e.status = :status")
+    fun oldestCreatedAt(
+        @Param("status") status: OutboxStatus,
+    ): Instant?
 }

--- a/services/ledger/src/test/kotlin/com/fincore/ledger/application/OutboxMetricsTest.kt
+++ b/services/ledger/src/test/kotlin/com/fincore/ledger/application/OutboxMetricsTest.kt
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.ledger.application
+
+import com.fincore.events.OutboxStatus
+import com.fincore.ledger.infrastructure.persistence.OutboxEventRepository
+import io.kotest.matchers.shouldBe
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class OutboxMetricsTest {
+    private val registry = SimpleMeterRegistry()
+    private val repository = mockk<OutboxEventRepository>()
+
+    @Test
+    fun `should expose one bounded gauge per status reflecting its count`() {
+        OutboxStatus.entries.forEachIndexed { index, status ->
+            every { repository.countByStatus(status) } returns (index + 1).toLong()
+        }
+        every { repository.oldestCreatedAt(OutboxStatus.PENDING) } returns null
+
+        OutboxMetrics(registry, repository)
+
+        OutboxStatus.entries.forEachIndexed { index, status ->
+            registry
+                .get(OutboxMetrics.METRIC_EVENTS)
+                .tag(OutboxMetrics.TAG_STATUS, status.name)
+                .gauge()
+                .value() shouldBe
+                (index + 1).toDouble()
+        }
+        registry.find(OutboxMetrics.METRIC_EVENTS).gauges().size shouldBe OutboxStatus.entries.size
+    }
+
+    @Test
+    fun `should report zero lag when there is no pending row`() {
+        every { repository.countByStatus(any()) } returns NONE
+        every { repository.oldestCreatedAt(OutboxStatus.PENDING) } returns null
+
+        OutboxMetrics(registry, repository)
+
+        registry.get(OutboxMetrics.METRIC_LAG_SECONDS).gauge().value() shouldBe NO_LAG
+    }
+
+    @Test
+    fun `should compute lag as the age of the oldest pending row`() {
+        val now = Instant.parse("2026-06-18T00:01:00Z")
+        val oldest = now.minusSeconds(AGE_SECONDS)
+
+        OutboxMetrics.lagSeconds(oldest, now) shouldBe AGE_SECONDS.toDouble()
+        OutboxMetrics.lagSeconds(null, now) shouldBe NO_LAG
+    }
+
+    private companion object {
+        const val NONE = 0L
+        const val NO_LAG = 0.0
+        const val AGE_SECONDS = 60L
+    }
+}


### PR DESCRIPTION
## What

Outbox observability for E-03, wired into the ledger's existing Micrometer + Prometheus stack (#51).

- `fincore.outbox.events{status}` - a gauge per `OutboxStatus` reporting the current row count (pending depth, failed, permanently-failed, published, publishing).
- `fincore.outbox.lag.seconds` - the age of the oldest still-unpublished (PENDING) row, 0 when drained; the operator-meaningful "how far behind is dispatch" signal.
- Backed by two read-only repository queries: `countByStatus` and `oldestCreatedAt(status): Instant?`.

**Bounded cardinality** (the key risk for a metrics slice): tags are only the fixed `OutboxStatus` enum - never `aggregateId`/`topic`/`id`. The gauges are read-only and polled at scrape time (no transaction, no startup DB hit), mirroring `LedgerMetrics`.

## Gates

Local (`-x integrationTest`, Docker down in WSL): `:services:ledger:{test,detekt,detektTest,spotlessCheck,assemble,compileIntegrationTestKotlin}` green. The `@DataJpaTest` Postgres IT runs on CI: `countByStatus` and `oldestCreatedAt` (incl. the null case). critic GO (IT tx-boundary + nullable `oldestCreatedAt` applied), code-reviewer APPROVE (sub-second lag precision + unique IT aggregateId applied), security-auditor PASS, evaluator 0.92.

Closes #196