### PR TITLE
feat(sandbox): add the payments service to docker-compose

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,9 @@ jobs:
         run: docker compose up -d --build --wait --wait-timeout 90
 
       - name: Smoke (readiness < 30s, public surface served)
-        run: bash scripts/demo.sh
+        run: |
+          bash scripts/demo.sh http://localhost:8080
+          bash scripts/demo.sh http://localhost:8081
 
       - name: Dump container logs on failure
         if: failure()

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
 FROM eclipse-temurin:21-jdk AS builder
+ARG SERVICE=ledger
 WORKDIR /workspace
 COPY . .
 RUN chmod +x gradlew \
- && ./gradlew :services:ledger:bootJar --no-daemon -x test \
- && find services/ledger/build/libs -name '*.jar' ! -name '*-plain.jar' -exec cp {} /workspace/app.jar \;
+ && ./gradlew :services:${SERVICE}:bootJar --no-daemon -x test \
+ && find services/${SERVICE}/build/libs -name '*.jar' ! -name '*-plain.jar' -exec cp {} /workspace/app.jar \;
 
 FROM gcr.io/distroless/java21-debian12:nonroot AS runtime
 WORKDIR /app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
       POSTGRES_DB: ledger
       POSTGRES_USER: ledger
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-ledger}
+    volumes:
+      - ./scripts/initdb:/docker-entrypoint-initdb.d:ro
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ledger -d ledger"]
       interval: 2s
@@ -24,3 +26,20 @@ services:
       SPRING_DATASOURCE_USERNAME: ledger
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD:-ledger}
       KEYCLOAK_ISSUER_URI: http://localhost/realms/fincore
+
+  payments:
+    build:
+      context: .
+      args:
+        SERVICE: payments
+    depends_on:
+      postgres:
+        condition: service_healthy
+    ports:
+      - "8081:8080"
+    environment:
+      SPRING_DATASOURCE_URL: jdbc:postgresql://postgres:5432/payments
+      SPRING_DATASOURCE_USERNAME: ledger
+      SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD:-ledger}
+      KEYCLOAK_ISSUER_URI: http://localhost/realms/fincore
+      FINCORE_PAYMENTS_BANK_SANDBOX_ENABLED: "true"

--- a/scripts/demo.sh
+++ b/scripts/demo.sh
@@ -19,12 +19,12 @@ for i in $(seq 1 "$attempts"); do
 done
 
 if [ "$ready" != true ]; then
-  echo "FAIL: ledger readiness not UP within $((attempts * interval))s at $READINESS"
+  echo "FAIL: readiness not UP within $((attempts * interval))s at $READINESS"
   exit 1
 fi
 
 if ! curl -fsS -o /dev/null "$LIVENESS"; then
-  echo "FAIL: ledger liveness not UP at $LIVENESS"
+  echo "FAIL: liveness not UP at $LIVENESS"
   exit 1
 fi
 
@@ -34,4 +34,4 @@ if [ "$code" != "200" ]; then
   exit 1
 fi
 
-echo "ledger smoke OK: readiness UP, liveness UP, api-docs 200"
+echo "smoke OK ($BASE_URL): readiness UP, liveness UP, api-docs 200"

--- a/scripts/initdb/01-create-payments-db.sql
+++ b/scripts/initdb/01-create-payments-db.sql
@@ -1,0 +1,5 @@
+-- SPDX-License-Identifier: BUSL-1.1
+-- SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+-- Runs once on first postgres init (empty data dir). Gives payments its own
+-- database so its Liquibase DATABASECHANGELOG/lock stay isolated from ledger.
+CREATE DATABASE payments OWNER ledger;


### PR DESCRIPTION
Adds the payments service to the local sandbox compose stack (E-06, #238).

## What
- Parameterize the root `Dockerfile` with `ARG SERVICE=ledger` so the same multi-stage build produces either service jar. Default `ledger` keeps the ledger build and the docker image CI job unchanged.
- Add a `payments` service to `docker-compose.yml` on host port 8081, pointing at its own `payments` database, `depends_on` postgres healthy, with the sandbox bank provider enabled (`FINCORE_PAYMENTS_BANK_SANDBOX_ENABLED=true`) so it boots without a real adapter.
- Create the second database via a postgres initdb script (`scripts/initdb/01-create-payments-db.sql`) so each service keeps an isolated Liquibase `DATABASECHANGELOG`/lock.
- Genericize `scripts/demo.sh` wording so it smoke-checks any base URL (behaviour identical for ledger).
- `compose-smoke` CI job now polls both 8080 (ledger) and 8081 (payments), preserving the load-bearing step order.

## Notes
- The webhook HMAC secret is intentionally omitted; `PaymentWebhookProperties` defaults to a blank fail-closed secret, so payments boots fine and no weak secret is committed.
- Docker is unavailable in WSL, so local `docker compose config` could not run. The CI **Compose smoke** job is the binding verification: payments must come up on 8081.

## Gate chain
- security-auditor (opus): PASS, no must-fix.
- evaluator: PASS (0.876 >= 0.80).
- code-reviewer findings were out-of-scope (referenced .kt files not in this infra-only diff) and rejected.

Closes #238