### PR TITLE
feat(observability): add an opt-in docker-compose observability profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,19 @@ docker compose -f deploy/docker-compose.yml up -d
 
 Full guide: [Getting Started](https://github.com/tiana-code/fincore-engine/wiki/Getting-Started)
 
+### Observability profile (optional)
+
+The telemetry backends are an opt-in Compose profile, so the default stack stays lean:
+
+```bash
+docker compose --profile observability up -d
+```
+
+This adds Prometheus (`:9090`, scrapes the services' `/actuator/prometheus`), Grafana (`:3000`, anonymous access
+enabled, datasources pre-provisioned), Tempo (receives OTLP traces via the OpenTelemetry collector) and Loki. The
+services export traces to the collector automatically when the profile is up. Loki is provisioned as a datasource;
+shipping the services' JSON logs into it (a log shipper) is a follow-up - until then use `docker compose logs`.
+
 ---
 
 ## Repository layout

--- a/deploy/observability/grafana/provisioning/datasources/datasources.yaml
+++ b/deploy/observability/grafana/provisioning/datasources/datasources.yaml
@@ -1,0 +1,16 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+  - name: Tempo
+    type: tempo
+    access: proxy
+    url: http://tempo:3200
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100

--- a/deploy/observability/loki-config.yaml
+++ b/deploy/observability/loki-config.yaml
@@ -1,0 +1,26 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  instance_addr: 127.0.0.1
+  path_prefix: /tmp/loki
+  storage:
+    filesystem:
+      chunks_directory: /tmp/loki/chunks
+      rules_directory: /tmp/loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h

--- a/deploy/observability/otel-collector-config.yaml
+++ b/deploy/observability/otel-collector-config.yaml
@@ -1,0 +1,21 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+exporters:
+  otlp/tempo:
+    endpoint: tempo:4317
+    tls:
+      insecure: true
+  debug:
+    verbosity: basic
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [otlp/tempo, debug]

--- a/deploy/observability/prometheus.yml
+++ b/deploy/observability/prometheus.yml
@@ -1,0 +1,14 @@
+# Prometheus scrape config for the local observability profile.
+# Targets use the compose service name and the CONTAINER port 8080 (not the host-published 8081).
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: ledger
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ["ledger:8080"]
+  - job_name: payments
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets: ["payments:8080"]

--- a/deploy/observability/tempo.yaml
+++ b/deploy/observability/tempo.yaml
@@ -1,0 +1,19 @@
+server:
+  http_listen_port: 3200
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4319
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /var/tempo/traces
+    wal:
+      path: /var/tempo/wal

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,6 +27,7 @@ services:
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD:-ledger}
       KEYCLOAK_ISSUER_URI: http://localhost/realms/fincore
       SPRING_LIQUIBASE_CONTEXTS: production,demo
+      OTLP_TRACING_ENDPOINT: http://otel-collector:4318/v1/traces
 
   payments:
     build:
@@ -44,3 +45,55 @@ services:
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD:-ledger}
       KEYCLOAK_ISSUER_URI: http://localhost/realms/fincore
       FINCORE_PAYMENTS_BANK_SANDBOX_ENABLED: "true"
+      OTLP_TRACING_ENDPOINT: http://otel-collector:4318/v1/traces
+
+  # Opt-in telemetry backends. Started only with `docker compose --profile observability up`;
+  # the default stack (and the CI compose smoke) never starts these.
+  otel-collector:
+    image: otel/opentelemetry-collector-contrib:0.114.0
+    profiles: [observability]
+    command: ["--config=/etc/otel-collector-config.yaml"]
+    volumes:
+      - ./deploy/observability/otel-collector-config.yaml:/etc/otel-collector-config.yaml:ro
+    ports:
+      - "4318:4318"
+
+  tempo:
+    image: grafana/tempo:2.6.1
+    profiles: [observability]
+    command: ["-config.file=/etc/tempo.yaml"]
+    volumes:
+      - ./deploy/observability/tempo.yaml:/etc/tempo.yaml:ro
+      - tempo-data:/var/tempo
+
+  loki:
+    image: grafana/loki:3.2.1
+    profiles: [observability]
+    command: ["-config.file=/etc/loki/loki-config.yaml"]
+    volumes:
+      - ./deploy/observability/loki-config.yaml:/etc/loki/loki-config.yaml:ro
+      - loki-data:/tmp/loki
+
+  prometheus:
+    image: prom/prometheus:v2.55.1
+    profiles: [observability]
+    volumes:
+      - ./deploy/observability/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+    ports:
+      - "9090:9090"
+
+  grafana:
+    image: grafana/grafana:11.4.0
+    profiles: [observability]
+    environment:
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-admin}
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: "Viewer"
+    volumes:
+      - ./deploy/observability/grafana/provisioning:/etc/grafana/provisioning:ro
+    ports:
+      - "3000:3000"
+
+volumes:
+  tempo-data:
+  loki-data:

--- a/services/payments/src/main/kotlin/com/fincore/payments/config/SecurityConfig.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/config/SecurityConfig.kt
@@ -54,6 +54,7 @@ class SecurityConfig {
                 "/swagger-ui.html",
                 "/actuator/health",
                 "/actuator/health/**",
+                "/actuator/prometheus",
             )
     }
 }


### PR DESCRIPTION
Adds a local telemetry stack as an opt-in Compose profile (E-07, #250).

## What
- New `observability` profile services (all `profiles: [observability]`, pinned image tags): Prometheus, Grafana, Tempo, Loki, an OpenTelemetry collector. Plain `docker compose up` (and the CI compose smoke) never starts them.
- Prometheus scrapes ledger and payments on their **container** port (`ledger:8080`, `payments:8080`) at `/actuator/prometheus`.
- ledger and payments export OTLP traces to the collector, which forwards them to Tempo.
- Grafana is pre-provisioned (Prometheus default + Tempo + Loki datasources), anonymous Viewer access, admin password via env-default.
- Config files under `deploy/observability/`; named volumes for Loki/Tempo.
- Payments `/actuator/prometheus` is now permitAll (pulled forward so it is scrapable; matches ledger/decision). `/v1/payments/**` stays scope-protected.
- README documents the profile and the Loki log-shipping follow-up.

## Why the default smoke stays green
The backends are profile-gated, so `docker compose up --wait` (no profile) ignores them. The OTLP endpoint env on the core services targets the collector, but the Boot OTLP exporter is lazy and export failures are non-fatal - the services already defaulted that endpoint to an absent host and prior compose-smoke runs were green, so readiness is unaffected.

## Gate chain
- critic: GO (2 notes applied: no depends_on to profiled services, pinned tags).
- security-auditor (opus): PASS - only credential is the env-default Grafana password; payments metrics permit matches convention; profile off by default; §5.3 clean.
- code-reviewer: its OTLP must-fix was a pre-existing/tolerated condition (rejected with evidence; auditor concurred); its two advisories (named volumes, explicit anon Viewer role) were adopted.
- evaluator: PASS (0.885 >= 0.80).
- payments gradle gates green; Docker unavailable locally so the binding check is the CI Compose smoke staying green.

Closes #250