### PR TITLE
feat(compliance): bootstrap the compliance module and domain

### DIFF
--- a/libs/fincore-core/src/main/kotlin/com/fincore/core/AmlAlertId.kt
+++ b/libs/fincore-core/src/main/kotlin/com/fincore/core/AmlAlertId.kt
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.core
+
+import java.util.UUID
+
+@JvmInline
+value class AmlAlertId(
+    val value: UUID,
+) {
+    override fun toString(): String = PrefixedUlid.format(PREFIX, value)
+
+    companion object {
+        private const val PREFIX = "alert_"
+
+        fun generate(): AmlAlertId = AmlAlertId(PrefixedUlid.generate())
+
+        fun fromString(raw: String): AmlAlertId = AmlAlertId(PrefixedUlid.parse(PREFIX, raw))
+    }
+}

--- a/libs/fincore-core/src/main/kotlin/com/fincore/core/AmlRuleId.kt
+++ b/libs/fincore-core/src/main/kotlin/com/fincore/core/AmlRuleId.kt
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.core
+
+import java.util.UUID
+
+@JvmInline
+value class AmlRuleId(
+    val value: UUID,
+) {
+    override fun toString(): String = PrefixedUlid.format(PREFIX, value)
+
+    companion object {
+        private const val PREFIX = "rule_"
+
+        fun generate(): AmlRuleId = AmlRuleId(PrefixedUlid.generate())
+
+        fun fromString(raw: String): AmlRuleId = AmlRuleId(PrefixedUlid.parse(PREFIX, raw))
+    }
+}

--- a/libs/fincore-core/src/main/kotlin/com/fincore/core/ComplianceCaseId.kt
+++ b/libs/fincore-core/src/main/kotlin/com/fincore/core/ComplianceCaseId.kt
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.core
+
+import java.util.UUID
+
+@JvmInline
+value class ComplianceCaseId(
+    val value: UUID,
+) {
+    override fun toString(): String = PrefixedUlid.format(PREFIX, value)
+
+    companion object {
+        private const val PREFIX = "case_"
+
+        fun generate(): ComplianceCaseId = ComplianceCaseId(PrefixedUlid.generate())
+
+        fun fromString(raw: String): ComplianceCaseId = ComplianceCaseId(PrefixedUlid.parse(PREFIX, raw))
+    }
+}

--- a/libs/fincore-core/src/main/kotlin/com/fincore/core/KycSessionId.kt
+++ b/libs/fincore-core/src/main/kotlin/com/fincore/core/KycSessionId.kt
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.core
+
+import java.util.UUID
+
+@JvmInline
+value class KycSessionId(
+    val value: UUID,
+) {
+    override fun toString(): String = PrefixedUlid.format(PREFIX, value)
+
+    companion object {
+        private const val PREFIX = "kyc_"
+
+        fun generate(): KycSessionId = KycSessionId(PrefixedUlid.generate())
+
+        fun fromString(raw: String): KycSessionId = KycSessionId(PrefixedUlid.parse(PREFIX, raw))
+    }
+}

--- a/libs/fincore-core/src/test/kotlin/com/fincore/core/ComplianceIdsTest.kt
+++ b/libs/fincore-core/src/test/kotlin/com/fincore/core/ComplianceIdsTest.kt
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.core
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldStartWith
+import org.junit.jupiter.api.Test
+
+class ComplianceIdsTest {
+    @Test
+    fun `should round-trip a kyc session id through its prefixed string`() {
+        val id = KycSessionId.generate()
+
+        id.toString() shouldStartWith "kyc_"
+        KycSessionId.fromString(id.toString()) shouldBe id
+    }
+
+    @Test
+    fun `should round-trip an aml alert id through its prefixed string`() {
+        val id = AmlAlertId.generate()
+
+        id.toString() shouldStartWith "alert_"
+        AmlAlertId.fromString(id.toString()) shouldBe id
+    }
+
+    @Test
+    fun `should round-trip a compliance case id through its prefixed string`() {
+        val id = ComplianceCaseId.generate()
+
+        id.toString() shouldStartWith "case_"
+        ComplianceCaseId.fromString(id.toString()) shouldBe id
+    }
+
+    @Test
+    fun `should round-trip an aml rule id through its prefixed string`() {
+        val id = AmlRuleId.generate()
+
+        id.toString() shouldStartWith "rule_"
+        AmlRuleId.fromString(id.toString()) shouldBe id
+    }
+
+    @Test
+    fun `should reject a kyc session id with the wrong prefix`() {
+        shouldThrow<IllegalArgumentException> { KycSessionId.fromString(AmlAlertId.generate().toString()) }
+    }
+
+    @Test
+    fun `should reject an aml alert id with the wrong prefix`() {
+        shouldThrow<IllegalArgumentException> { AmlAlertId.fromString(KycSessionId.generate().toString()) }
+    }
+
+    @Test
+    fun `should reject a compliance case id with the wrong prefix`() {
+        shouldThrow<IllegalArgumentException> { ComplianceCaseId.fromString(AmlRuleId.generate().toString()) }
+    }
+
+    @Test
+    fun `should reject an aml rule id with the wrong prefix`() {
+        shouldThrow<IllegalArgumentException> { AmlRuleId.fromString(ComplianceCaseId.generate().toString()) }
+    }
+}

--- a/services/compliance/build.gradle.kts
+++ b/services/compliance/build.gradle.kts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+}
+
+description = "FinCore Compliance service: KYC, AML and case-management domain"
+
+kotlin {
+    jvmToolchain(21)
+}
+
+dependencies {
+    implementation(project(":libs:fincore-core"))
+    implementation(libs.kotlin.stdlib)
+
+    testImplementation(libs.kotest.assertions.core)
+    testImplementation(libs.kotest.runner.junit5)
+    testImplementation(libs.mockk)
+}
+
+tasks.test {
+    useJUnitPlatform()
+}
+
+tasks.named<JacocoCoverageVerification>("jacocoTestCoverageVerification") {
+    dependsOn(tasks.test)
+    classDirectories.setFrom(
+        files(
+            classDirectories.files.map { dir ->
+                fileTree(dir) { include("**/com/fincore/compliance/domain/**") }
+            },
+        ),
+    )
+    violationRules {
+        rule {
+            limit {
+                counter = "LINE"
+                value = "COVEREDRATIO"
+                minimum = "0.90".toBigDecimal()
+            }
+            limit {
+                counter = "BRANCH"
+                value = "COVEREDRATIO"
+                minimum = "0.90".toBigDecimal()
+            }
+        }
+    }
+}
+
+tasks.named("check") {
+    dependsOn(tasks.named("jacocoTestCoverageVerification"))
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/domain/AmlAlert.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/domain/AmlAlert.kt
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.domain
+
+import com.fincore.compliance.domain.enum.AmlAlertStatus
+import com.fincore.core.AmlAlertId
+
+class AmlAlert(
+    val id: AmlAlertId,
+    ruleKey: String,
+    status: AmlAlertStatus = AmlAlertStatus.OPEN,
+) {
+    val ruleKey: String = RuleKey.validate(ruleKey, "AML alert ruleKey")
+
+    var status: AmlAlertStatus = status
+        private set
+
+    fun transitionTo(target: AmlAlertStatus) {
+        if (!status.canTransitionTo(target)) {
+            throw ComplianceDomainException("Illegal AML alert status transition: $status -> $target for alert $id")
+        }
+        status = target
+    }
+
+    fun isTerminal(): Boolean = status.isTerminal()
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/domain/AmlRule.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/domain/AmlRule.kt
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.domain
+
+import com.fincore.core.AmlRuleId
+
+class AmlRule(
+    val id: AmlRuleId,
+    ruleKey: String,
+    val enabled: Boolean = true,
+) {
+    val ruleKey: String = RuleKey.validate(ruleKey, "AML ruleKey")
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/domain/ComplianceCase.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/domain/ComplianceCase.kt
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.domain
+
+import com.fincore.compliance.domain.enum.CaseStatus
+import com.fincore.core.ComplianceCaseId
+
+class ComplianceCase(
+    val id: ComplianceCaseId,
+    reference: String,
+    status: CaseStatus = CaseStatus.OPEN,
+) {
+    val reference: String = validatedReference(reference)
+
+    var status: CaseStatus = status
+        private set
+
+    fun transitionTo(target: CaseStatus) {
+        if (!status.canTransitionTo(target)) {
+            throw ComplianceDomainException("Illegal case status transition: $status -> $target for case $id")
+        }
+        status = target
+    }
+
+    fun isTerminal(): Boolean = status.isTerminal()
+
+    private fun validatedReference(value: String): String {
+        if (value.isBlank() || value.length > MAX_REFERENCE_LENGTH) {
+            throw ComplianceDomainException(
+                "Case reference must be non-blank and at most $MAX_REFERENCE_LENGTH characters",
+            )
+        }
+        return value
+    }
+
+    private companion object {
+        const val MAX_REFERENCE_LENGTH = 140
+    }
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/domain/ComplianceDomainException.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/domain/ComplianceDomainException.kt
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.domain
+
+class ComplianceDomainException(
+    message: String,
+) : RuntimeException(message)

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/domain/KycSession.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/domain/KycSession.kt
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.domain
+
+import com.fincore.compliance.domain.enum.KycStatus
+import com.fincore.core.KycSessionId
+
+class KycSession(
+    val id: KycSessionId,
+    subjectReference: String,
+    status: KycStatus = KycStatus.INITIATED,
+) {
+    val subjectReference: String = validatedSubjectReference(subjectReference)
+
+    var status: KycStatus = status
+        private set
+
+    fun transitionTo(target: KycStatus) {
+        if (!status.canTransitionTo(target)) {
+            throw ComplianceDomainException("Illegal KYC status transition: $status -> $target for session $id")
+        }
+        status = target
+    }
+
+    fun isTerminal(): Boolean = status.isTerminal()
+
+    private fun validatedSubjectReference(value: String): String {
+        if (value.isBlank() || value.length > MAX_SUBJECT_REFERENCE_LENGTH) {
+            throw ComplianceDomainException(
+                "KYC subjectReference must be non-blank and at most $MAX_SUBJECT_REFERENCE_LENGTH characters",
+            )
+        }
+        return value
+    }
+
+    private companion object {
+        const val MAX_SUBJECT_REFERENCE_LENGTH = 140
+    }
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/domain/RuleKey.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/domain/RuleKey.kt
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.domain
+
+internal object RuleKey {
+    private val PATTERN = Regex("^[A-Za-z0-9_.:-]{1,128}$")
+    private const val DESCRIPTION = "1-128 characters from [A-Za-z0-9_.:-]"
+
+    fun validate(
+        value: String,
+        field: String,
+    ): String {
+        if (!PATTERN.matches(value)) {
+            throw ComplianceDomainException("$field must be $DESCRIPTION")
+        }
+        return value
+    }
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/domain/enum/AmlAlertStatus.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/domain/enum/AmlAlertStatus.kt
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.domain.enum
+
+enum class AmlAlertStatus {
+    OPEN,
+    RESOLVED,
+    DISMISSED,
+    ;
+
+    fun isTerminal(): Boolean = this == RESOLVED || this == DISMISSED
+
+    fun canTransitionTo(target: AmlAlertStatus): Boolean =
+        when (this) {
+            OPEN -> target == RESOLVED || target == DISMISSED
+            RESOLVED, DISMISSED -> false
+        }
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/domain/enum/CaseStatus.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/domain/enum/CaseStatus.kt
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.domain.enum
+
+enum class CaseStatus {
+    OPEN,
+    CLAIMED,
+    ESCALATED,
+    RESOLVED,
+    ;
+
+    fun isTerminal(): Boolean = this == RESOLVED
+
+    fun canTransitionTo(target: CaseStatus): Boolean =
+        when (this) {
+            OPEN -> target == CLAIMED
+            CLAIMED -> target == RESOLVED || target == ESCALATED
+            ESCALATED -> target == RESOLVED
+            RESOLVED -> false
+        }
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/domain/enum/KycStatus.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/domain/enum/KycStatus.kt
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.domain.enum
+
+enum class KycStatus {
+    INITIATED,
+    SCREENING,
+    APPROVED,
+    REJECTED,
+    ;
+
+    fun isTerminal(): Boolean = this == APPROVED || this == REJECTED
+
+    fun canTransitionTo(target: KycStatus): Boolean =
+        when (this) {
+            INITIATED -> target == SCREENING
+            SCREENING -> target == APPROVED || target == REJECTED
+            APPROVED, REJECTED -> false
+        }
+}

--- a/services/compliance/src/test/kotlin/com/fincore/compliance/domain/AmlAlertTest.kt
+++ b/services/compliance/src/test/kotlin/com/fincore/compliance/domain/AmlAlertTest.kt
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.domain
+
+import com.fincore.compliance.domain.enum.AmlAlertStatus
+import com.fincore.core.AmlAlertId
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class AmlAlertTest {
+    @Test
+    fun `should start open when created`() {
+        alert().status shouldBe AmlAlertStatus.OPEN
+    }
+
+    @Test
+    fun `should resolve when transitioned from open`() {
+        val a = alert()
+        a.transitionTo(AmlAlertStatus.RESOLVED)
+        a.status shouldBe AmlAlertStatus.RESOLVED
+        a.isTerminal() shouldBe true
+    }
+
+    @Test
+    fun `should dismiss when transitioned from open`() {
+        val a = alert()
+        a.transitionTo(AmlAlertStatus.DISMISSED)
+        a.status shouldBe AmlAlertStatus.DISMISSED
+    }
+
+    @Test
+    fun `should reject reopening a resolved alert`() {
+        val a = alert()
+        a.transitionTo(AmlAlertStatus.RESOLVED)
+        shouldThrow<ComplianceDomainException> { a.transitionTo(AmlAlertStatus.OPEN) }
+    }
+
+    @Test
+    fun `should reject a rule key with illegal characters`() {
+        shouldThrow<ComplianceDomainException> { AmlAlert(AmlAlertId.generate(), "bad key!") }
+    }
+
+    private fun alert(): AmlAlert = AmlAlert(AmlAlertId.generate(), "aml.velocity.daily")
+}

--- a/services/compliance/src/test/kotlin/com/fincore/compliance/domain/AmlRuleTest.kt
+++ b/services/compliance/src/test/kotlin/com/fincore/compliance/domain/AmlRuleTest.kt
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.domain
+
+import com.fincore.core.AmlRuleId
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class AmlRuleTest {
+    @Test
+    fun `should keep its rule key and default to enabled`() {
+        val rule = AmlRule(AmlRuleId.generate(), "aml.structuring")
+        rule.ruleKey shouldBe "aml.structuring"
+        rule.enabled shouldBe true
+    }
+
+    @Test
+    fun `should be disabled when created disabled`() {
+        AmlRule(AmlRuleId.generate(), "aml.structuring", enabled = false).enabled shouldBe false
+    }
+
+    @Test
+    fun `should reject a blank rule key`() {
+        shouldThrow<ComplianceDomainException> { AmlRule(AmlRuleId.generate(), "") }
+    }
+
+    @Test
+    fun `should reject a rule key with illegal characters`() {
+        shouldThrow<ComplianceDomainException> { AmlRule(AmlRuleId.generate(), "has space") }
+    }
+
+    @Test
+    fun `should accept a rule key at the maximum length`() {
+        AmlRule(AmlRuleId.generate(), "a".repeat(128)).ruleKey.length shouldBe 128
+    }
+
+    @Test
+    fun `should reject a rule key over the maximum length`() {
+        shouldThrow<ComplianceDomainException> { AmlRule(AmlRuleId.generate(), "a".repeat(129)) }
+    }
+}

--- a/services/compliance/src/test/kotlin/com/fincore/compliance/domain/ComplianceCaseTest.kt
+++ b/services/compliance/src/test/kotlin/com/fincore/compliance/domain/ComplianceCaseTest.kt
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.domain
+
+import com.fincore.compliance.domain.enum.CaseStatus
+import com.fincore.core.ComplianceCaseId
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class ComplianceCaseTest {
+    @Test
+    fun `should start open when created`() {
+        case().status shouldBe CaseStatus.OPEN
+    }
+
+    @Test
+    fun `should resolve through claimed when transitioned legally`() {
+        val c = case()
+        c.transitionTo(CaseStatus.CLAIMED)
+        c.transitionTo(CaseStatus.RESOLVED)
+        c.status shouldBe CaseStatus.RESOLVED
+        c.isTerminal() shouldBe true
+    }
+
+    @Test
+    fun `should resolve through escalation when escalated then resolved`() {
+        val c = case()
+        c.transitionTo(CaseStatus.CLAIMED)
+        c.transitionTo(CaseStatus.ESCALATED)
+        c.transitionTo(CaseStatus.RESOLVED)
+        c.status shouldBe CaseStatus.RESOLVED
+    }
+
+    @Test
+    fun `should reject claiming a resolved case`() {
+        val c = case()
+        c.transitionTo(CaseStatus.CLAIMED)
+        c.transitionTo(CaseStatus.RESOLVED)
+        shouldThrow<ComplianceDomainException> { c.transitionTo(CaseStatus.CLAIMED) }
+    }
+
+    @Test
+    fun `should reject a blank reference`() {
+        shouldThrow<ComplianceDomainException> { ComplianceCase(ComplianceCaseId.generate(), "") }
+    }
+
+    private fun case(): ComplianceCase = ComplianceCase(ComplianceCaseId.generate(), "case-ref-1")
+}

--- a/services/compliance/src/test/kotlin/com/fincore/compliance/domain/KycSessionTest.kt
+++ b/services/compliance/src/test/kotlin/com/fincore/compliance/domain/KycSessionTest.kt
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.domain
+
+import com.fincore.compliance.domain.enum.KycStatus
+import com.fincore.core.KycSessionId
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class KycSessionTest {
+    @Test
+    fun `should start in initiated when created`() {
+        session().status shouldBe KycStatus.INITIATED
+    }
+
+    @Test
+    fun `should advance through screening to approved when transitioned legally`() {
+        val s = session()
+        s.transitionTo(KycStatus.SCREENING)
+        s.transitionTo(KycStatus.APPROVED)
+        s.status shouldBe KycStatus.APPROVED
+        s.isTerminal() shouldBe true
+    }
+
+    @Test
+    fun `should reject an illegal transition`() {
+        shouldThrow<ComplianceDomainException> { session().transitionTo(KycStatus.APPROVED) }
+    }
+
+    @Test
+    fun `should reject a blank subject reference`() {
+        shouldThrow<ComplianceDomainException> { KycSession(KycSessionId.generate(), " ") }
+    }
+
+    @Test
+    fun `should reject a subject reference over the length limit`() {
+        shouldThrow<ComplianceDomainException> { KycSession(KycSessionId.generate(), "x".repeat(141)) }
+    }
+
+    private fun session(): KycSession = KycSession(KycSessionId.generate(), "subject-1")
+}

--- a/services/compliance/src/test/kotlin/com/fincore/compliance/domain/StatusTransitionConsistencyTest.kt
+++ b/services/compliance/src/test/kotlin/com/fincore/compliance/domain/StatusTransitionConsistencyTest.kt
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.domain
+
+import com.fincore.compliance.domain.enum.AmlAlertStatus
+import com.fincore.compliance.domain.enum.CaseStatus
+import com.fincore.compliance.domain.enum.KycStatus
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+
+class StatusTransitionConsistencyTest {
+    @Test
+    fun `should mark a kyc status terminal exactly when it has no legal transition`() {
+        KycStatus.entries.forEach { status ->
+            status.isTerminal() shouldBe KycStatus.entries.none { status.canTransitionTo(it) }
+        }
+    }
+
+    @Test
+    fun `should mark a case status terminal exactly when it has no legal transition`() {
+        CaseStatus.entries.forEach { status ->
+            status.isTerminal() shouldBe CaseStatus.entries.none { status.canTransitionTo(it) }
+        }
+    }
+
+    @Test
+    fun `should mark an aml alert status terminal exactly when it has no legal transition`() {
+        AmlAlertStatus.entries.forEach { status ->
+            status.isTerminal() shouldBe AmlAlertStatus.entries.none { status.canTransitionTo(it) }
+        }
+    }
+
+    @Test
+    fun `should never allow a status to transition to itself`() {
+        KycStatus.entries.forEach { it.canTransitionTo(it) shouldBe false }
+        CaseStatus.entries.forEach { it.canTransitionTo(it) shouldBe false }
+        AmlAlertStatus.entries.forEach { it.canTransitionTo(it) shouldBe false }
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,4 +30,5 @@ include(
     ":services:ledger",
     ":services:decision",
     ":services:payments",
+    ":services:compliance",
 )


### PR DESCRIPTION
First slice of E-04 Compliance (#261), starting v0.3.0.

## What
- New `services/compliance` Gradle module (pure-Kotlin domain for now; Boot/JPA/web arrive in later slices).
- Domain model: `KycSession`, `ComplianceCase`, `AmlAlert` aggregates (class, not data class; `var status private set`; guarded `transitionTo` throwing `ComplianceDomainException`), the `AmlRule` definition, status enums (`KycStatus`/`CaseStatus`/`AmlAlertStatus` with `canTransitionTo`/`isTerminal`), and a shared `RuleKey` validator.
- Four prefixed-ULID identifiers in `fincore-core`: `KycSessionId` (kyc_), `AmlAlertId` (alert_), `ComplianceCaseId` (case_), `AmlRuleId` (rule_), mirroring `PaymentId`.

## Clean-room (§5.3.1)
Generic only - no real KYC providers, sanctions lists, PEP, or business thresholds. `subjectReference`/`ruleKey` are generic validated strings.

## Tests
Domain invariants + legal/illegal transitions per aggregate, an `isTerminal` <-> `canTransitionTo` consistency property over all three enums, RuleKey length boundaries, and ID round-trip + wrong-prefix rejection for all four IDs. JaCoCo 90% line+branch gate on `compliance/domain/**`.

## Gate chain
- critic: GO-WITH-CHANGES (jacoco 90% domain gate, consistency test, pinned package paths - all applied).
- security-auditor (opus): PASS - clean-room clean, status machines provably consistent, no secrets, 5/5 ACs.
- code-reviewer: 2 must-fix applied (shared RuleKey validator + readable messages; wrong-prefix ID rejection tests).
- evaluator: PASS (0.918).
All local gates green (test/detekt/spotless/assemble/jacoco + fincore-core).

Closes #261