### PR TITLE
feat(sandbox): add amount-driven scenarios to the sandbox bank provider

### DIFF
--- a/services/payments/src/main/kotlin/com/fincore/payments/config/PaymentsConfig.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/config/PaymentsConfig.kt
@@ -6,6 +6,7 @@ package com.fincore.payments.config
 import com.fincore.payments.application.retry.PaymentRetryProperties
 import com.fincore.payments.application.screening.PaymentScreeningProperties
 import com.fincore.payments.application.webhook.PaymentWebhookProperties
+import com.fincore.payments.infrastructure.bank.SandboxBankProperties
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.context.annotation.Configuration
 
@@ -15,5 +16,6 @@ import org.springframework.context.annotation.Configuration
     PaymentWebhookProperties::class,
     PaymentRetryProperties::class,
     PaymentDispatcherProperties::class,
+    SandboxBankProperties::class,
 )
 class PaymentsConfig

--- a/services/payments/src/main/kotlin/com/fincore/payments/infrastructure/bank/SandboxBankProperties.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/infrastructure/bank/SandboxBankProperties.kt
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.infrastructure.bank
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import java.math.BigDecimal
+import java.time.Duration
+
+@ConfigurationProperties(prefix = "fincore.payments.bank.sandbox")
+data class SandboxBankProperties(
+    val rejectAmount: BigDecimal = DEFAULT_REJECT_AMOUNT,
+    val delayAmount: BigDecimal = DEFAULT_DELAY_AMOUNT,
+    val delay: Duration = DEFAULT_DELAY,
+    val maxDelay: Duration = DEFAULT_MAX_DELAY,
+) {
+    private companion object {
+        val DEFAULT_REJECT_AMOUNT: BigDecimal = BigDecimal("999.99")
+        val DEFAULT_DELAY_AMOUNT: BigDecimal = BigDecimal("888.88")
+        val DEFAULT_DELAY: Duration = Duration.ofSeconds(2)
+        val DEFAULT_MAX_DELAY: Duration = Duration.ofSeconds(10)
+    }
+}

--- a/services/payments/src/main/kotlin/com/fincore/payments/infrastructure/bank/SandboxBankProvider.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/infrastructure/bank/SandboxBankProvider.kt
@@ -8,6 +8,7 @@ import com.fincore.payments.application.bank.BankProvider
 import com.fincore.payments.application.bank.BankSubmissionResult
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
+import java.time.Duration
 
 @Component
 @ConditionalOnProperty(
@@ -16,13 +17,34 @@ import org.springframework.stereotype.Component
     havingValue = "true",
     matchIfMissing = false,
 )
-class SandboxBankProvider : BankProvider {
-    override fun submit(request: BankPaymentRequest): BankSubmissionResult =
+class SandboxBankProvider(
+    private val properties: SandboxBankProperties = SandboxBankProperties(),
+) : BankProvider {
+    override fun submit(request: BankPaymentRequest): BankSubmissionResult {
         if (request.reference.contains(REJECT_MARKER, ignoreCase = true)) {
-            BankSubmissionResult.Rejected("sandbox rejected by reference marker")
-        } else {
-            BankSubmissionResult.Accepted("sbx-${request.paymentId}")
+            return BankSubmissionResult.Rejected("sandbox rejected by reference marker")
         }
+        val amount = request.amount.amount
+        if (amount.compareTo(properties.rejectAmount) == 0) {
+            return BankSubmissionResult.Rejected("sandbox rejected: amount matches the decline scenario")
+        }
+        if (amount.compareTo(properties.delayAmount) == 0) {
+            sleepBounded(properties.delay)
+        }
+        return BankSubmissionResult.Accepted("sbx-${request.paymentId}")
+    }
+
+    private fun sleepBounded(delay: Duration) {
+        val millis = delay.coerceAtMost(properties.maxDelay).coerceAtLeast(Duration.ZERO).toMillis()
+        if (millis <= 0) {
+            return
+        }
+        try {
+            Thread.sleep(millis)
+        } catch (_: InterruptedException) {
+            Thread.currentThread().interrupt()
+        }
+    }
 
     private companion object {
         const val REJECT_MARKER = "reject"

--- a/services/payments/src/test/kotlin/com/fincore/payments/infrastructure/bank/SandboxBankProviderTest.kt
+++ b/services/payments/src/test/kotlin/com/fincore/payments/infrastructure/bank/SandboxBankProviderTest.kt
@@ -7,9 +7,13 @@ import com.fincore.core.Currency
 import com.fincore.core.Money
 import com.fincore.payments.application.bank.BankPaymentRequest
 import com.fincore.payments.application.bank.BankSubmissionResult
+import io.kotest.matchers.comparables.shouldBeGreaterThanOrEqualTo
+import io.kotest.matchers.comparables.shouldBeLessThan
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import org.junit.jupiter.api.Test
 import java.math.BigDecimal
+import java.time.Duration
 
 class SandboxBankProviderTest {
     private val provider = SandboxBankProvider()
@@ -22,6 +26,13 @@ class SandboxBankProviderTest {
     }
 
     @Test
+    fun `should accept plainly for an ordinary amount`() {
+        val result = provider.submit(request("order-1", "100.00"))
+
+        result shouldBe BankSubmissionResult.Accepted("sbx-pay_1")
+    }
+
+    @Test
     fun `should reject when the reference carries the reject marker`() {
         val result = provider.submit(request("please-REJECT-this"))
 
@@ -29,12 +40,61 @@ class SandboxBankProviderTest {
     }
 
     @Test
-    fun `should produce the same result when the same request is submitted twice`() {
-        val request = request("order-1")
+    fun `should reject when the amount matches the configured reject amount`() {
+        val result = provider.submit(request("order-1", "999.99"))
+
+        result shouldBe BankSubmissionResult.Rejected("sandbox rejected: amount matches the decline scenario")
+    }
+
+    @Test
+    fun `should reject by reference marker even when the amount matches the configured reject amount`() {
+        val result = provider.submit(request("reject-this", "999.99"))
+
+        result shouldBe BankSubmissionResult.Rejected("sandbox rejected by reference marker")
+    }
+
+    @Test
+    fun `should reject by reference marker even when the amount matches the configured delay amount`() {
+        val result = provider.submit(request("reject-this", "888.88"))
+
+        result shouldBe BankSubmissionResult.Rejected("sandbox rejected by reference marker")
+    }
+
+    @Test
+    fun `should accept after a bounded delay when the amount matches the configured delay amount`() {
+        val fast = SandboxBankProvider(SandboxBankProperties(delay = Duration.ofMillis(80), maxDelay = Duration.ofMillis(500)))
+
+        val elapsed = measureMillis { fast.submit(request("order-1", "888.88")).shouldBeInstanceOf<BankSubmissionResult.Accepted>() }
+
+        elapsed shouldBeGreaterThanOrEqualTo 80L
+        elapsed shouldBeLessThan 500L
+    }
+
+    @Test
+    fun `should clamp the delay to the configured maximum when the configured delay exceeds it`() {
+        val clamped = SandboxBankProvider(SandboxBankProperties(delay = Duration.ofMillis(800), maxDelay = Duration.ofMillis(120)))
+
+        val elapsed = measureMillis { clamped.submit(request("order-1", "888.88")).shouldBeInstanceOf<BankSubmissionResult.Accepted>() }
+
+        elapsed shouldBeGreaterThanOrEqualTo 120L
+        elapsed shouldBeLessThan 800L
+    }
+
+    @Test
+    fun `should produce the same result when the same plain-accept request is submitted twice`() {
+        val request = request("order-1", "100.00")
 
         provider.submit(request) shouldBe provider.submit(request)
     }
 
-    private fun request(reference: String): BankPaymentRequest =
-        BankPaymentRequest("pay_1", Money(BigDecimal("100.00"), Currency.USD), reference)
+    private fun measureMillis(block: () -> Unit): Long {
+        val start = System.nanoTime()
+        block()
+        return (System.nanoTime() - start) / 1_000_000
+    }
+
+    private fun request(
+        reference: String,
+        amount: String = "100.00",
+    ): BankPaymentRequest = BankPaymentRequest("pay_1", Money(BigDecimal(amount), Currency.USD), reference)
 }


### PR DESCRIPTION
Extends the sandbox bank provider (E-06, #234) with deterministic, amount-driven scenarios.

## What
- The payment amount now selects the outcome: a configured reject amount declines, a configured delay amount sleeps a bounded duration then accepts (slow-provider demo), any other amount accepts plainly.
- The existing reference reject-marker keeps precedence over any amount scenario (back-compat with the lifecycle ITs).
- Trigger amounts and the delay are configurable via new `SandboxBankProperties` (`@ConfigurationProperties`, neutral defaults 999.99 / 888.88 / PT2S, hard ceiling PT10S), matching the four existing payments property classes.
- A default-valued constructor keeps `SandboxBankProvider()` no-arg construction working (unit test + IT bean), and the `@ConditionalOnProperty` off-by-default gate is unchanged.

## Correctness / safety
- Amount comparison uses `BigDecimal.compareTo` (not `equals`) per the money rules.
- Bounded sleep: `delay.coerceAtMost(maxDelay).coerceAtLeast(ZERO)` so a misconfigured negative `maxDelay` cannot throw, and it can never hang. `submit()` runs outside any transaction, so the sleep holds no DB connection.
- `InterruptedException` is caught and the interrupt flag restored.
- Amount `100.00` (the lifecycle-IT amount) maps to plain accept, so existing ITs are unaffected.

## Gate chain
- critic: GO-WITH-CHANGES (4 must-fixes applied: small-ms delay/clamp tests, firm elapsed bounds, coerceAtMost/coerceAtLeast, determinism on plain-accept).
- security-auditor (opus): PASS, no must-fix.
- evaluator: PASS (0.885 >= 0.80).
- code-reviewer's lone must-fix (data class -> class) was rejected with evidence: that rule is JPA-entity-specific and all four sibling `@ConfigurationProperties` classes use `data class`; detekt is green.
- Local gates green: test, detekt, detektTest, spotlessCheck, assemble, compileIntegrationTestKotlin.

Closes #234