### PR TITLE
feat(payments): scaffold payments service and payment domain

### DIFF
--- a/services/payments/build.gradle.kts
+++ b/services/payments/build.gradle.kts
@@ -1,0 +1,118 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.spring)
+    alias(libs.plugins.kotlin.jpa)
+    alias(libs.plugins.spring.boot)
+    alias(libs.plugins.spring.dependency.management)
+    alias(libs.plugins.kotlin.kapt)
+}
+
+description = "FinCore Payments service: payment lifecycle, idempotency, outbox"
+
+kotlin {
+    jvmToolchain(21)
+}
+
+dependencies {
+    implementation(project(":libs:fincore-core"))
+    implementation(project(":libs:fincore-events"))
+    implementation(project(":libs:fincore-eventbus"))
+
+    implementation(libs.kotlin.stdlib)
+    implementation(libs.kotlin.reflect)
+    implementation(libs.jackson.module.kotlin)
+
+    implementation(libs.spring.boot.starter.web)
+    implementation(libs.spring.boot.starter.data.jpa)
+    implementation(libs.spring.boot.starter.security)
+    implementation(libs.spring.boot.starter.oauth2.resource.server)
+    implementation(libs.spring.boot.starter.actuator)
+    implementation(libs.spring.boot.starter.validation)
+    implementation(libs.springdoc.openapi.starter)
+
+    implementation(libs.mapstruct.core)
+    kapt(libs.mapstruct.processor)
+
+    implementation(libs.liquibase.core)
+    runtimeOnly(libs.postgres.jdbc)
+
+    implementation(libs.micrometer.registry.prometheus)
+    implementation(libs.micrometer.tracing.bridge.otel)
+    implementation(libs.opentelemetry.api)
+    implementation(libs.opentelemetry.exporter.otlp)
+
+    testImplementation(project(":libs:fincore-test-support"))
+    testImplementation(libs.spring.boot.starter.test)
+    testImplementation(libs.spring.security.test)
+    testImplementation(libs.kotest.assertions.core)
+    testImplementation(libs.kotest.property)
+    testImplementation(libs.kotest.runner.junit5)
+    testImplementation(libs.mockk)
+    testImplementation(libs.testcontainers.core)
+    testImplementation(libs.testcontainers.postgres)
+    testImplementation(libs.testcontainers.junit5)
+}
+
+tasks.test {
+    useJUnitPlatform()
+}
+
+sourceSets {
+    create("integrationTest") {
+        compileClasspath += sourceSets["main"].output + sourceSets["test"].output
+        runtimeClasspath += sourceSets["main"].output + sourceSets["test"].output
+    }
+}
+
+configurations["integrationTestImplementation"].extendsFrom(configurations["testImplementation"])
+configurations["integrationTestRuntimeOnly"].extendsFrom(configurations["testRuntimeOnly"])
+
+dependencies {
+    "integrationTestImplementation"(libs.postgres.jdbc)
+}
+
+val integrationTest =
+    tasks.register<Test>("integrationTest") {
+        description = "Runs integration tests (Spring Boot + Testcontainers)."
+        group = "verification"
+        testClassesDirs = sourceSets["integrationTest"].output.classesDirs
+        classpath = sourceSets["integrationTest"].runtimeClasspath
+        useJUnitPlatform()
+        shouldRunAfter(tasks.named("test"))
+    }
+
+tasks.named<JacocoCoverageVerification>("jacocoTestCoverageVerification") {
+    dependsOn(tasks.test)
+    classDirectories.setFrom(
+        files(
+            classDirectories.files.map { dir ->
+                fileTree(dir) {
+                    include("**/com/fincore/payments/domain/**")
+                    exclude("**/*MapperImpl*", "**/config/**")
+                }
+            },
+        ),
+    )
+    violationRules {
+        rule {
+            limit {
+                counter = "LINE"
+                value = "COVEREDRATIO"
+                minimum = "0.90".toBigDecimal()
+            }
+            limit {
+                counter = "BRANCH"
+                value = "COVEREDRATIO"
+                minimum = "0.90".toBigDecimal()
+            }
+        }
+    }
+}
+
+tasks.named("check") {
+    dependsOn(integrationTest)
+    dependsOn(tasks.named("jacocoTestCoverageVerification"))
+}

--- a/services/payments/src/main/kotlin/com/fincore/payments/PaymentsApplication.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/PaymentsApplication.kt
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+class PaymentsApplication
+
+fun main(args: Array<String>) {
+    runApplication<PaymentsApplication>(*args)
+}

--- a/services/payments/src/main/kotlin/com/fincore/payments/domain/Payment.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/domain/Payment.kt
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.domain
+
+import com.fincore.core.Money
+import com.fincore.core.PaymentId
+import com.fincore.payments.domain.enum.PaymentStatus
+import com.fincore.payments.domain.exception.PaymentDomainException
+
+class Payment(
+    val id: PaymentId,
+    val amount: Money,
+    reference: String,
+    status: PaymentStatus = PaymentStatus.INITIATED,
+) {
+    val reference: String = validatedReference(reference)
+
+    var status: PaymentStatus = status
+        private set
+
+    fun transitionTo(target: PaymentStatus) {
+        if (!status.canTransitionTo(target)) {
+            throw PaymentDomainException("Illegal payment status transition: $status -> $target for payment $id")
+        }
+        status = target
+    }
+
+    fun isTerminal(): Boolean = status.isTerminal()
+
+    private fun validatedReference(value: String): String {
+        if (value.isBlank() || value.length > MAX_REFERENCE_LENGTH) {
+            throw PaymentDomainException(
+                "Payment reference must be non-blank and at most $MAX_REFERENCE_LENGTH characters",
+            )
+        }
+        return value
+    }
+
+    private companion object {
+        const val MAX_REFERENCE_LENGTH = 140
+    }
+}

--- a/services/payments/src/main/kotlin/com/fincore/payments/domain/enum/PaymentStatus.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/domain/enum/PaymentStatus.kt
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.domain.enum
+
+enum class PaymentStatus {
+    INITIATED,
+    SCREENING,
+    SUBMITTED,
+    SETTLED,
+    FAILED,
+    CANCELLED,
+    ;
+
+    fun isTerminal(): Boolean = this == SETTLED || this == FAILED || this == CANCELLED
+
+    fun canTransitionTo(target: PaymentStatus): Boolean =
+        when (this) {
+            INITIATED -> target == SCREENING || target == CANCELLED
+            SCREENING -> target == SUBMITTED || target == FAILED || target == CANCELLED
+            SUBMITTED -> target == SETTLED || target == FAILED
+            SETTLED, FAILED, CANCELLED -> false
+        }
+}

--- a/services/payments/src/main/kotlin/com/fincore/payments/domain/exception/PaymentDomainException.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/domain/exception/PaymentDomainException.kt
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.domain.exception
+
+class PaymentDomainException(
+    message: String,
+) : RuntimeException(message)

--- a/services/payments/src/main/resources/application.yml
+++ b/services/payments/src/main/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  application:
+    name: payments

--- a/services/payments/src/test/kotlin/com/fincore/payments/domain/PaymentTest.kt
+++ b/services/payments/src/test/kotlin/com/fincore/payments/domain/PaymentTest.kt
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.domain
+
+import com.fincore.core.Currency
+import com.fincore.core.Money
+import com.fincore.core.PaymentId
+import com.fincore.payments.domain.enum.PaymentStatus
+import com.fincore.payments.domain.exception.PaymentDomainException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+class PaymentTest {
+    @Test
+    fun `should apply a legal transition`() {
+        val payment = payment()
+
+        payment.transitionTo(PaymentStatus.SCREENING)
+
+        payment.status shouldBe PaymentStatus.SCREENING
+    }
+
+    @Test
+    fun `should reject an illegal transition and leave the status unchanged`() {
+        val payment = payment()
+
+        shouldThrow<PaymentDomainException> { payment.transitionTo(PaymentStatus.SETTLED) }
+
+        payment.status shouldBe PaymentStatus.INITIATED
+    }
+
+    @Test
+    fun `should reject a blank reference`() {
+        shouldThrow<PaymentDomainException> { payment(reference = " ") }
+    }
+
+    @Test
+    fun `should reject an over-long reference`() {
+        shouldThrow<PaymentDomainException> { payment(reference = "a".repeat(OVER_MAX_REFERENCE)) }
+    }
+
+    @Test
+    fun `should report terminal only in a terminal status`() {
+        payment(status = PaymentStatus.SETTLED).isTerminal() shouldBe true
+        payment().isTerminal() shouldBe false
+    }
+
+    private fun payment(
+        reference: String = "order-1",
+        status: PaymentStatus = PaymentStatus.INITIATED,
+    ): Payment = Payment(PaymentId.generate(), Money(BigDecimal("100.00"), Currency.USD), reference, status)
+
+    private companion object {
+        const val OVER_MAX_REFERENCE = 141
+    }
+}

--- a/services/payments/src/test/kotlin/com/fincore/payments/domain/PaymentTransitionPropertyTest.kt
+++ b/services/payments/src/test/kotlin/com/fincore/payments/domain/PaymentTransitionPropertyTest.kt
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.domain
+
+import com.fincore.core.Currency
+import com.fincore.core.Money
+import com.fincore.core.PaymentId
+import com.fincore.payments.domain.enum.PaymentStatus
+import com.fincore.payments.domain.exception.PaymentDomainException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+
+class PaymentTransitionPropertyTest {
+    @Test
+    fun `should transition iff the edge is legal for every status pair`() {
+        PaymentStatus.entries.forEach { from ->
+            PaymentStatus.entries.forEach { to ->
+                val payment = Payment(PaymentId.generate(), Money(BigDecimal("100.00"), Currency.USD), "order-1", from)
+
+                if (from.canTransitionTo(to)) {
+                    payment.transitionTo(to)
+                    payment.status shouldBe to
+                } else {
+                    shouldThrow<PaymentDomainException> { payment.transitionTo(to) }
+                    payment.status shouldBe from
+                }
+            }
+        }
+    }
+}

--- a/services/payments/src/test/kotlin/com/fincore/payments/domain/enum/PaymentStatusTest.kt
+++ b/services/payments/src/test/kotlin/com/fincore/payments/domain/enum/PaymentStatusTest.kt
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.domain.enum
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class PaymentStatusTest {
+    @Test
+    fun `should report terminal for settled failed and cancelled only`() {
+        PaymentStatus.SETTLED.isTerminal() shouldBe true
+        PaymentStatus.FAILED.isTerminal() shouldBe true
+        PaymentStatus.CANCELLED.isTerminal() shouldBe true
+        PaymentStatus.INITIATED.isTerminal() shouldBe false
+        PaymentStatus.SCREENING.isTerminal() shouldBe false
+        PaymentStatus.SUBMITTED.isTerminal() shouldBe false
+    }
+
+    @Test
+    fun `should allow only screening or cancelled from initiated`() {
+        PaymentStatus.INITIATED.canTransitionTo(PaymentStatus.SCREENING) shouldBe true
+        PaymentStatus.INITIATED.canTransitionTo(PaymentStatus.CANCELLED) shouldBe true
+        PaymentStatus.INITIATED.canTransitionTo(PaymentStatus.SUBMITTED) shouldBe false
+        PaymentStatus.INITIATED.canTransitionTo(PaymentStatus.SETTLED) shouldBe false
+    }
+
+    @Test
+    fun `should allow only settled or failed from submitted`() {
+        PaymentStatus.SUBMITTED.canTransitionTo(PaymentStatus.SETTLED) shouldBe true
+        PaymentStatus.SUBMITTED.canTransitionTo(PaymentStatus.FAILED) shouldBe true
+        PaymentStatus.SUBMITTED.canTransitionTo(PaymentStatus.CANCELLED) shouldBe false
+    }
+
+    @Test
+    fun `should allow no transition out of a terminal status`() {
+        PaymentStatus.SETTLED.canTransitionTo(PaymentStatus.FAILED) shouldBe false
+        PaymentStatus.FAILED.canTransitionTo(PaymentStatus.SUBMITTED) shouldBe false
+        PaymentStatus.CANCELLED.canTransitionTo(PaymentStatus.INITIATED) shouldBe false
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -28,4 +28,5 @@ include(
     ":libs:decision-engine",
     ":services:ledger",
     ":services:decision",
+    ":services:payments",
 )


### PR DESCRIPTION
## What

Foundation slice of E-02 Payments. Adds the `services/payments` Spring Boot module (mirrors `services/ledger`) and the pure payment domain.

- `PaymentStatus` lifecycle: `INITIATED -> SCREENING|CANCELLED`, `SCREENING -> SUBMITTED|FAILED|CANCELLED`, `SUBMITTED -> SETTLED|FAILED`; `SETTLED/FAILED/CANCELLED` terminal. `canTransitionTo` + `isTerminal`.
- `Payment` aggregate: `PaymentId` + `Money` reused from `fincore-core`, validated non-blank reference, `status` mutable only through a guarded `transitionTo` that throws `PaymentDomainException` on an illegal edge and leaves the status unchanged.
- Framework-free domain (no Spring/JPA imports), so it is unit/property-testable without a context.

Late terminal-conflicting provider callbacks are handled as out-of-band reconciliation by the webhook handler (#214), not as state-machine edges (terminals stay closed).

## Gates

Local (`-x integrationTest`): `:services:payments:{test,detekt,detektTest,spotlessCheck,assemble,jacocoTestCoverageVerification}` green - the domain JaCoCo gate (0.90 line/branch on `com.fincore.payments.domain`) passes via an exhaustive 6x6 transition-matrix test plus unit tests. critic GO, security-auditor PASS, evaluator 0.92. No `@SpringBootTest` this slice, so the full starter set on the classpath starts no context.

Closes #208