### PR TITLE
feat(payments): add payment service with transactional outbox emit

### DIFF
--- a/services/payments/src/integrationTest/kotlin/com/fincore/payments/application/PaymentServiceIT.kt
+++ b/services/payments/src/integrationTest/kotlin/com/fincore/payments/application/PaymentServiceIT.kt
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.application
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fincore.core.Currency
+import com.fincore.core.Money
+import com.fincore.events.OutboxStatus
+import com.fincore.events.PaymentEvents
+import com.fincore.payments.domain.enum.PaymentStatus
+import com.fincore.payments.infrastructure.outbox.PaymentOutboxEventPublisherImpl
+import com.fincore.payments.infrastructure.persistence.PaymentEventRepository
+import com.fincore.payments.infrastructure.persistence.PaymentIdempotencyKeyRepository
+import com.fincore.payments.infrastructure.persistence.PaymentOutboxEventRepository
+import com.fincore.payments.infrastructure.persistence.PaymentPersistenceAdapter
+import com.fincore.payments.infrastructure.persistence.PaymentRepository
+import com.fincore.test.containers.PostgresContainerExtension
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@ExtendWith(PostgresContainerExtension::class)
+@Import(
+    PaymentServiceImpl::class,
+    PaymentIdempotencyStore::class,
+    PaymentPersistenceAdapter::class,
+    PaymentOutboxEventPublisherImpl::class,
+    PaymentServiceIT.ObjectMapperConfig::class,
+)
+class PaymentServiceIT(
+    @Autowired private val service: PaymentService,
+    @Autowired private val payments: PaymentRepository,
+    @Autowired private val paymentEvents: PaymentEventRepository,
+    @Autowired private val outbox: PaymentOutboxEventRepository,
+    @Autowired private val keys: PaymentIdempotencyKeyRepository,
+) {
+    @AfterEach
+    fun cleanUp() {
+        paymentEvents.deleteAll()
+        outbox.deleteAll()
+        keys.deleteAll()
+        payments.deleteAll()
+    }
+
+    @Test
+    fun `should persist a payment an event log row and a pending outbox event when initiating`() {
+        val payment = service.initiate(InitiatePaymentCommand("key-1", money(), "order-1"))
+
+        payments.findById(payment.id.value).isPresent shouldBe true
+        paymentEvents.count() shouldBe 1L
+        val outboxRows = outbox.findAll()
+        outboxRows.size shouldBe 1
+        outboxRows.first().status shouldBe OutboxStatus.PENDING
+        outboxRows.first().eventType shouldBe PaymentEvents.PaymentInitiated.fullType
+    }
+
+    @Test
+    fun `should not create a second payment when initiating twice with the same key`() {
+        val first = service.initiate(InitiatePaymentCommand("key-1", money(), "order-1"))
+        val second = service.initiate(InitiatePaymentCommand("key-1", money(), "order-1"))
+
+        second.id shouldBe first.id
+        payments.count() shouldBe 1L
+        outbox.count() shouldBe 1L
+    }
+
+    @Test
+    fun `should cancel an initiated payment and emit a cancelled event`() {
+        val payment = service.initiate(InitiatePaymentCommand("key-1", money(), "order-1"))
+
+        service.cancel(payment.id)
+
+        payments.findById(payment.id.value).orElseThrow().status shouldBe PaymentStatus.CANCELLED
+        outbox.findAll().any { it.eventType == PaymentEvents.PaymentCancelled.fullType } shouldBe true
+    }
+
+    private fun money(): Money = Money(BigDecimal("100.00"), Currency.USD)
+
+    @TestConfiguration
+    class ObjectMapperConfig {
+        @Bean
+        fun objectMapper(): ObjectMapper = ObjectMapper().findAndRegisterModules()
+    }
+
+    companion object {
+        @JvmStatic
+        @DynamicPropertySource
+        fun datasourceProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { PostgresContainerExtension.jdbcUrl }
+            registry.add("spring.datasource.username") { PostgresContainerExtension.username }
+            registry.add("spring.datasource.password") { PostgresContainerExtension.password }
+            registry.add("spring.jpa.hibernate.ddl-auto") { "none" }
+        }
+    }
+}

--- a/services/payments/src/main/kotlin/com/fincore/payments/application/InitiatePaymentCommand.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/application/InitiatePaymentCommand.kt
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.application
+
+import com.fincore.core.Money
+
+data class InitiatePaymentCommand(
+    val idempotencyKey: String,
+    val amount: Money,
+    val reference: String,
+)

--- a/services/payments/src/main/kotlin/com/fincore/payments/application/PaymentConcurrencyException.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/application/PaymentConcurrencyException.kt
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.application
+
+class PaymentConcurrencyException(
+    cause: Throwable,
+) : RuntimeException("Could not settle a concurrent payment initiation after retries", cause)

--- a/services/payments/src/main/kotlin/com/fincore/payments/application/PaymentEventData.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/application/PaymentEventData.kt
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.application
+
+import com.fincore.payments.domain.Payment
+
+data class PaymentEventData(
+    val paymentId: String,
+    val reference: String,
+    val amount: String,
+    val currency: String,
+    val status: String,
+) {
+    companion object {
+        fun from(payment: Payment): PaymentEventData =
+            PaymentEventData(
+                paymentId = payment.id.toString(),
+                reference = payment.reference,
+                amount = payment.amount.amount.toPlainString(),
+                currency = payment.amount.currency.code,
+                status = payment.status.name,
+            )
+    }
+}

--- a/services/payments/src/main/kotlin/com/fincore/payments/application/PaymentIdempotencyStore.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/application/PaymentIdempotencyStore.kt
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.application
+
+import com.fincore.payments.domain.Payment
+import com.fincore.payments.infrastructure.persistence.PaymentIdempotencyKeyEntity
+import com.fincore.payments.infrastructure.persistence.PaymentIdempotencyKeyRepository
+import com.fincore.payments.infrastructure.persistence.PaymentPersistenceAdapter
+import com.fincore.payments.infrastructure.persistence.PaymentRepository
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+// Raised when a concurrent caller already committed this idempotency key. The orchestrator retries in a fresh
+// transaction, where the winner's committed key is found and its payment replayed.
+internal class PaymentIdempotencyRaceException(
+    cause: Throwable,
+) : RuntimeException(cause)
+
+@Component
+class PaymentIdempotencyStore(
+    private val keyRepository: PaymentIdempotencyKeyRepository,
+    private val paymentRepository: PaymentRepository,
+    private val adapter: PaymentPersistenceAdapter,
+) {
+    @Transactional
+    fun reserveOrRun(
+        keyHash: String,
+        action: () -> Payment,
+    ): Payment {
+        val existing = keyRepository.findById(keyHash).orElse(null)
+        if (existing != null) {
+            val entity =
+                paymentRepository.findById(existing.paymentId).orElseThrow {
+                    IllegalStateException("Idempotency key references a missing payment ${existing.paymentId}")
+                }
+            return adapter.toDomain(entity)
+        }
+        val payment = action()
+        try {
+            keyRepository.saveAndFlush(PaymentIdempotencyKeyEntity(keyHash, payment.id.value, Instant.now()))
+        } catch (duplicate: DataIntegrityViolationException) {
+            throw PaymentIdempotencyRaceException(duplicate)
+        }
+        return payment
+    }
+}

--- a/services/payments/src/main/kotlin/com/fincore/payments/application/PaymentService.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/application/PaymentService.kt
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.application
+
+import com.fincore.core.PaymentId
+import com.fincore.payments.domain.Payment
+
+interface PaymentService {
+    fun initiate(command: InitiatePaymentCommand): Payment
+
+    fun cancel(id: PaymentId): Payment
+}

--- a/services/payments/src/main/kotlin/com/fincore/payments/application/PaymentServiceImpl.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/application/PaymentServiceImpl.kt
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.application
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fincore.core.PaymentId
+import com.fincore.events.EventEnvelope
+import com.fincore.events.EventType
+import com.fincore.events.PaymentEvents
+import com.fincore.payments.domain.Payment
+import com.fincore.payments.domain.enum.PaymentStatus
+import com.fincore.payments.domain.exception.PaymentNotFoundException
+import com.fincore.payments.infrastructure.outbox.PaymentOutboxEventPublisher
+import com.fincore.payments.infrastructure.persistence.PaymentEventEntity
+import com.fincore.payments.infrastructure.persistence.PaymentEventRepository
+import com.fincore.payments.infrastructure.persistence.PaymentPersistenceAdapter
+import com.fincore.payments.infrastructure.persistence.PaymentRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import java.util.UUID
+
+@Service
+class PaymentServiceImpl(
+    private val idempotencyStore: PaymentIdempotencyStore,
+    private val paymentRepository: PaymentRepository,
+    private val paymentEventRepository: PaymentEventRepository,
+    private val adapter: PaymentPersistenceAdapter,
+    private val outboxPublisher: PaymentOutboxEventPublisher,
+    private val objectMapper: ObjectMapper,
+) : PaymentService {
+    override fun initiate(command: InitiatePaymentCommand): Payment {
+        val keyHash = Sha256.hex(command.idempotencyKey)
+        var attempt = 0
+        while (true) {
+            try {
+                return idempotencyStore.reserveOrRun(keyHash) { createPayment(command) }
+            } catch (race: PaymentIdempotencyRaceException) {
+                attempt++
+                if (attempt >= MAX_ATTEMPTS) throw PaymentConcurrencyException(race)
+            }
+        }
+    }
+
+    @Transactional
+    override fun cancel(id: PaymentId): Payment {
+        val entity = paymentRepository.findById(id.value).orElseThrow { PaymentNotFoundException(id) }
+        val payment = adapter.toDomain(entity)
+        payment.transitionTo(PaymentStatus.CANCELLED)
+        entity.status = payment.status
+        paymentRepository.saveAndFlush(entity)
+        recordEvent(payment, PaymentEvents.PaymentCancelled)
+        return payment
+    }
+
+    private fun createPayment(command: InitiatePaymentCommand): Payment {
+        val payment = Payment(PaymentId.generate(), command.amount, command.reference)
+        paymentRepository.saveAndFlush(adapter.toNewEntity(payment, Instant.now()))
+        recordEvent(payment, PaymentEvents.PaymentInitiated)
+        return payment
+    }
+
+    private fun recordEvent(
+        payment: Payment,
+        type: EventType,
+    ) {
+        val now = Instant.now()
+        val envelope =
+            EventEnvelope.of(
+                source = SOURCE,
+                type = type,
+                data = PaymentEventData.from(payment),
+                subject = payment.id.toString(),
+            )
+        paymentEventRepository.saveAndFlush(
+            PaymentEventEntity(UUID.randomUUID(), payment.id.value, type.fullType, objectMapper.writeValueAsString(envelope), now),
+        )
+        outboxPublisher.publish(envelope, AGGREGATE_TYPE, payment.id.toString(), type.fullType, now)
+    }
+
+    private companion object {
+        const val MAX_ATTEMPTS = 3
+        const val SOURCE = "payments"
+        const val AGGREGATE_TYPE = "Payment"
+    }
+}

--- a/services/payments/src/main/kotlin/com/fincore/payments/application/Sha256.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/application/Sha256.kt
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.application
+
+import java.security.MessageDigest
+
+object Sha256 {
+    fun hex(value: String): String =
+        MessageDigest
+            .getInstance("SHA-256")
+            .digest(value.toByteArray(Charsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }
+}

--- a/services/payments/src/main/kotlin/com/fincore/payments/domain/exception/PaymentNotFoundException.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/domain/exception/PaymentNotFoundException.kt
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.domain.exception
+
+import com.fincore.core.PaymentId
+
+class PaymentNotFoundException(
+    id: PaymentId,
+) : RuntimeException("Payment not found: $id")

--- a/services/payments/src/main/kotlin/com/fincore/payments/infrastructure/outbox/PaymentOutboxEventPublisher.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/infrastructure/outbox/PaymentOutboxEventPublisher.kt
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.infrastructure.outbox
+
+import com.fincore.events.EventEnvelope
+import java.time.Instant
+
+interface PaymentOutboxEventPublisher {
+    fun publish(
+        envelope: EventEnvelope<*>,
+        aggregateType: String,
+        aggregateId: String,
+        eventType: String,
+        createdAt: Instant,
+    )
+}

--- a/services/payments/src/main/kotlin/com/fincore/payments/infrastructure/outbox/PaymentOutboxEventPublisherImpl.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/infrastructure/outbox/PaymentOutboxEventPublisherImpl.kt
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.infrastructure.outbox
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fincore.events.EventEnvelope
+import com.fincore.events.OutboxStatus
+import com.fincore.payments.infrastructure.persistence.PaymentOutboxEventEntity
+import com.fincore.payments.infrastructure.persistence.PaymentOutboxEventRepository
+import org.springframework.stereotype.Component
+import org.springframework.transaction.support.TransactionSynchronizationManager
+import java.time.Instant
+import java.util.UUID
+
+@Component
+class PaymentOutboxEventPublisherImpl(
+    private val outboxRepository: PaymentOutboxEventRepository,
+    private val objectMapper: ObjectMapper,
+) : PaymentOutboxEventPublisher {
+    override fun publish(
+        envelope: EventEnvelope<*>,
+        aggregateType: String,
+        aggregateId: String,
+        eventType: String,
+        createdAt: Instant,
+    ) {
+        check(TransactionSynchronizationManager.isActualTransactionActive()) {
+            "PaymentOutboxEventPublisher.publish must be called within an active transaction"
+        }
+        outboxRepository.saveAndFlush(
+            PaymentOutboxEventEntity(
+                id = UUID.randomUUID(),
+                aggregateType = aggregateType,
+                aggregateId = aggregateId,
+                eventType = eventType,
+                payload = objectMapper.writeValueAsString(envelope),
+                status = OutboxStatus.PENDING,
+                createdAt = createdAt,
+                publishedAt = null,
+                attempts = 0,
+                lastError = null,
+            ),
+        )
+    }
+}

--- a/services/payments/src/main/kotlin/com/fincore/payments/infrastructure/persistence/PaymentIdempotencyKeyEntity.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/infrastructure/persistence/PaymentIdempotencyKeyEntity.kt
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.infrastructure.persistence
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.Immutable
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Immutable
+@Table(name = "idempotency_keys", schema = "payments")
+class PaymentIdempotencyKeyEntity(
+    @Id
+    @Column(name = "key_hash", nullable = false, updatable = false)
+    var keyHash: String,
+    @Column(name = "payment_id", nullable = false, updatable = false)
+    var paymentId: UUID,
+    @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: Instant,
+)

--- a/services/payments/src/main/kotlin/com/fincore/payments/infrastructure/persistence/PaymentIdempotencyKeyRepository.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/infrastructure/persistence/PaymentIdempotencyKeyRepository.kt
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.infrastructure.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface PaymentIdempotencyKeyRepository : JpaRepository<PaymentIdempotencyKeyEntity, String>

--- a/services/payments/src/main/kotlin/com/fincore/payments/infrastructure/persistence/PaymentPersistenceAdapter.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/infrastructure/persistence/PaymentPersistenceAdapter.kt
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.infrastructure.persistence
+
+import com.fincore.core.Currency
+import com.fincore.core.Money
+import com.fincore.core.PaymentId
+import com.fincore.payments.domain.Payment
+import org.springframework.stereotype.Component
+import java.time.Instant
+
+// Hand-written because MapStruct cannot construct the value-class domain aggregate; the domain stays pure.
+@Component
+class PaymentPersistenceAdapter {
+    fun toDomain(entity: PaymentEntity): Payment =
+        Payment(
+            id = PaymentId(entity.id),
+            amount = Money(entity.amount, Currency.of(entity.currency.trim())),
+            reference = entity.reference,
+            status = entity.status,
+        )
+
+    fun toNewEntity(
+        payment: Payment,
+        now: Instant,
+    ): PaymentEntity =
+        PaymentEntity(
+            id = payment.id.value,
+            reference = payment.reference,
+            amount = payment.amount.amount,
+            currency = payment.amount.currency.code,
+            status = payment.status,
+            createdAt = now,
+            version = 0,
+        )
+}

--- a/services/payments/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/payments/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -16,3 +16,6 @@ databaseChangeLog:
   - include:
       file: v0.1/013-outbox-events.sql
       relativeToChangelogFile: true
+  - include:
+      file: v0.1/014-idempotency-keys.sql
+      relativeToChangelogFile: true

--- a/services/payments/src/main/resources/db/changelog/v0.1/014-idempotency-keys.sql
+++ b/services/payments/src/main/resources/db/changelog/v0.1/014-idempotency-keys.sql
@@ -1,0 +1,11 @@
+--liquibase formatted sql
+-- SPDX-License-Identifier: BUSL-1.1
+-- SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+--changeset fincore:payments-014-idempotency-keys dbms:postgresql
+CREATE TABLE IF NOT EXISTS payments.idempotency_keys (
+    key_hash    VARCHAR(64) NOT NULL,
+    payment_id  UUID        NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT pk_payments_idempotency_keys PRIMARY KEY (key_hash)
+);

--- a/services/payments/src/test/kotlin/com/fincore/payments/application/PaymentServiceImplTest.kt
+++ b/services/payments/src/test/kotlin/com/fincore/payments/application/PaymentServiceImplTest.kt
@@ -1,0 +1,111 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.application
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fincore.core.Currency
+import com.fincore.core.Money
+import com.fincore.core.PaymentId
+import com.fincore.events.PaymentEvents
+import com.fincore.payments.domain.Payment
+import com.fincore.payments.domain.enum.PaymentStatus
+import com.fincore.payments.domain.exception.PaymentDomainException
+import com.fincore.payments.domain.exception.PaymentNotFoundException
+import com.fincore.payments.infrastructure.outbox.PaymentOutboxEventPublisher
+import com.fincore.payments.infrastructure.persistence.PaymentEntity
+import com.fincore.payments.infrastructure.persistence.PaymentEventEntity
+import com.fincore.payments.infrastructure.persistence.PaymentEventRepository
+import com.fincore.payments.infrastructure.persistence.PaymentPersistenceAdapter
+import com.fincore.payments.infrastructure.persistence.PaymentRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.Optional
+import java.util.UUID
+
+class PaymentServiceImplTest {
+    private val idempotencyStore = mockk<PaymentIdempotencyStore>()
+    private val paymentRepository = mockk<PaymentRepository>(relaxed = true)
+    private val paymentEventRepository = mockk<PaymentEventRepository>(relaxed = true)
+    private val outboxPublisher = mockk<PaymentOutboxEventPublisher>(relaxed = true)
+    private val objectMapper = mockk<ObjectMapper> { every { writeValueAsString(any()) } returns "{}" }
+    private val service =
+        PaymentServiceImpl(
+            idempotencyStore,
+            paymentRepository,
+            paymentEventRepository,
+            PaymentPersistenceAdapter(),
+            outboxPublisher,
+            objectMapper,
+        )
+
+    init {
+        every { paymentRepository.saveAndFlush(any<PaymentEntity>()) } answers { firstArg() }
+        every { paymentEventRepository.saveAndFlush(any<PaymentEventEntity>()) } answers { firstArg() }
+    }
+
+    @Test
+    fun `should persist and emit an initiated event when initiating a payment`() {
+        every { idempotencyStore.reserveOrRun(any(), any()) } answers { secondArg<() -> Payment>().invoke() }
+
+        val payment = service.initiate(InitiatePaymentCommand("key-1", money(), "order-1"))
+
+        payment.status shouldBe PaymentStatus.INITIATED
+        verify { outboxPublisher.publish(any(), "Payment", any(), PaymentEvents.PaymentInitiated.fullType, any()) }
+    }
+
+    @Test
+    fun `should fail after exhausting retries when the idempotency key keeps racing`() {
+        every { idempotencyStore.reserveOrRun(any(), any()) } throws PaymentIdempotencyRaceException(RuntimeException())
+
+        shouldThrow<PaymentConcurrencyException> { service.initiate(InitiatePaymentCommand("key-1", money(), "order-1")) }
+
+        verify(exactly = MAX_RETRIES) { idempotencyStore.reserveOrRun(any(), any()) }
+    }
+
+    @Test
+    fun `should transition to cancelled and emit a cancelled event when cancelling`() {
+        val id = UUID.randomUUID()
+        every { paymentRepository.findById(id) } returns Optional.of(entity(id, PaymentStatus.INITIATED))
+
+        val payment = service.cancel(PaymentId(id))
+
+        payment.status shouldBe PaymentStatus.CANCELLED
+        verify { outboxPublisher.publish(any(), "Payment", any(), PaymentEvents.PaymentCancelled.fullType, any()) }
+    }
+
+    @Test
+    fun `should reject cancelling a terminal payment and emit nothing`() {
+        val id = UUID.randomUUID()
+        every { paymentRepository.findById(id) } returns Optional.of(entity(id, PaymentStatus.SETTLED))
+
+        shouldThrow<PaymentDomainException> { service.cancel(PaymentId(id)) }
+
+        verify(exactly = 0) { outboxPublisher.publish(any(), any(), any(), any(), any()) }
+    }
+
+    @Test
+    fun `should raise not found when cancelling an unknown payment`() {
+        val id = UUID.randomUUID()
+        every { paymentRepository.findById(id) } returns Optional.empty()
+
+        shouldThrow<PaymentNotFoundException> { service.cancel(PaymentId(id)) }
+    }
+
+    private fun money(): Money = Money(BigDecimal("100.00"), Currency.USD)
+
+    private fun entity(
+        id: UUID,
+        status: PaymentStatus,
+    ): PaymentEntity = PaymentEntity(id, "order-1", BigDecimal("100.00"), "USD", status, Instant.now(), 0L)
+
+    private companion object {
+        const val MAX_RETRIES = 3
+    }
+}


### PR DESCRIPTION
## What

Fourth slice of E-02. Adds the payments application service over the #208 domain / #209 schema / #210 shared dispatcher.

- **`PaymentService`** (interface + impl): `initiate(InitiatePaymentCommand)` (idempotent) and `cancel(PaymentId)`. Each persists the `Payment`, writes a `payment_events` row, and emits a `PaymentEvents.*` envelope to `payments.outbox_events` in one transaction. No external call inside the transaction (transactional outbox).
- **Idempotency** (concurrency-safe, mirrors the ledger): a non-transactional orchestrator (`PaymentServiceImpl.initiate`) retries a transactional store (`PaymentIdempotencyStore.reserveOrRun`) keyed by a SHA-256 of the command's idempotency key; a key race rolls back the loser's whole transaction and the retry replays the winner's committed payment (bounded by `MAX_ATTEMPTS`, then a typed `PaymentConcurrencyException`).
- **`PaymentPersistenceAdapter`** (hand-written domain<->entity), a local write-side `PaymentOutboxEventPublisher` (writes a `PaymentOutboxEventEntity`, guards `isActualTransactionActive()`), and a `payments.idempotency_keys` table.
- Tests: MockK unit tests (initiate, retry-exhaustion, cancel, terminal-cancel-reject, not-found) + a `@DataJpaTest` IT proving emit-in-transaction, idempotent replay, and cancel.

Scope splits (reviewable PRs): the read-side dispatch relay is **#222**; the HTTP `Idempotency-Key` filter is #216; screening/submit/settle/fail/retry transitions land with their drivers (#213/#214/#215). Only `initiate`/`cancel` have callers today.

## Gates

Local (`-x integrationTest`): `:services:payments:{test,detekt,detektTest,spotlessCheck,assemble,compileIntegrationTestKotlin}` green. critic GO, security-auditor PASS (INV-1 outbox-in-tx + INV-2 concurrency-safe idempotency confirmed), evaluator 0.855. The emit-in-transaction + idempotent-replay IT runs on CI.

Closes #211