### PR TITLE
feat(payments): wire the outbox dispatcher

### DIFF
--- a/services/payments/src/integrationTest/kotlin/com/fincore/payments/application/outbox/PaymentOutboxStoreIT.kt
+++ b/services/payments/src/integrationTest/kotlin/com/fincore/payments/application/outbox/PaymentOutboxStoreIT.kt
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.application.outbox
+
+import com.fincore.events.OutboxStatus
+import com.fincore.payments.infrastructure.persistence.PaymentOutboxEventEntity
+import com.fincore.payments.infrastructure.persistence.PaymentOutboxEventRepository
+import com.fincore.test.containers.PostgresContainerExtension
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.transaction.PlatformTransactionManager
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import org.springframework.transaction.support.TransactionTemplate
+import java.time.Duration
+import java.time.Instant
+import java.util.UUID
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@Import(PaymentOutboxStore::class)
+@ExtendWith(PostgresContainerExtension::class)
+class PaymentOutboxStoreIT(
+    @Autowired private val store: PaymentOutboxStore,
+    @Autowired private val repository: PaymentOutboxEventRepository,
+    @Autowired txManager: PlatformTransactionManager,
+) {
+    private val tx = TransactionTemplate(txManager)
+
+    @AfterEach
+    fun cleanUp() {
+        tx.execute { repository.deleteAll() }
+    }
+
+    @Test
+    fun `should claim a pending row, lease it, and skip it while the lease is held`() {
+        val id = insertPending()
+
+        val claimed = store.claim(MAX_ATTEMPTS, LEASE, BATCH_SIZE)
+        val again = store.claim(MAX_ATTEMPTS, LEASE, BATCH_SIZE)
+
+        claimed shouldHaveSize 1
+        claimed.first().id shouldBe id
+        again shouldHaveSize 0
+        val row = tx.execute { repository.findById(id).orElseThrow() }!!
+        row.status shouldBe OutboxStatus.PUBLISHING
+        row.leasedAt.shouldNotBeNull()
+    }
+
+    @Test
+    fun `should mark a claimed row published and clear the lease`() {
+        val id = insertPending()
+        store.claim(MAX_ATTEMPTS, LEASE, BATCH_SIZE)
+
+        store.markPublished(id)
+
+        val row = tx.execute { repository.findById(id).orElseThrow() }!!
+        row.status shouldBe OutboxStatus.PUBLISHED
+        row.publishedAt.shouldNotBeNull()
+        row.leasedAt.shouldBeNull()
+    }
+
+    @Test
+    fun `should mark failed below the cap and permanently failed at the cap`() {
+        val id = insertPending()
+
+        store.markFailed(id, attempts = 1, maxAttempts = MAX_ATTEMPTS, error = "boom")
+        tx.execute { repository.findById(id).orElseThrow() }!!.status shouldBe OutboxStatus.FAILED
+
+        store.markFailed(id, attempts = MAX_ATTEMPTS, maxAttempts = MAX_ATTEMPTS, error = "boom")
+        val row = tx.execute { repository.findById(id).orElseThrow() }!!
+        row.status shouldBe OutboxStatus.PERMANENTLY_FAILED
+        row.leasedAt.shouldBeNull()
+    }
+
+    private fun insertPending(): UUID {
+        val id = UUID.randomUUID()
+        tx.execute {
+            repository.saveAndFlush(
+                PaymentOutboxEventEntity(
+                    id = id,
+                    aggregateType = "Payment",
+                    aggregateId = "pay_1",
+                    eventType = "PaymentInitiated",
+                    payload = "{}",
+                    status = OutboxStatus.PENDING,
+                    createdAt = Instant.now(),
+                    publishedAt = null,
+                    attempts = 0,
+                    lastError = null,
+                    leasedAt = null,
+                ),
+            )
+        }
+        return id
+    }
+
+    companion object {
+        private const val MAX_ATTEMPTS = 10
+        private const val BATCH_SIZE = 10
+        private val LEASE: Duration = Duration.ofMinutes(5)
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun datasourceProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { PostgresContainerExtension.jdbcUrl }
+            registry.add("spring.datasource.username") { PostgresContainerExtension.username }
+            registry.add("spring.datasource.password") { PostgresContainerExtension.password }
+            registry.add("spring.jpa.hibernate.ddl-auto") { "none" }
+        }
+    }
+}

--- a/services/payments/src/main/kotlin/com/fincore/payments/application/outbox/PaymentOutboxStore.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/application/outbox/PaymentOutboxStore.kt
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.application.outbox
+
+import com.fincore.eventbus.outbox.ClaimedEvent
+import com.fincore.eventbus.outbox.OutboxStore
+import com.fincore.events.OutboxStatus
+import com.fincore.payments.infrastructure.persistence.PaymentOutboxEventRepository
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.time.Duration
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Payments-backed [OutboxStore]. Claim and settle are separate short transactions so the broker publish
+ * (in the dispatcher) never runs inside a DB transaction.
+ */
+@Component
+class PaymentOutboxStore(
+    private val repository: PaymentOutboxEventRepository,
+) : OutboxStore {
+    @Transactional
+    override fun claim(
+        maxAttempts: Int,
+        leaseTimeout: Duration,
+        batchSize: Int,
+    ): List<ClaimedEvent> {
+        val now = Instant.now()
+        val orphanDeadline = now.minus(leaseTimeout)
+        return repository.lockClaimableBatch(maxAttempts, orphanDeadline, batchSize).map { entity ->
+            entity.status = OutboxStatus.PUBLISHING
+            entity.leasedAt = now
+            ClaimedEvent(
+                id = entity.id,
+                aggregateType = entity.aggregateType,
+                aggregateId = entity.aggregateId,
+                eventType = entity.eventType,
+                payload = entity.payload,
+                attempts = entity.attempts,
+            )
+        }
+    }
+
+    @Transactional
+    override fun markPublished(id: UUID) {
+        repository.markPublished(id, OutboxStatus.PUBLISHED, Instant.now())
+    }
+
+    @Transactional
+    override fun markFailed(
+        id: UUID,
+        attempts: Int,
+        maxAttempts: Int,
+        error: String?,
+    ) {
+        val status = if (attempts >= maxAttempts) OutboxStatus.PERMANENTLY_FAILED else OutboxStatus.FAILED
+        repository.markSettledFailure(id, status, attempts, error)
+    }
+}

--- a/services/payments/src/main/kotlin/com/fincore/payments/config/PaymentDispatcherProperties.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/config/PaymentDispatcherProperties.kt
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.validation.annotation.Validated
+import java.time.Duration
+
+@Validated
+@ConfigurationProperties(prefix = "fincore.payments.dispatcher")
+data class PaymentDispatcherProperties(
+    val enabled: Boolean = false,
+    val pollDelay: Duration = defaultPollDelay,
+    val batchSize: Int = DEFAULT_BATCH_SIZE,
+    val maxAttempts: Int = DEFAULT_MAX_ATTEMPTS,
+    val leaseTimeout: Duration = defaultLeaseTimeout,
+    val sendTimeout: Duration = defaultSendTimeout,
+    val topicPrefix: String = "fincore",
+) {
+    init {
+        require(batchSize > 0) { "fincore.payments.dispatcher.batch-size must be positive" }
+        require(maxAttempts > 0) { "fincore.payments.dispatcher.max-attempts must be positive" }
+        require(!pollDelay.isNegative && !pollDelay.isZero) { "fincore.payments.dispatcher.poll-delay must be positive" }
+        require(!leaseTimeout.isNegative && !leaseTimeout.isZero) {
+            "fincore.payments.dispatcher.lease-timeout must be positive"
+        }
+        require(!sendTimeout.isNegative && !sendTimeout.isZero) { "fincore.payments.dispatcher.send-timeout must be positive" }
+    }
+
+    private companion object {
+        const val DEFAULT_BATCH_SIZE = 100
+        const val DEFAULT_MAX_ATTEMPTS = 10
+        val defaultPollDelay: Duration = Duration.ofSeconds(1)
+        val defaultLeaseTimeout: Duration = Duration.ofMinutes(5)
+        val defaultSendTimeout: Duration = Duration.ofSeconds(10)
+    }
+}

--- a/services/payments/src/main/kotlin/com/fincore/payments/config/PaymentOutboxDispatchConfig.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/config/PaymentOutboxDispatchConfig.kt
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.config
+
+import com.fincore.eventbus.outbox.OutboxDispatchSettings
+import com.fincore.eventbus.outbox.OutboxDispatcher
+import com.fincore.payments.application.outbox.PaymentOutboxStore
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.scheduling.annotation.EnableScheduling
+import org.springframework.scheduling.annotation.Scheduled
+
+@Configuration
+@EnableScheduling
+@ConditionalOnProperty(
+    prefix = "fincore.payments.dispatcher",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = false,
+)
+class PaymentOutboxDispatchConfig(
+    store: PaymentOutboxStore,
+    kafkaTemplate: KafkaTemplate<String, String>,
+    properties: PaymentDispatcherProperties,
+) {
+    private val dispatcher =
+        OutboxDispatcher(
+            store,
+            kafkaTemplate,
+            OutboxDispatchSettings(
+                batchSize = properties.batchSize,
+                maxAttempts = properties.maxAttempts,
+                leaseTimeout = properties.leaseTimeout,
+                sendTimeout = properties.sendTimeout,
+                topicPrefix = properties.topicPrefix,
+            ),
+        )
+
+    @Bean
+    fun paymentOutboxDispatcher(): OutboxDispatcher = dispatcher
+
+    @Scheduled(fixedDelayString = "\${fincore.payments.dispatcher.poll-delay}")
+    fun poll() {
+        dispatcher.dispatch()
+    }
+}

--- a/services/payments/src/main/kotlin/com/fincore/payments/config/PaymentsConfig.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/config/PaymentsConfig.kt
@@ -14,5 +14,6 @@ import org.springframework.context.annotation.Configuration
     PaymentScreeningProperties::class,
     PaymentWebhookProperties::class,
     PaymentRetryProperties::class,
+    PaymentDispatcherProperties::class,
 )
 class PaymentsConfig

--- a/services/payments/src/main/kotlin/com/fincore/payments/infrastructure/persistence/PaymentOutboxEventRepository.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/infrastructure/persistence/PaymentOutboxEventRepository.kt
@@ -3,7 +3,55 @@
 
 package com.fincore.payments.infrastructure.persistence
 
+import com.fincore.events.OutboxStatus
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import java.time.Instant
 import java.util.UUID
 
-interface PaymentOutboxEventRepository : JpaRepository<PaymentOutboxEventEntity, UUID>
+interface PaymentOutboxEventRepository : JpaRepository<PaymentOutboxEventEntity, UUID> {
+    @Query(
+        nativeQuery = true,
+        value = """
+            SELECT id, aggregate_type, aggregate_id, event_type, payload, status,
+                   attempts, last_error, created_at, published_at, leased_at
+            FROM payments.outbox_events
+            WHERE status = 'PENDING'
+               OR (status = 'FAILED' AND attempts < :maxAttempts)
+               OR (status = 'PUBLISHING' AND leased_at < :orphanDeadline)
+            ORDER BY created_at
+            LIMIT :batchSize
+            FOR UPDATE SKIP LOCKED
+        """,
+    )
+    fun lockClaimableBatch(
+        @Param("maxAttempts") maxAttempts: Int,
+        @Param("orphanDeadline") orphanDeadline: Instant,
+        @Param("batchSize") batchSize: Int,
+    ): List<PaymentOutboxEventEntity>
+
+    @Modifying(clearAutomatically = true)
+    @Query(
+        "update PaymentOutboxEventEntity e set e.status = :status, e.publishedAt = :publishedAt, e.leasedAt = null " +
+            "where e.id = :id",
+    )
+    fun markPublished(
+        @Param("id") id: UUID,
+        @Param("status") status: OutboxStatus,
+        @Param("publishedAt") publishedAt: Instant,
+    ): Int
+
+    @Modifying(clearAutomatically = true)
+    @Query(
+        "update PaymentOutboxEventEntity e set e.status = :status, e.attempts = :attempts, " +
+            "e.lastError = :lastError, e.leasedAt = null where e.id = :id",
+    )
+    fun markSettledFailure(
+        @Param("id") id: UUID,
+        @Param("status") status: OutboxStatus,
+        @Param("attempts") attempts: Int,
+        @Param("lastError") lastError: String?,
+    ): Int
+}

--- a/services/payments/src/test/kotlin/com/fincore/payments/config/PaymentOutboxDispatchConfigTest.kt
+++ b/services/payments/src/test/kotlin/com/fincore/payments/config/PaymentOutboxDispatchConfigTest.kt
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.config
+
+import com.fincore.eventbus.outbox.OutboxDispatcher
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import org.springframework.boot.autoconfigure.AutoConfigurations
+import org.springframework.boot.test.context.runner.ApplicationContextRunner
+
+class PaymentOutboxDispatchConfigTest {
+    @Test
+    fun `should not register a dispatcher bean when the dispatcher is disabled`() {
+        ApplicationContextRunner()
+            .withConfiguration(AutoConfigurations.of())
+            .withUserConfiguration(PaymentOutboxDispatchConfig::class.java)
+            .run { context ->
+                context.getBeanNamesForType(OutboxDispatcher::class.java).size shouldBe 0
+            }
+    }
+}


### PR DESCRIPTION
## What

Tenth slice of E-02. Connects payments to the shared outbox dispatcher (`com.fincore.eventbus.outbox`, #210) so events written to `payments.outbox_events` (#211/#213/#214) are relayed. An exact mirror of the CI-proven ledger dispatcher (#190/#210).

- **`PaymentOutboxEventRepository`** += `lockClaimableBatch` (native `FOR UPDATE SKIP LOCKED` on `payments.outbox_events`, explicit columns, PENDING / FAILED-under-cap / orphaned-PUBLISHING) + `markPublished` + `markSettledFailure` (`@Modifying(clearAutomatically=true)`).
- **`PaymentOutboxStore`** (`@Component`, implements the `OutboxStore` port): `@Transactional` `claim` (lease: PUBLISHING + `leased_at`) / `markPublished` / `markFailed` (PERMANENTLY_FAILED at the cap), each a separate short transaction.
- **`PaymentDispatcherProperties`** (`fincore.payments.dispatcher`, validated, **off by default**) + **`PaymentOutboxDispatchConfig`** (`@ConditionalOnProperty matchIfMissing=false` + `@Scheduled` poll) constructing the shared non-transactional `OutboxDispatcher` — so the broker send runs outside any DB transaction (8.10).

No schema change (table + indexes from #209). Cleanup/metrics over the payments outbox are later slices.

## Gates

Local (`-x integrationTest`): `:services:payments:{test,detekt,detektTest,spotlessCheck,assemble,compileIntegrationTestKotlin}` green. critic GO (exact mirror, no must-fix), security-auditor PASS (8.10 send-outside-tx via real proxy boundary, SKIP LOCKED + lease correct, native columns match the entity/schema, §5.3 clean, 4/4 ACs, no regression), evaluator 0.93. The store IT (claim/lease/skip, markPublished, markFailed) runs on CI against real Postgres.

Closes #222