### PR TITLE
feat(observability): add domain business metrics for ledger and payments

### DIFF
--- a/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/api/ObservabilityIT.kt
+++ b/services/ledger/src/integrationTest/kotlin/com/fincore/ledger/api/ObservabilityIT.kt
@@ -89,6 +89,16 @@ class ObservabilityIT(
     }
 
     @Test
+    fun `should report the posting timer with a success outcome after a transaction is posted`() {
+        postBalanced()
+
+        val body = rest.getForEntity("/actuator/prometheus", String::class.java).body ?: ""
+
+        body shouldContain "ledger_transactions_posting_seconds_count"
+        body shouldContain "outcome=\"success\""
+    }
+
+    @Test
     fun `should expose a tracer bean and bind the tracing properties`() {
         tracer.shouldNotBeNull()
         environment.getProperty("management.tracing.sampling.probability").shouldNotBeNull()

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/application/LedgerMetrics.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/application/LedgerMetrics.kt
@@ -5,7 +5,9 @@ package com.fincore.ledger.application
 
 import io.micrometer.core.instrument.Counter
 import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.Timer
 import org.springframework.stereotype.Component
+import java.util.concurrent.TimeUnit
 
 @Component
 class LedgerMetrics(
@@ -17,6 +19,10 @@ class LedgerMetrics(
         Counter.builder(METRIC_POSTED).tag(TAG_TYPE, TYPE_REVERSAL).register(registry)
     private val balanceReadsCounter: Counter =
         Counter.builder(METRIC_BALANCE_READS).register(registry)
+    private val postingSuccessTimer: Timer =
+        Timer.builder(METRIC_POSTING).tag(TAG_OUTCOME, OUTCOME_SUCCESS).register(registry)
+    private val postingFailureTimer: Timer =
+        Timer.builder(METRIC_POSTING).tag(TAG_OUTCOME, OUTCOME_FAILURE).register(registry)
 
     fun recordPost() = postedCounter.increment()
 
@@ -24,11 +30,20 @@ class LedgerMetrics(
 
     fun recordBalanceRead() = balanceReadsCounter.increment()
 
+    fun recordPosting(
+        success: Boolean,
+        durationNanos: Long,
+    ) = (if (success) postingSuccessTimer else postingFailureTimer).record(durationNanos, TimeUnit.NANOSECONDS)
+
     private companion object {
         const val METRIC_POSTED = "ledger.transactions.posted"
         const val METRIC_BALANCE_READS = "ledger.balance.reads"
+        const val METRIC_POSTING = "ledger.transactions.posting"
         const val TAG_TYPE = "type"
         const val TYPE_POST = "post"
         const val TYPE_REVERSAL = "reversal"
+        const val TAG_OUTCOME = "outcome"
+        const val OUTCOME_SUCCESS = "success"
+        const val OUTCOME_FAILURE = "failure"
     }
 }

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/application/TransactionPoster.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/application/TransactionPoster.kt
@@ -50,6 +50,18 @@ class TransactionPoster(
 ) {
     @Transactional
     fun post(command: PostTransactionCommand): PostedTransaction {
+        val start = System.nanoTime()
+        var succeeded = false
+        try {
+            val posted = doPost(command)
+            succeeded = true
+            return posted
+        } finally {
+            ledgerMetrics.recordPosting(succeeded, System.nanoTime() - start)
+        }
+    }
+
+    private fun doPost(command: PostTransactionCommand): PostedTransaction {
         val transaction = buildDomain(command)
         guardAccounts(transaction, command.currency)
         if (transactionRepository.existsByReference(command.reference)) {

--- a/services/ledger/src/test/kotlin/com/fincore/ledger/application/LedgerMetricsTest.kt
+++ b/services/ledger/src/test/kotlin/com/fincore/ledger/application/LedgerMetricsTest.kt
@@ -34,4 +34,13 @@ class LedgerMetricsTest {
 
         registry.counter("ledger.balance.reads").count() shouldBe 2.0
     }
+
+    @Test
+    fun `should record the posting timer under the matching outcome tag`() {
+        metrics.recordPosting(success = true, durationNanos = 1_000_000L)
+        metrics.recordPosting(success = false, durationNanos = 2_000_000L)
+
+        registry.timer("ledger.transactions.posting", "outcome", "success").count() shouldBe 1L
+        registry.timer("ledger.transactions.posting", "outcome", "failure").count() shouldBe 1L
+    }
 }

--- a/services/payments/src/integrationTest/kotlin/com/fincore/payments/application/PaymentLifecycleIT.kt
+++ b/services/payments/src/integrationTest/kotlin/com/fincore/payments/application/PaymentLifecycleIT.kt
@@ -34,6 +34,8 @@ import com.fincore.test.containers.PostgresContainerExtension
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.collections.shouldContainAll
 import io.kotest.matchers.shouldBe
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -58,6 +60,7 @@ import javax.crypto.spec.SecretKeySpec
 @ExtendWith(PostgresContainerExtension::class)
 @Import(
     PaymentServiceImpl::class,
+    PaymentMetrics::class,
     PaymentIdempotencyStore::class,
     PaymentPersistenceAdapter::class,
     PaymentOutboxEventPublisherImpl::class,
@@ -243,6 +246,8 @@ class PaymentLifecycleIT(
         fun retryProperties(): PaymentRetryProperties = PaymentRetryProperties(stuckAfter = Duration.ZERO, maxAge = Duration.ofHours(1))
 
         @Bean fun bankProvider(): BankProvider = SandboxBankProvider()
+
+        @Bean fun meterRegistry(): MeterRegistry = SimpleMeterRegistry()
     }
 
     companion object {

--- a/services/payments/src/integrationTest/kotlin/com/fincore/payments/application/PaymentMetricsIT.kt
+++ b/services/payments/src/integrationTest/kotlin/com/fincore/payments/application/PaymentMetricsIT.kt
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.application
+
+import com.fincore.core.Currency
+import com.fincore.core.Money
+import com.fincore.test.containers.PostgresContainerExtension
+import io.kotest.matchers.doubles.shouldBeGreaterThanOrEqual
+import io.micrometer.core.instrument.MeterRegistry
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.actuate.observability.AutoConfigureObservability
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import java.math.BigDecimal
+import java.util.UUID
+
+@SpringBootTest
+@AutoConfigureObservability
+@ExtendWith(PostgresContainerExtension::class)
+@Import(PaymentMetricsIT.TestBeans::class)
+class PaymentMetricsIT(
+    @Autowired private val paymentService: PaymentService,
+    @Autowired private val meterRegistry: MeterRegistry,
+) {
+    @TestConfiguration
+    class TestBeans {
+        @Bean fun jwtDecoder(): JwtDecoder = mockk()
+    }
+
+    @Test
+    fun `should increment the lifecycle counter with the initiated status when a payment is initiated`() {
+        paymentService.initiate(InitiatePaymentCommand(UUID.randomUUID().toString(), money(), "metrics-order"))
+
+        val count =
+            meterRegistry
+                .get("payments.lifecycle")
+                .tag("status", "initiated")
+                .counter()
+                .count()
+
+        count shouldBeGreaterThanOrEqual 1.0
+    }
+
+    private fun money(): Money = Money(BigDecimal("100.00"), Currency.USD)
+
+    companion object {
+        @JvmStatic
+        @DynamicPropertySource
+        fun properties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { PostgresContainerExtension.jdbcUrl }
+            registry.add("spring.datasource.username") { PostgresContainerExtension.username }
+            registry.add("spring.datasource.password") { PostgresContainerExtension.password }
+            registry.add("spring.jpa.hibernate.ddl-auto") { "none" }
+            registry.add("spring.security.oauth2.resourceserver.jwt.issuer-uri") { "https://issuer.test" }
+            registry.add("fincore.payments.bank.sandbox.enabled") { "true" }
+        }
+    }
+}

--- a/services/payments/src/integrationTest/kotlin/com/fincore/payments/application/PaymentServiceIT.kt
+++ b/services/payments/src/integrationTest/kotlin/com/fincore/payments/application/PaymentServiceIT.kt
@@ -17,6 +17,8 @@ import com.fincore.payments.infrastructure.persistence.PaymentPersistenceAdapter
 import com.fincore.payments.infrastructure.persistence.PaymentRepository
 import com.fincore.test.containers.PostgresContainerExtension
 import io.kotest.matchers.shouldBe
+import io.micrometer.core.instrument.MeterRegistry
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -38,6 +40,7 @@ import java.math.BigDecimal
 @ExtendWith(PostgresContainerExtension::class)
 @Import(
     PaymentServiceImpl::class,
+    PaymentMetrics::class,
     PaymentIdempotencyStore::class,
     PaymentPersistenceAdapter::class,
     PaymentOutboxEventPublisherImpl::class,
@@ -96,6 +99,8 @@ class PaymentServiceIT(
     class ObjectMapperConfig {
         @Bean
         fun objectMapper(): ObjectMapper = ObjectMapper().findAndRegisterModules()
+
+        @Bean fun meterRegistry(): MeterRegistry = SimpleMeterRegistry()
     }
 
     companion object {

--- a/services/payments/src/main/kotlin/com/fincore/payments/application/PaymentMetrics.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/application/PaymentMetrics.kt
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.application
+
+import com.fincore.payments.domain.enum.PaymentStatus
+import io.micrometer.core.instrument.MeterRegistry
+import org.springframework.stereotype.Component
+
+@Component
+class PaymentMetrics(
+    private val registry: MeterRegistry,
+) {
+    fun record(status: PaymentStatus) = registry.counter(METRIC, TAG_STATUS, status.name.lowercase()).increment()
+
+    private companion object {
+        const val METRIC = "payments.lifecycle"
+        const val TAG_STATUS = "status"
+    }
+}

--- a/services/payments/src/main/kotlin/com/fincore/payments/application/PaymentServiceImpl.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/application/PaymentServiceImpl.kt
@@ -29,6 +29,7 @@ class PaymentServiceImpl(
     private val adapter: PaymentPersistenceAdapter,
     private val outboxPublisher: PaymentOutboxEventPublisher,
     private val objectMapper: ObjectMapper,
+    private val metrics: PaymentMetrics,
 ) : PaymentService {
     override fun initiate(command: InitiatePaymentCommand): Payment {
         val keyHash = Sha256.hex(command.idempotencyKey)
@@ -57,6 +58,7 @@ class PaymentServiceImpl(
         payment.transitionTo(PaymentStatus.SCREENING)
         entity.status = payment.status
         paymentRepository.saveAndFlush(entity)
+        metrics.record(PaymentStatus.SCREENING)
         return payment
     }
 
@@ -72,6 +74,7 @@ class PaymentServiceImpl(
         entity.providerReference = providerReference
         paymentRepository.saveAndFlush(entity)
         recordEvent(payment, PaymentEvents.PaymentScreened)
+        metrics.record(PaymentStatus.SUBMITTED)
         return payment
     }
 
@@ -96,6 +99,7 @@ class PaymentServiceImpl(
         entity.status = payment.status
         paymentRepository.saveAndFlush(entity)
         recordEvent(payment, type, detail)
+        metrics.record(target)
         return payment
     }
 
@@ -103,6 +107,7 @@ class PaymentServiceImpl(
         val payment = Payment(PaymentId.generate(), command.amount, command.reference)
         paymentRepository.saveAndFlush(adapter.toNewEntity(payment, Instant.now()))
         recordEvent(payment, PaymentEvents.PaymentInitiated)
+        metrics.record(PaymentStatus.INITIATED)
         return payment
     }
 

--- a/services/payments/src/test/kotlin/com/fincore/payments/application/PaymentServiceImplTest.kt
+++ b/services/payments/src/test/kotlin/com/fincore/payments/application/PaymentServiceImplTest.kt
@@ -35,6 +35,7 @@ class PaymentServiceImplTest {
     private val paymentEventRepository = mockk<PaymentEventRepository>(relaxed = true)
     private val outboxPublisher = mockk<PaymentOutboxEventPublisher>(relaxed = true)
     private val objectMapper = mockk<ObjectMapper> { every { writeValueAsString(any()) } returns "{}" }
+    private val metrics = mockk<PaymentMetrics>(relaxed = true)
     private val service =
         PaymentServiceImpl(
             idempotencyStore,
@@ -43,6 +44,7 @@ class PaymentServiceImplTest {
             PaymentPersistenceAdapter(),
             outboxPublisher,
             objectMapper,
+            metrics,
         )
 
     init {


### PR DESCRIPTION
Adds custom Micrometer business metrics beyond the default http/jvm meters (E-07, #248).

## What
- **Ledger**: a posting timer `ledger.transactions.posting` tagged by `outcome` (success/failure), recorded around the post path (the existing `ledger.transactions.posted` counter is left intact). `post()` is a thin timing wrapper around an extracted `doPost()`.
- **Payments**: a new `PaymentMetrics` lifecycle counter `payments.lifecycle` tagged by `status`, incremented at each `PaymentServiceImpl` transition (initiated/screening/submitted/settled/failed/cancelled).
- Micrometer idioms: no `_total` hand-suffix (the registry adds it), no pinned versions (Boot BOM). Tags are bounded enum values only - no amounts, references, or PII.

## Tests
- `LedgerMetricsTest` extended for the timer's success and failure outcomes.
- ledger `ObservabilityIT` asserts `ledger_transactions_posting_seconds_count{outcome="success"}` on /actuator/prometheus.
- new payments `PaymentMetricsIT` initiates a payment and asserts the lifecycle counter via the injected `MeterRegistry` (payments /actuator/prometheus is not yet permitAll - that is #249).

## Gate chain
- critic: GO-WITH-CHANGES (3 fixes applied: IT style, detekt/constants, record-by-target-status).
- security-auditor (opus): PASS - tags are bounded enums, no PII/amounts, timing wrapper does not swallow exceptions.
- code-reviewer: its findings were adjudicated and rejected - two HIGHs were wrong-base-diff false positives about #247's already-merged PiiMasker (git-verified absent from this changeset), and the metric-before-commit notes match the pre-existing accepted `recordPost()` pattern (observability, not ledger records).
- evaluator: PASS (0.895 >= 0.80).
- Local gates green for both services.

Closes #248