### PR TITLE
feat(payments): add inbound webhook handler with hmac verify and dedup

### DIFF
--- a/services/payments/src/integrationTest/kotlin/com/fincore/payments/infrastructure/persistence/ProcessedWebhookDedupIT.kt
+++ b/services/payments/src/integrationTest/kotlin/com/fincore/payments/infrastructure/persistence/ProcessedWebhookDedupIT.kt
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.infrastructure.persistence
+
+import com.fincore.test.containers.PostgresContainerExtension
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionTemplate
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@ExtendWith(PostgresContainerExtension::class)
+class ProcessedWebhookDedupIT(
+    @Autowired private val webhooks: ProcessedWebhookRepository,
+    @Autowired txManager: PlatformTransactionManager,
+) {
+    private val tx = TransactionTemplate(txManager)
+
+    @AfterEach
+    fun cleanUp() {
+        tx.execute { webhooks.deleteAll() }
+    }
+
+    @Test
+    fun `should insert once and no-op on a duplicate delivery id`() {
+        val first = tx.execute { webhooks.insertIfAbsent("delivery-1") }
+        val second = tx.execute { webhooks.insertIfAbsent("delivery-1") }
+
+        first shouldBe 1
+        second shouldBe 0
+        tx.execute { webhooks.count() } shouldBe 1L
+    }
+
+    companion object {
+        @JvmStatic
+        @DynamicPropertySource
+        fun datasourceProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { PostgresContainerExtension.jdbcUrl }
+            registry.add("spring.datasource.username") { PostgresContainerExtension.username }
+            registry.add("spring.datasource.password") { PostgresContainerExtension.password }
+            registry.add("spring.jpa.hibernate.ddl-auto") { "none" }
+        }
+    }
+}

--- a/services/payments/src/main/kotlin/com/fincore/payments/application/PaymentService.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/application/PaymentService.kt
@@ -22,4 +22,6 @@ interface PaymentService {
         id: PaymentId,
         reason: String,
     ): Payment
+
+    fun markSettled(id: PaymentId): Payment
 }

--- a/services/payments/src/main/kotlin/com/fincore/payments/application/PaymentServiceImpl.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/application/PaymentServiceImpl.kt
@@ -77,6 +77,9 @@ class PaymentServiceImpl(
         reason: String,
     ): Payment = transition(id, PaymentStatus.FAILED, PaymentEvents.PaymentFailed, reason)
 
+    @Transactional
+    override fun markSettled(id: PaymentId): Payment = transition(id, PaymentStatus.SETTLED, PaymentEvents.PaymentSettled)
+
     private fun transition(
         id: PaymentId,
         target: PaymentStatus,

--- a/services/payments/src/main/kotlin/com/fincore/payments/application/webhook/PaymentWebhookHandler.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/application/webhook/PaymentWebhookHandler.kt
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.application.webhook
+
+import com.fincore.core.PaymentId
+import com.fincore.payments.application.PaymentService
+import com.fincore.payments.domain.enum.PaymentStatus
+import com.fincore.payments.infrastructure.persistence.PaymentRepository
+import com.fincore.payments.infrastructure.persistence.ProcessedWebhookRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * Handles a verified inbound payment webhook: correlate by provider reference, dedup by delivery id, and settle/fail
+ * the payment. All database work commits in one transaction; there is no outbound call. A late or conflicting webhook
+ * (illegal transition) is ignored as reconciliation, not an error.
+ */
+@Service
+class PaymentWebhookHandler(
+    private val verifier: WebhookSignatureVerifier,
+    private val paymentRepository: PaymentRepository,
+    private val processedWebhookRepository: ProcessedWebhookRepository,
+    private val paymentService: PaymentService,
+) {
+    @Transactional
+    fun handle(
+        rawPayload: String,
+        signatureHex: String,
+        notification: PaymentWebhookNotification,
+    ): WebhookResult {
+        if (!verifier.verify(rawPayload, signatureHex)) {
+            throw WebhookSignatureException("invalid webhook signature")
+        }
+        val entity =
+            paymentRepository.findByProviderReference(notification.providerReference)
+                ?: return WebhookResult.Ignored("no matching payment")
+        if (!entity.status.canTransitionTo(targetStatus(notification.outcome))) {
+            return WebhookResult.Ignored("payment not in a settleable state")
+        }
+        return dedupAndApply(PaymentId(entity.id), notification)
+    }
+
+    private fun dedupAndApply(
+        id: PaymentId,
+        notification: PaymentWebhookNotification,
+    ): WebhookResult {
+        if (processedWebhookRepository.insertIfAbsent(notification.deliveryId) == 0) {
+            return WebhookResult.Duplicate
+        }
+        when (notification.outcome) {
+            WebhookOutcome.SETTLED -> paymentService.markSettled(id)
+            WebhookOutcome.FAILED -> paymentService.markFailed(id, FAILURE_REASON)
+        }
+        return WebhookResult.Processed
+    }
+
+    private fun targetStatus(outcome: WebhookOutcome): PaymentStatus =
+        when (outcome) {
+            WebhookOutcome.SETTLED -> PaymentStatus.SETTLED
+            WebhookOutcome.FAILED -> PaymentStatus.FAILED
+        }
+
+    private companion object {
+        const val FAILURE_REASON = "provider reported failure"
+    }
+}

--- a/services/payments/src/main/kotlin/com/fincore/payments/application/webhook/PaymentWebhookNotification.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/application/webhook/PaymentWebhookNotification.kt
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.application.webhook
+
+data class PaymentWebhookNotification(
+    val deliveryId: String,
+    val providerReference: String,
+    val outcome: WebhookOutcome,
+)

--- a/services/payments/src/main/kotlin/com/fincore/payments/application/webhook/PaymentWebhookProperties.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/application/webhook/PaymentWebhookProperties.kt
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.application.webhook
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "fincore.payments.webhook")
+data class PaymentWebhookProperties(
+    val hmacSecret: String = "",
+)

--- a/services/payments/src/main/kotlin/com/fincore/payments/application/webhook/WebhookOutcome.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/application/webhook/WebhookOutcome.kt
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.application.webhook
+
+enum class WebhookOutcome { SETTLED, FAILED }

--- a/services/payments/src/main/kotlin/com/fincore/payments/application/webhook/WebhookResult.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/application/webhook/WebhookResult.kt
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.application.webhook
+
+sealed interface WebhookResult {
+    data object Processed : WebhookResult
+
+    data object Duplicate : WebhookResult
+
+    data class Ignored(
+        val reason: String,
+    ) : WebhookResult
+}

--- a/services/payments/src/main/kotlin/com/fincore/payments/application/webhook/WebhookSignatureException.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/application/webhook/WebhookSignatureException.kt
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.application.webhook
+
+class WebhookSignatureException(
+    message: String,
+) : RuntimeException(message)

--- a/services/payments/src/main/kotlin/com/fincore/payments/application/webhook/WebhookSignatureVerifier.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/application/webhook/WebhookSignatureVerifier.kt
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.application.webhook
+
+import org.springframework.stereotype.Component
+import java.security.MessageDigest
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+/**
+ * Verifies an inbound webhook's HMAC-SHA256 signature against the configured shared secret. Fail-closed: a blank
+ * secret or a mismatch returns false. The compare is constant-time over case-normalized hex.
+ */
+@Component
+class WebhookSignatureVerifier(
+    private val properties: PaymentWebhookProperties,
+) {
+    fun verify(
+        payload: String,
+        signatureHex: String,
+    ): Boolean {
+        if (properties.hmacSecret.isBlank()) return false
+        val expected = hmacHex(payload).toByteArray(Charsets.UTF_8)
+        val provided = signatureHex.trim().lowercase().toByteArray(Charsets.UTF_8)
+        return MessageDigest.isEqual(expected, provided)
+    }
+
+    private fun hmacHex(payload: String): String {
+        val mac = Mac.getInstance(ALGORITHM)
+        mac.init(SecretKeySpec(properties.hmacSecret.toByteArray(Charsets.UTF_8), ALGORITHM))
+        return mac.doFinal(payload.toByteArray(Charsets.UTF_8)).joinToString("") { "%02x".format(it) }
+    }
+
+    private companion object {
+        const val ALGORITHM = "HmacSHA256"
+    }
+}

--- a/services/payments/src/main/kotlin/com/fincore/payments/config/PaymentsConfig.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/config/PaymentsConfig.kt
@@ -4,9 +4,10 @@
 package com.fincore.payments.config
 
 import com.fincore.payments.application.screening.PaymentScreeningProperties
+import com.fincore.payments.application.webhook.PaymentWebhookProperties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration
 
 @Configuration
-@EnableConfigurationProperties(PaymentScreeningProperties::class)
+@EnableConfigurationProperties(PaymentScreeningProperties::class, PaymentWebhookProperties::class)
 class PaymentsConfig

--- a/services/payments/src/main/kotlin/com/fincore/payments/infrastructure/persistence/PaymentRepository.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/infrastructure/persistence/PaymentRepository.kt
@@ -6,4 +6,6 @@ package com.fincore.payments.infrastructure.persistence
 import org.springframework.data.jpa.repository.JpaRepository
 import java.util.UUID
 
-interface PaymentRepository : JpaRepository<PaymentEntity, UUID>
+interface PaymentRepository : JpaRepository<PaymentEntity, UUID> {
+    fun findByProviderReference(providerReference: String): PaymentEntity?
+}

--- a/services/payments/src/main/kotlin/com/fincore/payments/infrastructure/persistence/ProcessedWebhookRepository.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/infrastructure/persistence/ProcessedWebhookRepository.kt
@@ -4,5 +4,17 @@
 package com.fincore.payments.infrastructure.persistence
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
-interface ProcessedWebhookRepository : JpaRepository<ProcessedWebhookEntity, String>
+interface ProcessedWebhookRepository : JpaRepository<ProcessedWebhookEntity, String> {
+    @Modifying
+    @Query(
+        nativeQuery = true,
+        value = "INSERT INTO payments.processed_webhooks(delivery_id, received_at) VALUES (:deliveryId, NOW()) ON CONFLICT DO NOTHING",
+    )
+    fun insertIfAbsent(
+        @Param("deliveryId") deliveryId: String,
+    ): Int
+}

--- a/services/payments/src/test/kotlin/com/fincore/payments/application/webhook/PaymentWebhookHandlerTest.kt
+++ b/services/payments/src/test/kotlin/com/fincore/payments/application/webhook/PaymentWebhookHandlerTest.kt
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.application.webhook
+
+import com.fincore.payments.application.PaymentService
+import com.fincore.payments.domain.enum.PaymentStatus
+import com.fincore.payments.infrastructure.persistence.PaymentEntity
+import com.fincore.payments.infrastructure.persistence.PaymentRepository
+import com.fincore.payments.infrastructure.persistence.ProcessedWebhookRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.UUID
+
+class PaymentWebhookHandlerTest {
+    private val verifier = mockk<WebhookSignatureVerifier>()
+    private val paymentRepository = mockk<PaymentRepository>()
+    private val processedWebhookRepository = mockk<ProcessedWebhookRepository>(relaxed = true)
+    private val paymentService = mockk<PaymentService>(relaxed = true)
+    private val handler = PaymentWebhookHandler(verifier, paymentRepository, processedWebhookRepository, paymentService)
+
+    private val id = UUID.randomUUID()
+
+    @Test
+    fun `should reject and touch no repository when the signature is invalid`() {
+        every { verifier.verify(any(), any()) } returns false
+
+        shouldThrow<WebhookSignatureException> { handler.handle("body", "sig", notification(WebhookOutcome.SETTLED)) }
+
+        verify(exactly = 0) { paymentRepository.findByProviderReference(any()) }
+        verify(exactly = 0) { processedWebhookRepository.insertIfAbsent(any()) }
+    }
+
+    @Test
+    fun `should ignore when no payment matches the provider reference`() {
+        every { verifier.verify(any(), any()) } returns true
+        every { paymentRepository.findByProviderReference("prov-1") } returns null
+
+        handler.handle("body", "sig", notification(WebhookOutcome.SETTLED)) shouldBe WebhookResult.Ignored("no matching payment")
+
+        verify(exactly = 0) { processedWebhookRepository.insertIfAbsent(any()) }
+    }
+
+    @Test
+    fun `should ignore a conflicting webhook for an already terminal payment`() {
+        every { verifier.verify(any(), any()) } returns true
+        every { paymentRepository.findByProviderReference("prov-1") } returns entity(PaymentStatus.SETTLED)
+
+        val result = handler.handle("body", "sig", notification(WebhookOutcome.SETTLED))
+
+        (result is WebhookResult.Ignored) shouldBe true
+        verify(exactly = 0) { processedWebhookRepository.insertIfAbsent(any()) }
+        verify(exactly = 0) { paymentService.markSettled(any()) }
+    }
+
+    @Test
+    fun `should settle a submitted payment on a fresh delivery`() {
+        every { verifier.verify(any(), any()) } returns true
+        every { paymentRepository.findByProviderReference("prov-1") } returns entity(PaymentStatus.SUBMITTED)
+        every { processedWebhookRepository.insertIfAbsent("d-1") } returns 1
+
+        handler.handle("body", "sig", notification(WebhookOutcome.SETTLED)) shouldBe WebhookResult.Processed
+
+        verify { paymentService.markSettled(any()) }
+    }
+
+    @Test
+    fun `should fail a submitted payment when the outcome is failed`() {
+        every { verifier.verify(any(), any()) } returns true
+        every { paymentRepository.findByProviderReference("prov-1") } returns entity(PaymentStatus.SUBMITTED)
+        every { processedWebhookRepository.insertIfAbsent("d-1") } returns 1
+
+        handler.handle("body", "sig", notification(WebhookOutcome.FAILED)) shouldBe WebhookResult.Processed
+
+        verify { paymentService.markFailed(any(), any()) }
+    }
+
+    @Test
+    fun `should report duplicate and not transition when the delivery was already seen`() {
+        every { verifier.verify(any(), any()) } returns true
+        every { paymentRepository.findByProviderReference("prov-1") } returns entity(PaymentStatus.SUBMITTED)
+        every { processedWebhookRepository.insertIfAbsent("d-1") } returns 0
+
+        handler.handle("body", "sig", notification(WebhookOutcome.SETTLED)) shouldBe WebhookResult.Duplicate
+
+        verify(exactly = 0) { paymentService.markSettled(any()) }
+    }
+
+    private fun notification(outcome: WebhookOutcome): PaymentWebhookNotification = PaymentWebhookNotification("d-1", "prov-1", outcome)
+
+    private fun entity(status: PaymentStatus): PaymentEntity =
+        PaymentEntity(id, "order-1", BigDecimal("100.00"), "USD", status, Instant.now(), 0L, "prov-1")
+}

--- a/services/payments/src/test/kotlin/com/fincore/payments/application/webhook/WebhookSignatureVerifierTest.kt
+++ b/services/payments/src/test/kotlin/com/fincore/payments/application/webhook/WebhookSignatureVerifierTest.kt
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.application.webhook
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+
+class WebhookSignatureVerifierTest {
+    private val secret = "payments-test-key"
+    private val verifier = WebhookSignatureVerifier(PaymentWebhookProperties(hmacSecret = secret))
+    private val payload = """{"deliveryId":"d-1","providerReference":"prov-1","outcome":"SETTLED"}"""
+
+    @Test
+    fun `should accept a signature produced with the configured secret`() {
+        verifier.verify(payload, sign(payload, secret)) shouldBe true
+    }
+
+    @Test
+    fun `should accept an upper-case signature`() {
+        verifier.verify(payload, sign(payload, secret).uppercase()) shouldBe true
+    }
+
+    @Test
+    fun `should accept a signature carrying surrounding whitespace`() {
+        verifier.verify(payload, " ${sign(payload, secret)}\n") shouldBe true
+    }
+
+    @Test
+    fun `should reject a tampered signature`() {
+        verifier.verify(payload, sign("other", secret)) shouldBe false
+    }
+
+    @Test
+    fun `should reject when the secret is not configured`() {
+        WebhookSignatureVerifier(PaymentWebhookProperties()).verify(payload, sign(payload, secret)) shouldBe false
+    }
+
+    private fun sign(
+        body: String,
+        key: String,
+    ): String {
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(key.toByteArray(Charsets.UTF_8), "HmacSHA256"))
+        return mac.doFinal(body.toByteArray(Charsets.UTF_8)).joinToString("") { "%02x".format(it) }
+    }
+}


### PR DESCRIPTION
## What

Seventh slice of E-02. The inbound payment-webhook **handler service** (variant B; the HTTP endpoint + security land with the REST slice #216) that takes a submitted payment to its final state.

- **`WebhookSignatureVerifier`**: HMAC-SHA256 over the raw payload with a configured shared secret, `MessageDigest.isEqual` constant-time compare, hex trimmed + case-normalized, **fail-closed** on a blank secret or mismatch.
- **`PaymentWebhookHandler`** (`@Transactional`, inbound-only, no external call): verify (throws before any DB write) -> correlate by `provider_reference` (unmatched -> `Ignored`, not deduped, retry-able) -> legal-transition pre-check (illegal/terminal -> `Ignored`, so no exception crosses the tx -> no rollback-only) -> dedup via native `INSERT ... ON CONFLICT DO NOTHING` (duplicate -> `Duplicate`) -> `markSettled`/`markFailed`. The dedup row + transition + outbox emit commit atomically.
- Adds `PaymentService.markSettled` (SUBMITTED -> SETTLED, `PaymentSettled`), `PaymentRepository.findByProviderReference`, `ProcessedWebhookRepository.insertIfAbsent`, and registers `PaymentWebhookProperties`.
- The `@DataJpaTest` dedup IT closes the #209-deferred hard PK-conflict test (native double-insert -> 1 then 0).

A concurrent-race conflict self-heals: the optimistic-lock/illegal-transition exception propagates, the whole tx (dedup row included) rolls back, the provider retries, and the retry sees the terminal state and returns `Ignored`.

OSS boundary (§5.3): generic notification shape, neutral "provider reported failure", no real provider/payload/partner; the HMAC secret is config-only (no hardcoded literal; gitleaks-safe).

## Gates

Local (`-x integrationTest`): `:services:payments:{test,detekt,detektTest,spotlessCheck,assemble,compileIntegrationTestKotlin}` green. critic GO (pre-check no-rollback-only + hex-normalize + fail-closed secret applied), security-auditor PASS (HMAC constant-time/fail-closed + gitleaks-safe + §5.3 clean, 7/7 ACs), evaluator 0.932. The dedup IT runs on CI.

Closes #214