### PR TITLE
feat(observability): propagate a correlation id in payments and decision

### DIFF
--- a/services/decision/src/main/kotlin/com/fincore/decision/store/api/observability/CorrelationIdAttributes.kt
+++ b/services/decision/src/main/kotlin/com/fincore/decision/store/api/observability/CorrelationIdAttributes.kt
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.store.api.observability
+
+object CorrelationIdAttributes {
+    const val HEADER = "X-Correlation-Id"
+    const val MDC_KEY = "correlation_id"
+}

--- a/services/decision/src/main/kotlin/com/fincore/decision/store/api/observability/CorrelationIdFilter.kt
+++ b/services/decision/src/main/kotlin/com/fincore/decision/store/api/observability/CorrelationIdFilter.kt
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.store.api.observability
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.MDC
+import org.springframework.web.filter.OncePerRequestFilter
+import java.util.UUID
+
+class CorrelationIdFilter : OncePerRequestFilter() {
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val correlationId = resolve(request.getHeader(CorrelationIdAttributes.HEADER))
+        MDC.put(CorrelationIdAttributes.MDC_KEY, correlationId)
+        response.setHeader(CorrelationIdAttributes.HEADER, correlationId)
+        try {
+            filterChain.doFilter(request, response)
+        } finally {
+            MDC.remove(CorrelationIdAttributes.MDC_KEY)
+        }
+    }
+
+    private fun resolve(inbound: String?): String =
+        inbound?.takeUnless { it.isBlank() }?.let(::canonicalUuidOrNull) ?: UUID.randomUUID().toString()
+
+    private fun canonicalUuidOrNull(value: String): String? = runCatching { UUID.fromString(value).toString() }.getOrNull()
+}

--- a/services/decision/src/main/kotlin/com/fincore/decision/store/config/CorrelationIdFilterConfig.kt
+++ b/services/decision/src/main/kotlin/com/fincore/decision/store/config/CorrelationIdFilterConfig.kt
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.store.config
+
+import com.fincore.decision.store.api.observability.CorrelationIdFilter
+import org.springframework.boot.web.servlet.FilterRegistrationBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.Ordered
+
+@Configuration
+class CorrelationIdFilterConfig {
+    @Bean
+    fun correlationIdFilterRegistration(): FilterRegistrationBean<CorrelationIdFilter> =
+        FilterRegistrationBean(CorrelationIdFilter()).apply {
+            order = Ordered.HIGHEST_PRECEDENCE
+            addUrlPatterns("/*")
+        }
+}

--- a/services/decision/src/test/kotlin/com/fincore/decision/store/api/observability/CorrelationIdFilterTest.kt
+++ b/services/decision/src/test/kotlin/com/fincore/decision/store/api/observability/CorrelationIdFilterTest.kt
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.store.api.observability
+
+import com.fincore.decision.store.api.observability.CorrelationIdAttributes.HEADER
+import com.fincore.decision.store.api.observability.CorrelationIdAttributes.MDC_KEY
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import jakarta.servlet.FilterChain
+import jakarta.servlet.ServletRequest
+import jakarta.servlet.ServletResponse
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.slf4j.MDC
+import org.springframework.mock.web.MockFilterChain
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import java.util.UUID
+
+class CorrelationIdFilterTest {
+    private val filter = CorrelationIdFilter()
+
+    @AfterEach
+    fun clearMdc() = MDC.clear()
+
+    @Test
+    fun `should echo a valid inbound correlation id on the response`() {
+        val inbound = "123e4567-e89b-12d3-a456-426614174000"
+        val response = MockHttpServletResponse()
+        filter.doFilter(requestWith(inbound), response, MockFilterChain())
+        response.getHeader(HEADER) shouldBe inbound
+    }
+
+    @Test
+    fun `should generate a valid uuid when no inbound id is present`() {
+        val response = MockHttpServletResponse()
+        filter.doFilter(MockHttpServletRequest(), response, MockFilterChain())
+        val header = response.getHeader(HEADER)
+        header.shouldNotBeNull()
+        shouldNotThrowAny { UUID.fromString(header) }
+    }
+
+    @Test
+    fun `should replace an invalid inbound id without rejecting the request`() {
+        val response = MockHttpServletResponse()
+        val chain = MockFilterChain()
+        filter.doFilter(requestWith("not-a-uuid"), response, chain)
+        val header = response.getHeader(HEADER)
+        header shouldNotBe "not-a-uuid"
+        shouldNotThrowAny { UUID.fromString(header) }
+        chain.request.shouldNotBeNull()
+        response.status shouldBe 200
+    }
+
+    @Test
+    fun `should expose the correlation id in the MDC during the chain`() {
+        val response = MockHttpServletResponse()
+        val captor = MdcCapturingChain()
+        filter.doFilter(MockHttpServletRequest(), response, captor)
+        captor.observed shouldBe response.getHeader(HEADER)
+    }
+
+    @Test
+    fun `should clear the MDC after the request completes`() {
+        filter.doFilter(MockHttpServletRequest(), MockHttpServletResponse(), MockFilterChain())
+        MDC.get(MDC_KEY).shouldBeNull()
+    }
+
+    @Test
+    fun `should clear the MDC even when the chain throws`() {
+        val boom = FilterChain { _, _ -> throw IllegalStateException("boom") }
+        shouldThrow<IllegalStateException> {
+            filter.doFilter(MockHttpServletRequest(), MockHttpServletResponse(), boom)
+        }
+        MDC.get(MDC_KEY).shouldBeNull()
+    }
+
+    private fun requestWith(correlationId: String): MockHttpServletRequest =
+        MockHttpServletRequest().apply { addHeader(HEADER, correlationId) }
+
+    private class MdcCapturingChain : FilterChain {
+        var observed: String? = null
+
+        override fun doFilter(
+            request: ServletRequest,
+            response: ServletResponse,
+        ) {
+            observed = MDC.get(MDC_KEY)
+        }
+    }
+}

--- a/services/decision/src/test/kotlin/com/fincore/decision/store/config/CorrelationIdFilterConfigTest.kt
+++ b/services/decision/src/test/kotlin/com/fincore/decision/store/config/CorrelationIdFilterConfigTest.kt
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.decision.store.config
+
+import com.fincore.decision.store.api.observability.CorrelationIdFilter
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+import org.springframework.core.Ordered
+
+class CorrelationIdFilterConfigTest {
+    private val registration = CorrelationIdFilterConfig().correlationIdFilterRegistration()
+
+    @Test
+    fun `should register the filter at highest precedence`() {
+        registration.order shouldBe Ordered.HIGHEST_PRECEDENCE
+    }
+
+    @Test
+    fun `should apply the filter to every path`() {
+        registration.urlPatterns shouldContain "/*"
+    }
+
+    @Test
+    fun `should wrap the correlation id filter`() {
+        registration.filter.shouldBeInstanceOf<CorrelationIdFilter>()
+    }
+}

--- a/services/payments/src/main/kotlin/com/fincore/payments/api/observability/CorrelationIdAttributes.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/api/observability/CorrelationIdAttributes.kt
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.api.observability
+
+object CorrelationIdAttributes {
+    const val HEADER = "X-Correlation-Id"
+    const val MDC_KEY = "correlation_id"
+}

--- a/services/payments/src/main/kotlin/com/fincore/payments/api/observability/CorrelationIdFilter.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/api/observability/CorrelationIdFilter.kt
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.api.observability
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.MDC
+import org.springframework.web.filter.OncePerRequestFilter
+import java.util.UUID
+
+class CorrelationIdFilter : OncePerRequestFilter() {
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val correlationId = resolve(request.getHeader(CorrelationIdAttributes.HEADER))
+        MDC.put(CorrelationIdAttributes.MDC_KEY, correlationId)
+        response.setHeader(CorrelationIdAttributes.HEADER, correlationId)
+        try {
+            filterChain.doFilter(request, response)
+        } finally {
+            MDC.remove(CorrelationIdAttributes.MDC_KEY)
+        }
+    }
+
+    private fun resolve(inbound: String?): String =
+        inbound?.takeUnless { it.isBlank() }?.let(::canonicalUuidOrNull) ?: UUID.randomUUID().toString()
+
+    private fun canonicalUuidOrNull(value: String): String? = runCatching { UUID.fromString(value).toString() }.getOrNull()
+}

--- a/services/payments/src/main/kotlin/com/fincore/payments/config/CorrelationIdFilterConfig.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/config/CorrelationIdFilterConfig.kt
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.config
+
+import com.fincore.payments.api.observability.CorrelationIdFilter
+import org.springframework.boot.web.servlet.FilterRegistrationBean
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.core.Ordered
+
+@Configuration
+class CorrelationIdFilterConfig {
+    @Bean
+    fun correlationIdFilterRegistration(): FilterRegistrationBean<CorrelationIdFilter> =
+        FilterRegistrationBean(CorrelationIdFilter()).apply {
+            order = Ordered.HIGHEST_PRECEDENCE
+            addUrlPatterns("/*")
+        }
+}

--- a/services/payments/src/test/kotlin/com/fincore/payments/api/observability/CorrelationIdFilterTest.kt
+++ b/services/payments/src/test/kotlin/com/fincore/payments/api/observability/CorrelationIdFilterTest.kt
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.api.observability
+
+import com.fincore.payments.api.observability.CorrelationIdAttributes.HEADER
+import com.fincore.payments.api.observability.CorrelationIdAttributes.MDC_KEY
+import io.kotest.assertions.throwables.shouldNotThrowAny
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import jakarta.servlet.FilterChain
+import jakarta.servlet.ServletRequest
+import jakarta.servlet.ServletResponse
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.slf4j.MDC
+import org.springframework.mock.web.MockFilterChain
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import java.util.UUID
+
+class CorrelationIdFilterTest {
+    private val filter = CorrelationIdFilter()
+
+    @AfterEach
+    fun clearMdc() = MDC.clear()
+
+    @Test
+    fun `should echo a valid inbound correlation id on the response`() {
+        val inbound = "123e4567-e89b-12d3-a456-426614174000"
+        val response = MockHttpServletResponse()
+        filter.doFilter(requestWith(inbound), response, MockFilterChain())
+        response.getHeader(HEADER) shouldBe inbound
+    }
+
+    @Test
+    fun `should generate a valid uuid when no inbound id is present`() {
+        val response = MockHttpServletResponse()
+        filter.doFilter(MockHttpServletRequest(), response, MockFilterChain())
+        val header = response.getHeader(HEADER)
+        header.shouldNotBeNull()
+        shouldNotThrowAny { UUID.fromString(header) }
+    }
+
+    @Test
+    fun `should replace an invalid inbound id without rejecting the request`() {
+        val response = MockHttpServletResponse()
+        val chain = MockFilterChain()
+        filter.doFilter(requestWith("not-a-uuid"), response, chain)
+        val header = response.getHeader(HEADER)
+        header shouldNotBe "not-a-uuid"
+        shouldNotThrowAny { UUID.fromString(header) }
+        chain.request.shouldNotBeNull()
+        response.status shouldBe 200
+    }
+
+    @Test
+    fun `should expose the correlation id in the MDC during the chain`() {
+        val response = MockHttpServletResponse()
+        val captor = MdcCapturingChain()
+        filter.doFilter(MockHttpServletRequest(), response, captor)
+        captor.observed shouldBe response.getHeader(HEADER)
+    }
+
+    @Test
+    fun `should clear the MDC after the request completes`() {
+        filter.doFilter(MockHttpServletRequest(), MockHttpServletResponse(), MockFilterChain())
+        MDC.get(MDC_KEY).shouldBeNull()
+    }
+
+    @Test
+    fun `should clear the MDC even when the chain throws`() {
+        val boom = FilterChain { _, _ -> throw IllegalStateException("boom") }
+        shouldThrow<IllegalStateException> {
+            filter.doFilter(MockHttpServletRequest(), MockHttpServletResponse(), boom)
+        }
+        MDC.get(MDC_KEY).shouldBeNull()
+    }
+
+    private fun requestWith(correlationId: String): MockHttpServletRequest =
+        MockHttpServletRequest().apply { addHeader(HEADER, correlationId) }
+
+    private class MdcCapturingChain : FilterChain {
+        var observed: String? = null
+
+        override fun doFilter(
+            request: ServletRequest,
+            response: ServletResponse,
+        ) {
+            observed = MDC.get(MDC_KEY)
+        }
+    }
+}

--- a/services/payments/src/test/kotlin/com/fincore/payments/config/CorrelationIdFilterConfigTest.kt
+++ b/services/payments/src/test/kotlin/com/fincore/payments/config/CorrelationIdFilterConfigTest.kt
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.config
+
+import com.fincore.payments.api.observability.CorrelationIdFilter
+import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+import org.springframework.core.Ordered
+
+class CorrelationIdFilterConfigTest {
+    private val registration = CorrelationIdFilterConfig().correlationIdFilterRegistration()
+
+    @Test
+    fun `should register the filter at highest precedence`() {
+        registration.order shouldBe Ordered.HIGHEST_PRECEDENCE
+    }
+
+    @Test
+    fun `should apply the filter to every path`() {
+        registration.urlPatterns shouldContain "/*"
+    }
+
+    @Test
+    fun `should wrap the correlation id filter`() {
+        registration.filter.shouldBeInstanceOf<CorrelationIdFilter>()
+    }
+}


### PR DESCRIPTION
Brings correlation-id propagation parity to the payments and decision services (E-07, #246).

## What
Ports the ledger correlation-id pattern (from #50) into payments and decision, each in its own package:
- A `CorrelationIdFilter` (OncePerRequestFilter) reads `X-Correlation-Id`, accepts only a canonical UUID (any blank/invalid value is replaced with a generated UUID, never echoed raw), puts it in the MDC, echoes it on the response, and clears the MDC in a `finally` block.
- Registered via a `FilterRegistrationBean` at `HIGHEST_PRECEDENCE` (plain class, not `@Component`, so it is not double-registered) - the id is present even for 401/403 responses.
- Unit tests per service (filter behaviour + registration).

## Why no logging config change
Both services already emit structured JSON via Boot-native `logging.structured.format.console: logstash`, which includes MDC fields, so `MDC.put(correlation_id)` makes the id flow into the logs automatically. No `logback-spring.xml` is added (it would be redundant and risk overriding the working config).

## Gate chain
- critic: GO.
- security-auditor (opus): PASS - log-injection safe (UUID-only normalization blocks newline/control-char injection and header-splitting), no auth bypass, no must-fix.
- code-reviewer: APPROVED.
- evaluator: PASS (0.93 >= 0.80).
- Local gates green for both services: test, detekt, detektTest, spotlessCheck, assemble, compileIntegrationTestKotlin (unit tests pass locally).

Closes #246