### PR TITLE
feat(sandbox): add demo seed accounts via a context-gated liquibase changeset

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,7 @@ services:
       SPRING_DATASOURCE_USERNAME: ledger
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD:-ledger}
       KEYCLOAK_ISSUER_URI: http://localhost/realms/fincore
+      SPRING_LIQUIBASE_CONTEXTS: production,demo
 
   payments:
     build:

--- a/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/db/LedgerSchemaTestDb.kt
+++ b/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/db/LedgerSchemaTestDb.kt
@@ -19,6 +19,7 @@ import java.util.UUID
 
 internal const val IMAGE = "postgres:17-alpine"
 internal const val CHANGELOG = "db/changelog/db.changelog-master.yaml"
+internal const val PRODUCTION_CONTEXT = "production"
 internal const val ACTOR = "test"
 internal const val CCY = "USD"
 internal const val ASSET = "ASSET"
@@ -68,7 +69,7 @@ internal class LedgerSchemaTestDb(
         val connection = DriverManager.getConnection(postgres.jdbcUrl, postgres.username, postgres.password)
         val database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(JdbcConnection(connection))
         Liquibase(CHANGELOG, ClassLoaderResourceAccessor(), database).use { liquibase ->
-            liquibase.update(Contexts(), LabelExpression())
+            liquibase.update(Contexts(PRODUCTION_CONTEXT), LabelExpression())
         }
     }
 

--- a/services/ledger/src/main/resources/application.yml
+++ b/services/ledger/src/main/resources/application.yml
@@ -11,6 +11,7 @@ spring:
       ddl-auto: none
   liquibase:
     change-log: classpath:db/changelog/db.changelog-master.yaml
+    contexts: ${SPRING_LIQUIBASE_CONTEXTS:production}
   security:
     oauth2:
       resourceserver:

--- a/services/ledger/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/ledger/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -40,3 +40,6 @@ databaseChangeLog:
   - include:
       file: v0.1/021-outbox-events-leased-at.sql
       relativeToChangelogFile: true
+  - include:
+      file: demo/001-demo-accounts.sql
+      relativeToChangelogFile: true

--- a/services/ledger/src/main/resources/db/changelog/demo/001-demo-accounts.sql
+++ b/services/ledger/src/main/resources/db/changelog/demo/001-demo-accounts.sql
@@ -1,0 +1,12 @@
+--liquibase formatted sql
+-- SPDX-License-Identifier: BUSL-1.1
+-- SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+--changeset fincore:demo-001-accounts context:demo dbms:postgresql
+INSERT INTO ledger.accounts (id, name, type, currency, created_by, updated_by) VALUES
+    ('00000000-0000-0000-0000-000000000001', 'Customer Wallet USD', 'USER_WALLET', 'USD', 'demo-seed', 'demo-seed'),
+    ('00000000-0000-0000-0000-000000000002', 'Customer Wallet EUR', 'USER_WALLET', 'EUR', 'demo-seed', 'demo-seed'),
+    ('00000000-0000-0000-0000-000000000003', 'Platform Fee Income', 'FEE', 'USD', 'demo-seed', 'demo-seed'),
+    ('00000000-0000-0000-0000-000000000004', 'Settlement Reserve', 'RESERVE', 'USD', 'demo-seed', 'demo-seed'),
+    ('00000000-0000-0000-0000-000000000005', 'Suspense', 'SUSPENSE', 'USD', 'demo-seed', 'demo-seed')
+ON CONFLICT (id) DO NOTHING;


### PR DESCRIPTION
Adds demo seed data so a fresh sandbox stack is immediately explorable (E-06, #235).

## What
- New idempotent Liquibase changeset (`ledger/.../db/changelog/demo/001-demo-accounts.sql`) inserting 5 generic chart-of-accounts demo rows (`INSERT ... ON CONFLICT (id) DO NOTHING`, fixed UUIDs, `dbms:postgresql`, `context:demo`). Data lives only in the migration, per the Data Integrity Rules - no `seed.sh`, no client hardcode.
- Gating: ledger `spring.liquibase.contexts` defaults to `production` (a non-demo sentinel), so production and Helm deployments skip the demo changeset. The compose sandbox opts in with `SPRING_LIQUIBASE_CONTEXTS=production,demo`.
- The schema-test harness (`LedgerSchemaTestDb.migrate()`) now migrates with the `production` context so the schema integration tests mirror production and never load demo rows.

## Why the context default matters
Liquibase runs every changeset when no runtime context is set, so a `context:demo` changeset alone would still load in prod. Defaulting the runtime contexts to `production` activates the filter; demo then loads only when `demo` is in the runtime contexts. No-context schema changesets always run, so this is back-compat for the existing schema.

## Verification
- Docker is unavailable in WSL, so the container replay could not run locally. The binding gate is CI **Compose smoke**: ledger boots with `production,demo`, so the demo changeset must apply cleanly against the real schema (every value validated against the `accounts` CHECK constraints) for readiness to pass.
- Idempotency is guaranteed by `ON CONFLICT DO NOTHING` plus Liquibase changeset tracking; production-skip is enforced by the context default (prod profile and Helm inject no demo context).
- Local ledger gates green: detekt, spotlessCheck, compileIntegrationTestKotlin.

## Gate chain
- critic: GO-WITH-CHANGES (3 must-fixes applied: `dbms:postgresql`, explicit NOT NULL column list, master-changelog replay).
- security-auditor (opus): PASS - prod provably never loads demo (prod profile + Helm + base sentinel), §5.3 clean, idempotent, non-destructive.
- code-reviewer: surfaced the empty-`Contexts()` harness impurity, fixed to `Contexts("production")`.
- evaluator: PASS (0.888 >= 0.80).

Closes #235