### PR TITLE
feat(observability): provision grafana dashboards as code

### DIFF
--- a/deploy/observability/grafana/dashboards/ledger-throughput.json
+++ b/deploy/observability/grafana/dashboards/ledger-throughput.json
@@ -1,0 +1,44 @@
+{
+  "uid": "fincore-ledger-throughput",
+  "title": "FinCore Ledger Throughput",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": false,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "timezone": "browser",
+  "tags": ["fincore", "observability", "ledger"],
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Transactions posted (per second, by type)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(ledger_transactions_posted_total[5m])) by (type)",
+          "legendFormat": "{{type}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Average posting latency (s, by outcome)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(ledger_transactions_posting_seconds_sum[5m])) by (outcome) / sum(rate(ledger_transactions_posting_seconds_count[5m])) by (outcome)",
+          "legendFormat": "{{outcome}}",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/deploy/observability/grafana/dashboards/payments-lifecycle.json
+++ b/deploy/observability/grafana/dashboards/payments-lifecycle.json
@@ -1,0 +1,43 @@
+{
+  "uid": "fincore-payments-lifecycle",
+  "title": "FinCore Payments Lifecycle",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": false,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "timezone": "browser",
+  "tags": ["fincore", "observability", "payments"],
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Lifecycle transitions (per second, by status)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(payments_lifecycle_total[5m])) by (status)",
+          "legendFormat": "{{status}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "stat",
+      "title": "Settled payments (cumulative since start)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 6, "w": 24, "x": 0, "y": 8 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(payments_lifecycle_total{status=\"settled\"})",
+          "legendFormat": "settled",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/deploy/observability/grafana/dashboards/service-health.json
+++ b/deploy/observability/grafana/dashboards/service-health.json
@@ -1,0 +1,59 @@
+{
+  "uid": "fincore-service-health",
+  "title": "FinCore Service Health (RED)",
+  "schemaVersion": 39,
+  "version": 1,
+  "editable": false,
+  "refresh": "30s",
+  "time": { "from": "now-1h", "to": "now" },
+  "timezone": "browser",
+  "tags": ["fincore", "observability"],
+  "panels": [
+    {
+      "id": 1,
+      "type": "timeseries",
+      "title": "Request rate (req/s)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(http_server_requests_seconds_count[5m])) by (job)",
+          "legendFormat": "{{job}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "type": "timeseries",
+      "title": "Server error rate (5xx req/s)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "sum(rate(http_server_requests_seconds_count{outcome=\"SERVER_ERROR\"}[5m])) by (job)",
+          "legendFormat": "{{job}}",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "type": "timeseries",
+      "title": "Request latency p95 (s)",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 8 },
+      "fieldConfig": { "defaults": { "unit": "s" }, "overrides": [] },
+      "targets": [
+        {
+          "datasource": { "type": "prometheus", "uid": "prometheus" },
+          "expr": "histogram_quantile(0.95, sum(rate(http_server_requests_seconds_bucket[5m])) by (le, job))",
+          "legendFormat": "{{job}}",
+          "refId": "A"
+        }
+      ]
+    }
+  ]
+}

--- a/deploy/observability/grafana/provisioning/dashboards/dashboards.yaml
+++ b/deploy/observability/grafana/provisioning/dashboards/dashboards.yaml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+providers:
+  - name: fincore
+    type: file
+    disableDeletion: true
+    allowUiUpdates: false
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/deploy/observability/grafana/provisioning/datasources/datasources.yaml
+++ b/deploy/observability/grafana/provisioning/datasources/datasources.yaml
@@ -3,6 +3,7 @@ apiVersion: 1
 datasources:
   - name: Prometheus
     type: prometheus
+    uid: prometheus
     access: proxy
     url: http://prometheus:9090
     isDefault: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -91,6 +91,7 @@ services:
       GF_AUTH_ANONYMOUS_ORG_ROLE: "Viewer"
     volumes:
       - ./deploy/observability/grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./deploy/observability/grafana/dashboards:/var/lib/grafana/dashboards:ro
     ports:
       - "3000:3000"
 


### PR DESCRIPTION
Provisions three Grafana dashboards as checked-in JSON, loaded by the observability compose profile (E-07, #251).

## What
- Dashboards: **Service Health** (RED - request rate, 5xx rate, p95 latency over http_server_requests), **Ledger Throughput** (posted counter by type + average posting latency), **Payments Lifecycle** (transitions by status + cumulative settled).
- A file-provisioning provider loads them from a mounted dir; the grafana compose service gets a read-only mount of the dashboards dir.
- The Prometheus datasource gets a fixed `uid: prometheus` so panels bind deterministically (no `${DS_PROMETHEUS}` prompt).
- Dashboards are `editable: false` + `allowUiUpdates: false` + `disableDeletion: true` - the repo is the source of truth.

## Correctness
- All panels reference real emitted metrics (verified against #245/#248). HTTP p95 uses `histogram_quantile` over `http_server_requests_seconds_bucket` (buckets enabled for http); the ledger posting timer has no buckets, so its panel uses `rate(_sum)/rate(_count)` for average latency.
- All 3 JSON validated locally.

## Gate chain
- critic: GO-WITH-CHANGES (impl-discipline confirms applied).
- security-auditor (opus): PASS - no secrets, §5.3 clean, datasource by uid, read-only profile-gated mounts.
- code-reviewer: 2 must-fix adopted (disableDeletion true; clarified the cumulative-counter stat title); plus editable:false for GitOps consistency.
- evaluator: PASS (0.84 >= 0.80).
- grafana is profile-gated so the default stack / CI compose-smoke is unaffected.

Closes #251