### PR TITLE
feat(observability): add prometheus operator servicemonitor to the helm charts

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -55,3 +55,10 @@ jobs:
         run: |
           helm template ${{ matrix.chart }} deploy/helm/${{ matrix.chart }} --set image.tag=test \
             | kubeconform -strict -summary -kubernetes-version "$KUBERNETES_VERSION"
+
+      - name: Validate the ServiceMonitor renders (operator CRD skipped)
+        run: |
+          rendered=$(helm template ${{ matrix.chart }} deploy/helm/${{ matrix.chart }} \
+            --set image.tag=test --set serviceMonitor.enabled=true)
+          echo "$rendered" | grep -q 'kind: ServiceMonitor'
+          echo "$rendered" | kubeconform -strict -summary -skip ServiceMonitor -kubernetes-version "$KUBERNETES_VERSION"

--- a/deploy/helm/ledger/templates/servicemonitor.yaml
+++ b/deploy/helm/ledger/templates/servicemonitor.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "ledger.fullname" . }}
+  labels:
+    {{- include "ledger.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "ledger.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: {{ .Values.serviceMonitor.path }}
+      interval: {{ .Values.serviceMonitor.interval }}
+{{- end }}

--- a/deploy/helm/ledger/values.yaml
+++ b/deploy/helm/ledger/values.yaml
@@ -19,6 +19,12 @@ service:
   type: ClusterIP
   port: 8080
 
+# Prometheus Operator ServiceMonitor. Off by default; enable on a cluster running the operator.
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  path: /actuator/prometheus
+
 resources:
   requests:
     cpu: 250m

--- a/deploy/helm/payments/templates/servicemonitor.yaml
+++ b/deploy/helm/payments/templates/servicemonitor.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "payments.fullname" . }}
+  labels:
+    {{- include "payments.labels" . | nindent 4 }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "payments.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: http
+      path: {{ .Values.serviceMonitor.path }}
+      interval: {{ .Values.serviceMonitor.interval }}
+{{- end }}

--- a/deploy/helm/payments/values.yaml
+++ b/deploy/helm/payments/values.yaml
@@ -19,6 +19,12 @@ service:
   type: ClusterIP
   port: 8080
 
+# Prometheus Operator ServiceMonitor. Off by default; enable on a cluster running the operator.
+serviceMonitor:
+  enabled: false
+  interval: 30s
+  path: /actuator/prometheus
+
 resources:
   requests:
     cpu: 250m


### PR DESCRIPTION
Adds a Prometheus Operator ServiceMonitor to the ledger and payments Helm charts (E-07, #249).

## What
- New `templates/servicemonitor.yaml` in both charts, gated behind `serviceMonitor.enabled` (default `false` in values.yaml). When enabled it selects the service via `matchLabels = <chart>.selectorLabels` and scrapes the named `http` port at `/actuator/prometheus` on a configurable interval.
- The payments `/actuator/prometheus` permit was already added in #250, so this slice is templates only.

## CI safety
- The default `helm template` render (no flag) emits no ServiceMonitor, so the existing `kubeconform -strict` step is unchanged and green (it never needs the operator CRD schema).
- A new step renders with `--set serviceMonitor.enabled=true`, asserts `kind: ServiceMonitor` is present (non-vacuous), and runs `kubeconform -strict -skip ServiceMonitor` - catching template errors and validating the rest without a network CRD-schema fetch.

## Gate chain
- critic: GO-WITH-CHANGES (the flag-on render assertion was added; matchLabels-subset confirmed).
- security-auditor (opus): PASS - no secrets, no Actions injection (only `matrix.chart` interpolated), off-by-default, §5.3 clean.
- code-reviewer: its lone must-fix (add `namespaceSelector`) was rejected with evidence - the chart co-locates the ServiceMonitor and the Service in the release namespace, so an omitted selector already discovers it; `matchNames: [release-namespace]` is functionally identical to the default, and exemplary charts default to empty.
- evaluator: PASS (0.89 >= 0.80).
- helm/kubeconform unavailable locally; the binding check is the CI helm-test job.

Closes #249