### PR TITLE
feat(sandbox): add an importable bruno api collection

### DIFF
--- a/api/collection/README.md
+++ b/api/collection/README.md
@@ -1,0 +1,41 @@
+# FinCore Engine API collection
+
+An importable [Bruno](https://www.usebruno.com/) collection covering the implemented ledger, payments and decision
+endpoints, for exploring a local sandbox. Bruno is open source and stores requests as plain text, so the collection is
+diffable and reviewable. Postman and Insomnia can import a Bruno collection if you prefer those tools.
+
+## Use
+
+1. Install Bruno, then open this folder (`api/collection`) as a collection.
+2. Select the **sandbox** environment and set its variables:
+   - `ledgerUrl`, `paymentsUrl`, `decisionUrl` - base URLs (defaults target the local compose stack).
+   - `token` - a bearer JWT with the required scopes. **Empty by default**; the sandbox compose stack does not run an
+     identity provider, so obtain a token from your own Keycloak (or run the services against one) before calling the
+     authenticated endpoints.
+   - resource ids (`accountId`, `secondAccountId`, `transactionId`, `paymentId`) - fill in after creating a resource.
+   - `webhookSignature` - empty by default; see Webhooks below.
+
+## Scopes
+
+| Service | Read | Write |
+|---------|------|-------|
+| Ledger | `ledger:read` | `ledger:write` |
+| Payments | `payments:read` | `payments:write` |
+| Decision | `decision:read` | `decision:write` |
+
+Mutating ledger requests (create account, post transaction, reverse) and payment initiation require an
+`Idempotency-Key` header; the other endpoints do not.
+
+## Webhooks
+
+`POST /v1/payments/webhooks` is authenticated by an HMAC signature over the raw body (`X-Webhook-Signature`), not a
+bearer token. The `webhookSignature` variable is empty by default, so the request is rejected until you supply a
+signature computed from the body and the configured sandbox secret. The end-to-end demo script computes it for you.
+
+## Services and the sandbox
+
+The sandbox compose stack runs ledger (`8080`) and payments (`8081`). The decision service is not part of that stack;
+`decisionUrl` is a placeholder for running it separately. Endpoints that are specified but not yet implemented
+(compliance/KYC, webhook subscriptions) are intentionally omitted.
+
+SPDX-License-Identifier: BUSL-1.1

--- a/api/collection/bruno.json
+++ b/api/collection/bruno.json
@@ -1,0 +1,9 @@
+{
+  "version": "1",
+  "name": "FinCore Engine",
+  "type": "collection",
+  "ignore": [
+    "node_modules",
+    ".git"
+  ]
+}

--- a/api/collection/decision/Create rule.bru
+++ b/api/collection/decision/Create rule.bru
@@ -1,0 +1,26 @@
+meta {
+  name: Create rule
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{decisionUrl}}/v1/decision/rules
+  body: json
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{token}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "ruleKey": "demo.approve"
+  }
+}
+
+docs {
+  Scope: decision:write. Creates the rule shell; publish a version next.
+}

--- a/api/collection/decision/Evaluate rule.bru
+++ b/api/collection/decision/Evaluate rule.bru
@@ -1,0 +1,26 @@
+meta {
+  name: Evaluate rule
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{decisionUrl}}/v1/decision/rules/{{ruleKey}}/evaluate
+  body: json
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{token}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "amount": 100
+  }
+}
+
+docs {
+  Scope: decision:write. The body is the attributes map evaluated against the rule's active version.
+}

--- a/api/collection/decision/Get decision logs.bru
+++ b/api/collection/decision/Get decision logs.bru
@@ -1,0 +1,23 @@
+meta {
+  name: Get decision logs
+  type: http
+  seq: 6
+}
+
+get {
+  url: {{decisionUrl}}/v1/decision/logs?inputHash={{inputHash}}
+  body: none
+  auth: none
+}
+
+params:query {
+  inputHash: {{inputHash}}
+}
+
+headers {
+  Authorization: Bearer {{token}}
+}
+
+docs {
+  Scope: decision:read. Provide exactly one of inputHash or ruleVersionId; with neither (or both) the request returns 400.
+}

--- a/api/collection/decision/Get rule.bru
+++ b/api/collection/decision/Get rule.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Get rule
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{decisionUrl}}/v1/decision/rules/{{ruleKey}}
+  body: none
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{token}}
+}
+
+docs {
+  Scope: decision:read.
+}

--- a/api/collection/decision/Publish rule version.bru
+++ b/api/collection/decision/Publish rule version.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Publish rule version
+  type: http
+  seq: 2
+}
+
+post {
+  url: {{decisionUrl}}/v1/decision/rules/{{ruleKey}}/versions
+  body: json
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{token}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "condition": { "attr": "amount", "op": "gte", "value": 0 },
+    "outcome": { "label": "APPROVE" }
+  }
+}
+
+docs {
+  Scope: decision:write. The body is the rule's JSON DSL; it is validated fail-closed before storage. No Idempotency-Key by design.
+}

--- a/api/collection/decision/Replay.bru
+++ b/api/collection/decision/Replay.bru
@@ -1,0 +1,32 @@
+meta {
+  name: Replay
+  type: http
+  seq: 5
+}
+
+post {
+  url: {{decisionUrl}}/v1/decision/replay
+  body: json
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{token}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "candidate": {
+      "condition": { "attr": "amount", "op": "gte", "value": 0 },
+      "outcome": { "label": "APPROVE" }
+    },
+    "inputs": [
+      { "amount": 100 }
+    ]
+  }
+}
+
+docs {
+  Scope: decision:write. Read-only diff of a candidate DSL against recorded decisions; writes nothing.
+}

--- a/api/collection/environments/sandbox.bru
+++ b/api/collection/environments/sandbox.bru
@@ -1,0 +1,14 @@
+vars {
+  ledgerUrl: http://localhost:8080
+  paymentsUrl: http://localhost:8081
+  decisionUrl: http://localhost:8082
+  token:
+  idempotencyKey: demo-key-0001
+  webhookSignature:
+  accountId:
+  secondAccountId:
+  transactionId:
+  paymentId:
+  ruleKey: demo.approve
+  inputHash:
+}

--- a/api/collection/ledger/Create account.bru
+++ b/api/collection/ledger/Create account.bru
@@ -1,0 +1,29 @@
+meta {
+  name: Create account
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{ledgerUrl}}/v1/accounts
+  body: json
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{token}}
+  Idempotency-Key: {{idempotencyKey}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "name": "Customer Wallet USD",
+    "type": "USER_WALLET",
+    "currency": "USD"
+  }
+}
+
+docs {
+  Scope: ledger:write. Requires an Idempotency-Key. type is one of ASSET, LIABILITY, EQUITY, REVENUE, EXPENSE, USER_WALLET, FEE, RESERVE, SUSPENSE.
+}

--- a/api/collection/ledger/Get account balance.bru
+++ b/api/collection/ledger/Get account balance.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Get account balance
+  type: http
+  seq: 4
+}
+
+get {
+  url: {{ledgerUrl}}/v1/accounts/{{accountId}}/balance
+  body: none
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{token}}
+}
+
+docs {
+  Scope: ledger:read.
+}

--- a/api/collection/ledger/Get account.bru
+++ b/api/collection/ledger/Get account.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Get account
+  type: http
+  seq: 3
+}
+
+get {
+  url: {{ledgerUrl}}/v1/accounts/{{accountId}}
+  body: none
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{token}}
+}
+
+docs {
+  Scope: ledger:read.
+}

--- a/api/collection/ledger/Get transaction.bru
+++ b/api/collection/ledger/Get transaction.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Get transaction
+  type: http
+  seq: 8
+}
+
+get {
+  url: {{ledgerUrl}}/v1/transactions/{{transactionId}}
+  body: none
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{token}}
+}
+
+docs {
+  Scope: ledger:read. Returns the transaction with its entries.
+}

--- a/api/collection/ledger/List account entries.bru
+++ b/api/collection/ledger/List account entries.bru
@@ -1,0 +1,23 @@
+meta {
+  name: List account entries
+  type: http
+  seq: 5
+}
+
+get {
+  url: {{ledgerUrl}}/v1/accounts/{{accountId}}/entries?limit=20
+  body: none
+  auth: none
+}
+
+params:query {
+  limit: 20
+}
+
+headers {
+  Authorization: Bearer {{token}}
+}
+
+docs {
+  Scope: ledger:read. Cursor-paginated.
+}

--- a/api/collection/ledger/List accounts.bru
+++ b/api/collection/ledger/List accounts.bru
@@ -1,0 +1,23 @@
+meta {
+  name: List accounts
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{ledgerUrl}}/v1/accounts?limit=20
+  body: none
+  auth: none
+}
+
+params:query {
+  limit: 20
+}
+
+headers {
+  Authorization: Bearer {{token}}
+}
+
+docs {
+  Scope: ledger:read. Cursor-paginated: add &cursor=... from a previous response's nextCursor.
+}

--- a/api/collection/ledger/List transactions.bru
+++ b/api/collection/ledger/List transactions.bru
@@ -1,0 +1,23 @@
+meta {
+  name: List transactions
+  type: http
+  seq: 7
+}
+
+get {
+  url: {{ledgerUrl}}/v1/transactions?limit=20
+  body: none
+  auth: none
+}
+
+params:query {
+  limit: 20
+}
+
+headers {
+  Authorization: Bearer {{token}}
+}
+
+docs {
+  Scope: ledger:read. Cursor-paginated.
+}

--- a/api/collection/ledger/Post transaction.bru
+++ b/api/collection/ledger/Post transaction.bru
@@ -1,0 +1,41 @@
+meta {
+  name: Post transaction
+  type: http
+  seq: 6
+}
+
+post {
+  url: {{ledgerUrl}}/v1/transactions
+  body: json
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{token}}
+  Idempotency-Key: {{idempotencyKey}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "reference": "demo-tx-1",
+    "description": "demo balanced posting",
+    "currency": "USD",
+    "entries": [
+      {
+        "accountId": "{{accountId}}",
+        "direction": "DEBIT",
+        "amount": "100.00"
+      },
+      {
+        "accountId": "{{secondAccountId}}",
+        "direction": "CREDIT",
+        "amount": "100.00"
+      }
+    ]
+  }
+}
+
+docs {
+  Scope: ledger:write. Requires an Idempotency-Key. Entries must balance to zero per currency (sum of DEBIT == sum of CREDIT) and share one currency. Set accountId and secondAccountId to two existing accounts.
+}

--- a/api/collection/ledger/Reverse transaction.bru
+++ b/api/collection/ledger/Reverse transaction.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Reverse transaction
+  type: http
+  seq: 9
+}
+
+post {
+  url: {{ledgerUrl}}/v1/transactions/{{transactionId}}/reverse
+  body: json
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{token}}
+  Idempotency-Key: {{idempotencyKey}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "reason": "demo reversal"
+  }
+}
+
+docs {
+  Scope: ledger:write. Requires an Idempotency-Key. Marks the original REVERSED and posts a compensating transaction.
+}

--- a/api/collection/payments/Cancel payment.bru
+++ b/api/collection/payments/Cancel payment.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Cancel payment
+  type: http
+  seq: 3
+}
+
+post {
+  url: {{paymentsUrl}}/v1/payments/{{paymentId}}/cancel
+  body: none
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{token}}
+}
+
+docs {
+  Scope: payments:write. Only valid before submission.
+}

--- a/api/collection/payments/Get payment.bru
+++ b/api/collection/payments/Get payment.bru
@@ -1,0 +1,19 @@
+meta {
+  name: Get payment
+  type: http
+  seq: 2
+}
+
+get {
+  url: {{paymentsUrl}}/v1/payments/{{paymentId}}
+  body: none
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{token}}
+}
+
+docs {
+  Scope: payments:read.
+}

--- a/api/collection/payments/Initiate payment.bru
+++ b/api/collection/payments/Initiate payment.bru
@@ -1,0 +1,29 @@
+meta {
+  name: Initiate payment
+  type: http
+  seq: 1
+}
+
+post {
+  url: {{paymentsUrl}}/v1/payments
+  body: json
+  auth: none
+}
+
+headers {
+  Authorization: Bearer {{token}}
+  Idempotency-Key: {{idempotencyKey}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "amount": "100.00",
+    "currency": "USD",
+    "reference": "demo-order-1"
+  }
+}
+
+docs {
+  Scope: payments:write. Requires an Idempotency-Key. amount must be positive; currency is an ISO 4217 code.
+}

--- a/api/collection/payments/Send webhook.bru
+++ b/api/collection/payments/Send webhook.bru
@@ -1,0 +1,28 @@
+meta {
+  name: Send webhook
+  type: http
+  seq: 4
+}
+
+post {
+  url: {{paymentsUrl}}/v1/payments/webhooks
+  body: json
+  auth: none
+}
+
+headers {
+  X-Webhook-Signature: {{webhookSignature}}
+  Content-Type: application/json
+}
+
+body:json {
+  {
+    "deliveryId": "demo-delivery-1",
+    "providerReference": "sbx-demo-1",
+    "outcome": "SETTLED"
+  }
+}
+
+docs {
+  No bearer token: authenticated by an HMAC signature over the raw body in X-Webhook-Signature. With an empty webhookSignature the request is rejected (fail-closed); compute the signature from the body and the configured sandbox secret. outcome is SETTLED or FAILED.
+}


### PR DESCRIPTION
Adds an importable API collection for exploring the sandbox (E-06, #237).

## What
- A [Bruno](https://www.usebruno.com/) collection under `api/collection/` covering the implemented endpoints across the three services: ledger (9 requests), payments (4), decision (6).
- Built from the **running controllers and DTOs**, not the umbrella `api/openapi.yaml` (which has drifted), so the requests match what the services actually serve.
- Env-parameterised via a `sandbox` environment: base URLs per service plus a bearer `token` and `webhookSignature` that are **empty placeholders** - no secrets committed.
- README documents the scopes, the `Idempotency-Key` requirement (only on the four mutating endpoints that need it), the HMAC webhook flow, and that the decision service runs outside the sandbox compose stack.

## Why Bruno
Open source (no commercial/login wall), plain text so it is diffable and reviewable in PRs, and importable (Postman and Insomnia can import a Bruno collection).

## Gate chain
- critic: GO-WITH-CHANGES (all applied: full transaction body with two entries + `secondAccountId`, `Idempotency-Key` only where required, `logs` carries the required `inputHash`, README honesty on the decision service + webhook signature).
- security-auditor (opus): PASS - zero embedded secrets, localhost-only URLs, §5.3 clean.
- code-reviewer: APPROVED - request shapes verified against the real controllers/DTOs.
- evaluator: PASS (0.89 >= 0.80).
- No Kotlin; the binding CI gate is gitleaks (no secret literals).

Closes #237