### PR TITLE
feat(payments): add rest api, security and openapi

### DIFF
--- a/services/payments/src/integrationTest/kotlin/com/fincore/payments/api/PaymentsApiContextIT.kt
+++ b/services/payments/src/integrationTest/kotlin/com/fincore/payments/api/PaymentsApiContextIT.kt
@@ -12,6 +12,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
 import org.springframework.security.oauth2.jwt.JwtDecoder
 import org.springframework.test.context.DynamicPropertyRegistry
 import org.springframework.test.context.DynamicPropertySource
@@ -23,6 +24,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 @SpringBootTest
 @AutoConfigureMockMvc
 @ExtendWith(PostgresContainerExtension::class)
+@Import(PaymentsApiContextIT.TestBeans::class)
 class PaymentsApiContextIT(
     @Autowired private val mockMvc: MockMvc,
 ) {

--- a/services/payments/src/integrationTest/kotlin/com/fincore/payments/api/PaymentsApiContextIT.kt
+++ b/services/payments/src/integrationTest/kotlin/com/fincore/payments/api/PaymentsApiContextIT.kt
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.api
+
+import com.fincore.test.containers.PostgresContainerExtension
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ExtendWith(PostgresContainerExtension::class)
+class PaymentsApiContextIT(
+    @Autowired private val mockMvc: MockMvc,
+) {
+    @TestConfiguration
+    class TestBeans {
+        @Bean fun jwtDecoder(): JwtDecoder = mockk()
+    }
+
+    @Test
+    fun `should serve the openapi document listing the payment operations`() {
+        mockMvc
+            .perform(get("/v3/api-docs"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.paths['/v1/payments']").exists())
+            .andExpect(jsonPath("$.paths['/v1/payments/{id}']").exists())
+    }
+
+    companion object {
+        @JvmStatic
+        @DynamicPropertySource
+        fun properties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { PostgresContainerExtension.jdbcUrl }
+            registry.add("spring.datasource.username") { PostgresContainerExtension.username }
+            registry.add("spring.datasource.password") { PostgresContainerExtension.password }
+            registry.add("spring.jpa.hibernate.ddl-auto") { "none" }
+            registry.add("spring.security.oauth2.resourceserver.jwt.issuer-uri") { "https://issuer.test" }
+        }
+    }
+}

--- a/services/payments/src/integrationTest/kotlin/com/fincore/payments/api/PaymentsApiContextIT.kt
+++ b/services/payments/src/integrationTest/kotlin/com/fincore/payments/api/PaymentsApiContextIT.kt
@@ -51,6 +51,7 @@ class PaymentsApiContextIT(
             registry.add("spring.datasource.password") { PostgresContainerExtension.password }
             registry.add("spring.jpa.hibernate.ddl-auto") { "none" }
             registry.add("spring.security.oauth2.resourceserver.jwt.issuer-uri") { "https://issuer.test" }
+            registry.add("fincore.payments.bank.sandbox.enabled") { "true" }
         }
     }
 }

--- a/services/payments/src/main/kotlin/com/fincore/payments/api/PaymentController.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/api/PaymentController.kt
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.api
+
+import com.fincore.core.PaymentId
+import com.fincore.payments.api.dto.request.InitiatePaymentRequest
+import com.fincore.payments.api.dto.response.PaymentResponse
+import com.fincore.payments.api.mapper.PaymentApiMapper
+import com.fincore.payments.application.PaymentService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.net.URI
+
+@Tag(name = "Payments", description = "Initiate, read, and cancel payments")
+@RestController
+@RequestMapping("/v1/payments")
+class PaymentController(
+    private val paymentService: PaymentService,
+    private val mapper: PaymentApiMapper,
+) {
+    @Operation(summary = "Initiate a payment", description = "Creates a payment; idempotent on the Idempotency-Key header.")
+    @PostMapping
+    fun initiate(
+        @RequestHeader("Idempotency-Key") idempotencyKey: String,
+        @Valid @RequestBody request: InitiatePaymentRequest,
+    ): ResponseEntity<PaymentResponse> {
+        val response = mapper.toResponse(paymentService.initiate(mapper.toCommand(request, idempotencyKey)))
+        return ResponseEntity.created(URI.create("/v1/payments/${response.id}")).body(response)
+    }
+
+    @Operation(summary = "Get a payment", description = "Returns the payment or 404.")
+    @GetMapping("/{id}")
+    fun get(
+        @PathVariable id: String,
+    ): PaymentResponse = mapper.toResponse(paymentService.get(PaymentId.fromString(id)))
+
+    @Operation(summary = "Cancel a payment", description = "Cancels a non-terminal payment, or 409 if illegal.")
+    @PostMapping("/{id}/cancel")
+    fun cancel(
+        @PathVariable id: String,
+    ): PaymentResponse = mapper.toResponse(paymentService.cancel(PaymentId.fromString(id)))
+}

--- a/services/payments/src/main/kotlin/com/fincore/payments/api/dto/request/InitiatePaymentRequest.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/api/dto/request/InitiatePaymentRequest.kt
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.api.dto.request
+
+import jakarta.validation.constraints.DecimalMin
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
+import java.math.BigDecimal
+
+data class InitiatePaymentRequest(
+    @field:DecimalMin(value = "0.0", inclusive = false, message = "amount must be positive")
+    val amount: BigDecimal,
+    @field:Pattern(regexp = "^[A-Z]{3}$", message = "currency must be an ISO 4217 code")
+    val currency: String,
+    @field:NotBlank
+    @field:Size(max = 140)
+    val reference: String,
+)

--- a/services/payments/src/main/kotlin/com/fincore/payments/api/dto/response/PaymentResponse.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/api/dto/response/PaymentResponse.kt
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.api.dto.response
+
+import java.math.BigDecimal
+
+data class PaymentResponse(
+    val id: String,
+    val reference: String,
+    val amount: BigDecimal,
+    val currency: String,
+    val status: String,
+)

--- a/services/payments/src/main/kotlin/com/fincore/payments/api/error/ProblemType.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/api/error/ProblemType.kt
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.api.error
+
+import org.springframework.http.HttpStatus
+import java.net.URI
+
+enum class ProblemType(
+    val slug: String,
+    val status: HttpStatus,
+    val code: String,
+    val title: String,
+) {
+    PAYMENT_NOT_FOUND("payment-not-found", HttpStatus.NOT_FOUND, "PAYMENT_NOT_FOUND", "payment not found"),
+    PAYMENT_CONFLICT("payment-conflict", HttpStatus.CONFLICT, "PAYMENT_CONFLICT", "illegal payment state transition"),
+    CONCURRENCY_CONFLICT("concurrency-conflict", HttpStatus.SERVICE_UNAVAILABLE, "CONCURRENCY_CONFLICT", "concurrency conflict, retry"),
+    VALIDATION_FAILED("validation-failed", HttpStatus.BAD_REQUEST, "VALIDATION_FAILED", "invalid request"),
+    MALFORMED_REQUEST("malformed-request", HttpStatus.BAD_REQUEST, "MALFORMED_REQUEST", "invalid request"),
+    INVALID_REQUEST("invalid-request", HttpStatus.BAD_REQUEST, "INVALID_REQUEST", "invalid request"),
+    INTERNAL_ERROR("internal-error", HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", "internal error"),
+    ;
+
+    val type: URI get() = URI.create(BASE_URI + slug)
+
+    companion object {
+        const val BASE_URI = "https://fincore.dev/errors/"
+    }
+}

--- a/services/payments/src/main/kotlin/com/fincore/payments/api/mapper/PaymentApiMapper.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/api/mapper/PaymentApiMapper.kt
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.api.mapper
+
+import com.fincore.core.Currency
+import com.fincore.core.Money
+import com.fincore.payments.api.dto.request.InitiatePaymentRequest
+import com.fincore.payments.api.dto.response.PaymentResponse
+import com.fincore.payments.application.InitiatePaymentCommand
+import com.fincore.payments.domain.Payment
+import org.springframework.stereotype.Component
+
+// Hand-written: MapStruct cannot construct the value-class Money/PaymentId; ids cross the wire as prefixed strings.
+@Component
+class PaymentApiMapper {
+    fun toCommand(
+        request: InitiatePaymentRequest,
+        idempotencyKey: String,
+    ): InitiatePaymentCommand =
+        InitiatePaymentCommand(
+            idempotencyKey = idempotencyKey,
+            amount = Money(request.amount, Currency.of(request.currency)),
+            reference = request.reference,
+        )
+
+    fun toResponse(payment: Payment): PaymentResponse =
+        PaymentResponse(
+            id = payment.id.toString(),
+            reference = payment.reference,
+            amount = payment.amount.amount,
+            currency = payment.amount.currency.code,
+            status = payment.status.name,
+        )
+}

--- a/services/payments/src/main/kotlin/com/fincore/payments/application/PaymentService.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/application/PaymentService.kt
@@ -9,6 +9,8 @@ import com.fincore.payments.domain.Payment
 interface PaymentService {
     fun initiate(command: InitiatePaymentCommand): Payment
 
+    fun get(id: PaymentId): Payment
+
     fun cancel(id: PaymentId): Payment
 
     fun screen(id: PaymentId): Payment

--- a/services/payments/src/main/kotlin/com/fincore/payments/application/PaymentServiceImpl.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/application/PaymentServiceImpl.kt
@@ -43,6 +43,10 @@ class PaymentServiceImpl(
         }
     }
 
+    @Transactional(readOnly = true)
+    override fun get(id: PaymentId): Payment =
+        adapter.toDomain(paymentRepository.findById(id.value).orElseThrow { PaymentNotFoundException(id) })
+
     @Transactional
     override fun cancel(id: PaymentId): Payment = transition(id, PaymentStatus.CANCELLED, PaymentEvents.PaymentCancelled)
 

--- a/services/payments/src/main/kotlin/com/fincore/payments/config/SecurityConfig.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/config/SecurityConfig.kt
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter
+import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter
+import org.springframework.security.web.SecurityFilterChain
+
+@Configuration
+@EnableWebSecurity
+class SecurityConfig {
+    // Order matters (first match wins): public paths (incl. the HMAC-verified webhook) before the scoped /v1/payments
+    // rules, and the GET read rule before the catch-all write rule.
+    @Bean
+    fun filterChain(http: HttpSecurity): SecurityFilterChain =
+        http
+            .csrf { it.disable() }
+            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            .authorizeHttpRequests {
+                it
+                    .requestMatchers(*PUBLIC_PATHS)
+                    .permitAll()
+                    .requestMatchers(HttpMethod.GET, PAYMENT_PATHS)
+                    .hasAuthority(SCOPE_READ)
+                    .requestMatchers(PAYMENT_PATHS)
+                    .hasAuthority(SCOPE_WRITE)
+                    .anyRequest()
+                    .authenticated()
+            }.oauth2ResourceServer { resource ->
+                resource.jwt { it.jwtAuthenticationConverter(jwtAuthenticationConverter()) }
+            }.build()
+
+    private fun jwtAuthenticationConverter(): JwtAuthenticationConverter =
+        JwtAuthenticationConverter().apply {
+            setJwtGrantedAuthoritiesConverter(JwtGrantedAuthoritiesConverter())
+        }
+
+    private companion object {
+        const val PAYMENT_PATHS = "/v1/payments/**"
+        const val SCOPE_READ = "SCOPE_payments:read"
+        const val SCOPE_WRITE = "SCOPE_payments:write"
+        val PUBLIC_PATHS =
+            arrayOf(
+                "/v1/payments/webhooks",
+                "/v3/api-docs/**",
+                "/swagger-ui/**",
+                "/swagger-ui.html",
+                "/actuator/health",
+                "/actuator/health/**",
+            )
+    }
+}

--- a/services/payments/src/main/kotlin/com/fincore/payments/exception/GlobalExceptionHandler.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/exception/GlobalExceptionHandler.kt
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.exception
+
+import com.fincore.payments.api.error.ProblemType
+import com.fincore.payments.application.PaymentConcurrencyException
+import com.fincore.payments.domain.exception.PaymentDomainException
+import com.fincore.payments.domain.exception.PaymentNotFoundException
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.http.HttpHeaders
+import org.springframework.http.ProblemDetail
+import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.validation.FieldError
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.MissingRequestHeaderException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import java.net.URI
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+    @ExceptionHandler(PaymentNotFoundException::class)
+    fun handleNotFound(
+        ex: PaymentNotFoundException,
+        request: HttpServletRequest,
+    ): ProblemDetail = problem(ProblemType.PAYMENT_NOT_FOUND, ex.message, request)
+
+    @ExceptionHandler(PaymentDomainException::class)
+    fun handleDomain(
+        ex: PaymentDomainException,
+        request: HttpServletRequest,
+    ): ProblemDetail = problem(ProblemType.PAYMENT_CONFLICT, ex.message, request)
+
+    @ExceptionHandler(PaymentConcurrencyException::class)
+    fun handleConcurrency(
+        ex: PaymentConcurrencyException,
+        request: HttpServletRequest,
+    ): ResponseEntity<ProblemDetail> = retryable(ProblemType.CONCURRENCY_CONFLICT, ex.message, request)
+
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleValidation(
+        ex: MethodArgumentNotValidException,
+        request: HttpServletRequest,
+    ): ProblemDetail =
+        problem(ProblemType.VALIDATION_FAILED, "Request validation failed", request).apply {
+            setProperty("errors", ex.bindingResult.fieldErrors.map(::toFieldError))
+        }
+
+    @ExceptionHandler(HttpMessageNotReadableException::class)
+    fun handleUnreadable(request: HttpServletRequest): ProblemDetail =
+        problem(ProblemType.MALFORMED_REQUEST, "Request body is missing or malformed", request)
+
+    @ExceptionHandler(MissingRequestHeaderException::class)
+    fun handleMissingHeader(
+        ex: MissingRequestHeaderException,
+        request: HttpServletRequest,
+    ): ProblemDetail = problem(ProblemType.INVALID_REQUEST, ex.message, request)
+
+    @ExceptionHandler(IllegalArgumentException::class)
+    fun handleIllegalArgument(
+        ex: IllegalArgumentException,
+        request: HttpServletRequest,
+    ): ProblemDetail = problem(ProblemType.INVALID_REQUEST, ex.message, request)
+
+    @ExceptionHandler(Exception::class)
+    fun handleUnexpected(request: HttpServletRequest): ProblemDetail =
+        problem(ProblemType.INTERNAL_ERROR, "An unexpected error occurred", request)
+
+    private fun toFieldError(error: FieldError): Map<String, String> =
+        mapOf("field" to error.field, "message" to (error.defaultMessage ?: "invalid"))
+
+    private fun retryable(
+        type: ProblemType,
+        detail: String?,
+        request: HttpServletRequest,
+    ): ResponseEntity<ProblemDetail> =
+        ResponseEntity
+            .status(type.status)
+            .header(HttpHeaders.RETRY_AFTER, RETRY_AFTER_SECONDS)
+            .body(problem(type, detail, request))
+
+    private fun problem(
+        type: ProblemType,
+        detail: String?,
+        request: HttpServletRequest,
+    ): ProblemDetail =
+        ProblemDetail.forStatusAndDetail(type.status, detail ?: type.title).apply {
+            this.title = type.title
+            this.type = type.type
+            this.instance = URI.create(request.requestURI)
+            setProperty("code", type.code)
+        }
+
+    private companion object {
+        const val RETRY_AFTER_SECONDS = "1"
+    }
+}

--- a/services/payments/src/main/resources/application.yml
+++ b/services/payments/src/main/resources/application.yml
@@ -6,3 +6,8 @@ spring:
       ddl-auto: none
   liquibase:
     change-log: classpath:db/changelog/db.changelog-master.yaml
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: ${KEYCLOAK_ISSUER_URI}

--- a/services/payments/src/test/kotlin/com/fincore/payments/api/PaymentControllerTest.kt
+++ b/services/payments/src/test/kotlin/com/fincore/payments/api/PaymentControllerTest.kt
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.api
+
+import com.fincore.core.Currency
+import com.fincore.core.Money
+import com.fincore.core.PaymentId
+import com.fincore.payments.api.mapper.PaymentApiMapper
+import com.fincore.payments.application.PaymentConcurrencyException
+import com.fincore.payments.application.PaymentService
+import com.fincore.payments.config.SecurityConfig
+import com.fincore.payments.domain.Payment
+import com.fincore.payments.domain.enum.PaymentStatus
+import com.fincore.payments.domain.exception.PaymentDomainException
+import com.fincore.payments.domain.exception.PaymentNotFoundException
+import com.fincore.payments.exception.GlobalExceptionHandler
+import io.kotest.matchers.shouldNotBe
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.math.BigDecimal
+
+@WebMvcTest(PaymentController::class)
+@Import(SecurityConfig::class, PaymentApiMapper::class, GlobalExceptionHandler::class, PaymentControllerTest.Mocks::class)
+class PaymentControllerTest(
+    @Autowired private val mockMvc: MockMvc,
+    @Autowired private val paymentService: PaymentService,
+) {
+    @TestConfiguration
+    class Mocks {
+        @Bean fun paymentService(): PaymentService = mockk()
+
+        @Bean fun jwtDecoder(): JwtDecoder = mockk()
+    }
+
+    @BeforeEach
+    fun resetMocks() {
+        clearMocks(paymentService)
+    }
+
+    @Test
+    fun `should initiate and return 201 when authorized with write scope`() {
+        every { paymentService.initiate(any()) } returns payment(PaymentStatus.INITIATED)
+
+        mockMvc
+            .perform(
+                post("/v1/payments")
+                    .with(jwt().authorities(SimpleGrantedAuthority(WRITE)))
+                    .header("Idempotency-Key", "key-1")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(VALID_BODY),
+            ).andExpect(status().isCreated)
+            .andExpect(jsonPath("$.status").value("INITIATED"))
+    }
+
+    @Test
+    fun `should return 401 when initiating without a token`() {
+        mockMvc
+            .perform(
+                post("/v1/payments").header("Idempotency-Key", "key-1").contentType(MediaType.APPLICATION_JSON).content(VALID_BODY),
+            ).andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    fun `should return 403 when initiating with only the read scope`() {
+        mockMvc
+            .perform(
+                post("/v1/payments")
+                    .with(jwt().authorities(SimpleGrantedAuthority(READ)))
+                    .header("Idempotency-Key", "key-1")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(VALID_BODY),
+            ).andExpect(status().isForbidden)
+    }
+
+    @Test
+    fun `should return 400 when the idempotency key header is missing`() {
+        mockMvc
+            .perform(
+                post("/v1/payments")
+                    .with(jwt().authorities(SimpleGrantedAuthority(WRITE)))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(VALID_BODY),
+            ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `should return 400 when the body is invalid`() {
+        mockMvc
+            .perform(
+                post("/v1/payments")
+                    .with(jwt().authorities(SimpleGrantedAuthority(WRITE)))
+                    .header("Idempotency-Key", "key-1")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"amount":-1,"currency":"usd","reference":""}"""),
+            ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `should return 503 when initiation races on the idempotency key`() {
+        every { paymentService.initiate(any()) } throws PaymentConcurrencyException(RuntimeException("race"))
+
+        mockMvc
+            .perform(
+                post("/v1/payments")
+                    .with(jwt().authorities(SimpleGrantedAuthority(WRITE)))
+                    .header("Idempotency-Key", "key-1")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(VALID_BODY),
+            ).andExpect(status().isServiceUnavailable)
+    }
+
+    @Test
+    fun `should return the payment when getting with read scope`() {
+        val payment = payment(PaymentStatus.INITIATED)
+        every { paymentService.get(payment.id) } returns payment
+
+        mockMvc
+            .perform(get("/v1/payments/${payment.id}").with(jwt().authorities(SimpleGrantedAuthority(READ))))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value(payment.id.toString()))
+    }
+
+    @Test
+    fun `should return 404 when getting an unknown payment`() {
+        val id = PaymentId.generate()
+        every { paymentService.get(any()) } throws PaymentNotFoundException(id)
+
+        mockMvc
+            .perform(get("/v1/payments/$id").with(jwt().authorities(SimpleGrantedAuthority(READ))))
+            .andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun `should return 409 when cancelling a terminal payment`() {
+        every { paymentService.cancel(any()) } throws PaymentDomainException("illegal transition")
+
+        mockMvc
+            .perform(post("/v1/payments/${PaymentId.generate()}/cancel").with(jwt().authorities(SimpleGrantedAuthority(WRITE))))
+            .andExpect(status().isConflict)
+    }
+
+    @Test
+    fun `should not reject the webhook path as unauthorized`() {
+        val result =
+            mockMvc
+                .perform(post("/v1/payments/webhooks").contentType(MediaType.APPLICATION_JSON).content("{}"))
+                .andReturn()
+
+        result.response.status shouldNotBe UNAUTHORIZED
+    }
+
+    private fun payment(status: PaymentStatus): Payment =
+        Payment(PaymentId.generate(), Money(BigDecimal("100.00"), Currency.USD), "order-1", status)
+
+    private companion object {
+        const val READ = "SCOPE_payments:read"
+        const val WRITE = "SCOPE_payments:write"
+        const val UNAUTHORIZED = 401
+        const val VALID_BODY = """{"amount":100.00,"currency":"USD","reference":"order-1"}"""
+    }
+}


### PR DESCRIPTION
## What

Ninth slice of E-02. The payments web layer (mirrors the decision service #172).

- **`PaymentController`** (`/v1/payments`, thin): `POST` initiate (`Idempotency-Key` header -> command; #211 service-level dedup), `GET /{id}`, `POST /{id}/cancel`. Ids are `String` path vars parsed via `PaymentId.fromString` (value classes never cross the wire as MVC params); a hand `PaymentApiMapper` builds `Money`/`PaymentId`.
- **`SecurityConfig`** (OAuth2 resource server, csrf off, stateless): public paths (docs/health + `/v1/payments/webhooks`) permitted **first**, then `GET /v1/payments/**`=`SCOPE_payments:read`, then `/v1/payments/**`=`SCOPE_payments:write`, then `anyRequest().authenticated()` (first-match-wins ordering).
- **RFC 7807** `GlobalExceptionHandler` + `ProblemType`: not-found 404, illegal transition 409, concurrency 503 (Retry-After), missing Idempotency-Key 400, validation 400, fallback 500.
- `PaymentService.get` (`@Transactional(readOnly=true)`); `application.yml` += `issuer-uri: ${KEYCLOAK_ISSUER_URI}`.
- OpenAPI 3.1 via springdoc + a `@SpringBootTest` contract IT; `@WebMvcTest` covers authz (401/403), initiate/get/cancel, validation, concurrency-503, missing-key-400, and the webhook-not-401 ordering.

The webhook HTTP endpoint is split to **#216b** (SecurityConfig already permits the path). Idempotency is service-level (header -> command); the same-key-different-body replay returns the original payment without a 422 (documented #211 behavior).

## Gates

Local (`-x integrationTest`): `:services:payments:{test,detekt,detektTest,spotlessCheck,assemble,compileIntegrationTestKotlin}` green (54 tests). critic GO (matcher ordering + webhook-not-401 + concurrency-503 applied), security-auditor PASS (authz order correct, §5.3 clean, secret gitleaks-safe, 7/7 ACs), evaluator 0.888. The OpenAPI contract IT runs on CI.

Closes #216