### PR TITLE
feat(compliance): add compliance schema and jpa persistence

### DIFF
--- a/services/compliance/build.gradle.kts
+++ b/services/compliance/build.gradle.kts
@@ -3,9 +3,13 @@
 
 plugins {
     alias(libs.plugins.kotlin.jvm)
+    alias(libs.plugins.kotlin.spring)
+    alias(libs.plugins.kotlin.jpa)
+    alias(libs.plugins.spring.boot)
+    alias(libs.plugins.spring.dependency.management)
 }
 
-description = "FinCore Compliance service: KYC, AML and case-management domain"
+description = "FinCore Compliance service: KYC, AML and case-management domain and persistence"
 
 kotlin {
     jvmToolchain(21)
@@ -13,16 +17,51 @@ kotlin {
 
 dependencies {
     implementation(project(":libs:fincore-core"))
-    implementation(libs.kotlin.stdlib)
 
+    implementation(libs.kotlin.stdlib)
+    implementation(libs.kotlin.reflect)
+
+    implementation(libs.spring.boot.starter.data.jpa)
+    implementation(libs.liquibase.core)
+    runtimeOnly(libs.postgres.jdbc)
+
+    testImplementation(project(":libs:fincore-test-support"))
+    testImplementation(libs.spring.boot.starter.test)
     testImplementation(libs.kotest.assertions.core)
     testImplementation(libs.kotest.runner.junit5)
     testImplementation(libs.mockk)
+    testImplementation(libs.testcontainers.core)
+    testImplementation(libs.testcontainers.postgres)
+    testImplementation(libs.testcontainers.junit5)
 }
 
 tasks.test {
     useJUnitPlatform()
 }
+
+sourceSets {
+    create("integrationTest") {
+        compileClasspath += sourceSets["main"].output + sourceSets["test"].output
+        runtimeClasspath += sourceSets["main"].output + sourceSets["test"].output
+    }
+}
+
+configurations["integrationTestImplementation"].extendsFrom(configurations["testImplementation"])
+configurations["integrationTestRuntimeOnly"].extendsFrom(configurations["testRuntimeOnly"])
+
+dependencies {
+    "integrationTestImplementation"(libs.postgres.jdbc)
+}
+
+val integrationTest =
+    tasks.register<Test>("integrationTest") {
+        description = "Runs integration tests (Spring Boot + Testcontainers)."
+        group = "verification"
+        testClassesDirs = sourceSets["integrationTest"].output.classesDirs
+        classpath = sourceSets["integrationTest"].runtimeClasspath
+        useJUnitPlatform()
+        shouldRunAfter(tasks.named("test"))
+    }
 
 tasks.named<JacocoCoverageVerification>("jacocoTestCoverageVerification") {
     dependsOn(tasks.test)
@@ -50,5 +89,6 @@ tasks.named<JacocoCoverageVerification>("jacocoTestCoverageVerification") {
 }
 
 tasks.named("check") {
+    dependsOn(integrationTest)
     dependsOn(tasks.named("jacocoTestCoverageVerification"))
 }

--- a/services/compliance/src/integrationTest/kotlin/com/fincore/compliance/infrastructure/persistence/ComplianceSchemaPersistenceIT.kt
+++ b/services/compliance/src/integrationTest/kotlin/com/fincore/compliance/infrastructure/persistence/ComplianceSchemaPersistenceIT.kt
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.infrastructure.persistence
+
+import com.fincore.compliance.domain.enum.AmlAlertStatus
+import com.fincore.compliance.domain.enum.CaseStatus
+import com.fincore.compliance.domain.enum.KycStatus
+import com.fincore.test.containers.PostgresContainerExtension
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+import java.util.UUID
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@ExtendWith(PostgresContainerExtension::class)
+class ComplianceSchemaPersistenceIT(
+    @Autowired private val kycSessions: KycSessionRepository,
+    @Autowired private val amlAlerts: AmlAlertRepository,
+    @Autowired private val cases: ComplianceCaseRepository,
+    @Autowired private val amlRules: AmlRuleRepository,
+) {
+    @AfterEach
+    fun cleanUp() {
+        kycSessions.deleteAll()
+        amlAlerts.deleteAll()
+        cases.deleteAll()
+        amlRules.deleteAll()
+    }
+
+    @Test
+    fun `should round-trip a kyc session preserving status and version`() {
+        val id = UUID.randomUUID()
+        kycSessions.saveAndFlush(KycSessionEntity(id, "subject-1", KycStatus.INITIATED, Instant.now(), 0L))
+
+        val reloaded = kycSessions.findById(id).orElseThrow()
+        reloaded.subjectReference shouldBe "subject-1"
+        reloaded.status shouldBe KycStatus.INITIATED
+        reloaded.version shouldBe 0L
+    }
+
+    @Test
+    fun `should find aml alerts by status`() {
+        amlAlerts.saveAndFlush(AmlAlertEntity(UUID.randomUUID(), "aml.velocity", AmlAlertStatus.OPEN, Instant.now(), 0L))
+
+        amlAlerts.findByStatus(AmlAlertStatus.OPEN).size shouldBe 1
+    }
+
+    @Test
+    fun `should round-trip a compliance case preserving status`() {
+        val id = UUID.randomUUID()
+        cases.saveAndFlush(ComplianceCaseEntity(id, "case-ref-1", CaseStatus.OPEN, Instant.now(), 0L))
+
+        cases.findById(id).orElseThrow().status shouldBe CaseStatus.OPEN
+    }
+
+    @Test
+    fun `should round-trip an aml rule preserving the enabled flag`() {
+        val id = UUID.randomUUID()
+        amlRules.saveAndFlush(AmlRuleEntity(id, "aml.structuring", false, Instant.now()))
+
+        val reloaded = amlRules.findById(id).orElseThrow()
+        reloaded.enabled shouldBe false
+        amlRules.findByRuleKey("aml.structuring")?.id shouldBe id
+    }
+
+    companion object {
+        @JvmStatic
+        @DynamicPropertySource
+        fun datasourceProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { PostgresContainerExtension.jdbcUrl }
+            registry.add("spring.datasource.username") { PostgresContainerExtension.username }
+            registry.add("spring.datasource.password") { PostgresContainerExtension.password }
+            registry.add("spring.jpa.hibernate.ddl-auto") { "none" }
+        }
+    }
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/ComplianceApplication.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/ComplianceApplication.kt
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+
+@SpringBootApplication
+class ComplianceApplication
+
+fun main(args: Array<String>) {
+    runApplication<ComplianceApplication>(*args)
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/persistence/AmlAlertEntity.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/persistence/AmlAlertEntity.kt
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.infrastructure.persistence
+
+import com.fincore.compliance.domain.enum.AmlAlertStatus
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import jakarta.persistence.Version
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(name = "aml_alerts", schema = "compliance")
+class AmlAlertEntity(
+    @Id
+    @Column(name = "id", nullable = false, updatable = false)
+    var id: UUID,
+    @Column(name = "rule_key", nullable = false, updatable = false)
+    var ruleKey: String,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    var status: AmlAlertStatus,
+    @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: Instant,
+    @Version
+    @Column(name = "version", nullable = false)
+    var version: Long,
+)

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/persistence/AmlAlertRepository.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/persistence/AmlAlertRepository.kt
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.infrastructure.persistence
+
+import com.fincore.compliance.domain.enum.AmlAlertStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface AmlAlertRepository : JpaRepository<AmlAlertEntity, UUID> {
+    fun findByStatus(status: AmlAlertStatus): List<AmlAlertEntity>
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/persistence/AmlRuleEntity.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/persistence/AmlRuleEntity.kt
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.infrastructure.persistence
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(name = "aml_rules", schema = "compliance")
+class AmlRuleEntity(
+    @Id
+    @Column(name = "id", nullable = false, updatable = false)
+    var id: UUID,
+    @Column(name = "rule_key", nullable = false, updatable = false)
+    var ruleKey: String,
+    @Column(name = "enabled", nullable = false)
+    var enabled: Boolean,
+    @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: Instant,
+)

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/persistence/AmlRuleRepository.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/persistence/AmlRuleRepository.kt
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.infrastructure.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface AmlRuleRepository : JpaRepository<AmlRuleEntity, UUID> {
+    fun findByRuleKey(ruleKey: String): AmlRuleEntity?
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/persistence/ComplianceCaseEntity.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/persistence/ComplianceCaseEntity.kt
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.infrastructure.persistence
+
+import com.fincore.compliance.domain.enum.CaseStatus
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import jakarta.persistence.Version
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(name = "compliance_cases", schema = "compliance")
+class ComplianceCaseEntity(
+    @Id
+    @Column(name = "id", nullable = false, updatable = false)
+    var id: UUID,
+    @Column(name = "reference", nullable = false, updatable = false)
+    var reference: String,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    var status: CaseStatus,
+    @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: Instant,
+    @Version
+    @Column(name = "version", nullable = false)
+    var version: Long,
+)

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/persistence/ComplianceCaseRepository.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/persistence/ComplianceCaseRepository.kt
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.infrastructure.persistence
+
+import com.fincore.compliance.domain.enum.CaseStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface ComplianceCaseRepository : JpaRepository<ComplianceCaseEntity, UUID> {
+    fun findByStatus(status: CaseStatus): List<ComplianceCaseEntity>
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/persistence/KycSessionEntity.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/persistence/KycSessionEntity.kt
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.infrastructure.persistence
+
+import com.fincore.compliance.domain.enum.KycStatus
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import jakarta.persistence.Version
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Table(name = "kyc_sessions", schema = "compliance")
+class KycSessionEntity(
+    @Id
+    @Column(name = "id", nullable = false, updatable = false)
+    var id: UUID,
+    @Column(name = "subject_reference", nullable = false, updatable = false)
+    var subjectReference: String,
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    var status: KycStatus,
+    @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: Instant,
+    @Version
+    @Column(name = "version", nullable = false)
+    var version: Long,
+)

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/persistence/KycSessionRepository.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/persistence/KycSessionRepository.kt
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.infrastructure.persistence
+
+import com.fincore.compliance.domain.enum.KycStatus
+import org.springframework.data.jpa.repository.JpaRepository
+import java.util.UUID
+
+interface KycSessionRepository : JpaRepository<KycSessionEntity, UUID> {
+    fun findByStatus(status: KycStatus): List<KycSessionEntity>
+}

--- a/services/compliance/src/main/resources/application.yml
+++ b/services/compliance/src/main/resources/application.yml
@@ -1,0 +1,8 @@
+spring:
+  application:
+    name: compliance
+  jpa:
+    hibernate:
+      ddl-auto: none
+  liquibase:
+    change-log: classpath:db/changelog/db.changelog-master.yaml

--- a/services/compliance/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/compliance/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: BUSL-1.1
+# SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+databaseChangeLog:
+  - include:
+      file: v0.1/001-schema.sql
+      relativeToChangelogFile: true
+  - include:
+      file: v0.1/010-kyc-sessions.sql
+      relativeToChangelogFile: true
+  - include:
+      file: v0.1/011-aml-alerts.sql
+      relativeToChangelogFile: true
+  - include:
+      file: v0.1/012-compliance-cases.sql
+      relativeToChangelogFile: true
+  - include:
+      file: v0.1/013-aml-rules.sql
+      relativeToChangelogFile: true

--- a/services/compliance/src/main/resources/db/changelog/v0.1/001-schema.sql
+++ b/services/compliance/src/main/resources/db/changelog/v0.1/001-schema.sql
@@ -1,0 +1,6 @@
+--liquibase formatted sql
+-- SPDX-License-Identifier: BUSL-1.1
+-- SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+--changeset fincore:compliance-001-schema dbms:postgresql
+CREATE SCHEMA IF NOT EXISTS compliance;

--- a/services/compliance/src/main/resources/db/changelog/v0.1/010-kyc-sessions.sql
+++ b/services/compliance/src/main/resources/db/changelog/v0.1/010-kyc-sessions.sql
@@ -1,0 +1,17 @@
+--liquibase formatted sql
+-- SPDX-License-Identifier: BUSL-1.1
+-- SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+--changeset fincore:compliance-010-kyc-sessions dbms:postgresql
+CREATE TABLE IF NOT EXISTS compliance.kyc_sessions (
+    id                 UUID         NOT NULL DEFAULT gen_random_uuid(),
+    subject_reference  VARCHAR(140) NOT NULL,
+    status             VARCHAR(16)  NOT NULL,
+    created_at         TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    version            BIGINT       NOT NULL DEFAULT 0,
+    CONSTRAINT pk_kyc_sessions PRIMARY KEY (id),
+    CONSTRAINT ck_kyc_sessions_status
+        CHECK (status IN ('INITIATED', 'SCREENING', 'APPROVED', 'REJECTED'))
+);
+
+CREATE INDEX IF NOT EXISTS ix_kyc_sessions_status ON compliance.kyc_sessions (status);

--- a/services/compliance/src/main/resources/db/changelog/v0.1/011-aml-alerts.sql
+++ b/services/compliance/src/main/resources/db/changelog/v0.1/011-aml-alerts.sql
@@ -1,0 +1,17 @@
+--liquibase formatted sql
+-- SPDX-License-Identifier: BUSL-1.1
+-- SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+--changeset fincore:compliance-011-aml-alerts dbms:postgresql
+CREATE TABLE IF NOT EXISTS compliance.aml_alerts (
+    id          UUID        NOT NULL DEFAULT gen_random_uuid(),
+    rule_key    VARCHAR(128) NOT NULL,
+    status      VARCHAR(16) NOT NULL,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    version     BIGINT      NOT NULL DEFAULT 0,
+    CONSTRAINT pk_aml_alerts PRIMARY KEY (id),
+    CONSTRAINT ck_aml_alerts_status
+        CHECK (status IN ('OPEN', 'RESOLVED', 'DISMISSED'))
+);
+
+CREATE INDEX IF NOT EXISTS ix_aml_alerts_status ON compliance.aml_alerts (status);

--- a/services/compliance/src/main/resources/db/changelog/v0.1/012-compliance-cases.sql
+++ b/services/compliance/src/main/resources/db/changelog/v0.1/012-compliance-cases.sql
@@ -1,0 +1,17 @@
+--liquibase formatted sql
+-- SPDX-License-Identifier: BUSL-1.1
+-- SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+--changeset fincore:compliance-012-compliance-cases dbms:postgresql
+CREATE TABLE IF NOT EXISTS compliance.compliance_cases (
+    id          UUID         NOT NULL DEFAULT gen_random_uuid(),
+    reference   VARCHAR(140) NOT NULL,
+    status      VARCHAR(16)  NOT NULL,
+    created_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    version     BIGINT       NOT NULL DEFAULT 0,
+    CONSTRAINT pk_compliance_cases PRIMARY KEY (id),
+    CONSTRAINT ck_compliance_cases_status
+        CHECK (status IN ('OPEN', 'CLAIMED', 'ESCALATED', 'RESOLVED'))
+);
+
+CREATE INDEX IF NOT EXISTS ix_compliance_cases_status ON compliance.compliance_cases (status);

--- a/services/compliance/src/main/resources/db/changelog/v0.1/013-aml-rules.sql
+++ b/services/compliance/src/main/resources/db/changelog/v0.1/013-aml-rules.sql
@@ -1,0 +1,13 @@
+--liquibase formatted sql
+-- SPDX-License-Identifier: BUSL-1.1
+-- SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+--changeset fincore:compliance-013-aml-rules dbms:postgresql
+CREATE TABLE IF NOT EXISTS compliance.aml_rules (
+    id          UUID         NOT NULL DEFAULT gen_random_uuid(),
+    rule_key    VARCHAR(128) NOT NULL,
+    enabled     BOOLEAN      NOT NULL DEFAULT TRUE,
+    created_at  TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    CONSTRAINT pk_aml_rules PRIMARY KEY (id),
+    CONSTRAINT uq_aml_rules_rule_key UNIQUE (rule_key)
+);


### PR DESCRIPTION
Second slice of E-04 Compliance (#262). Persists the #261 domain.

## What
- New `compliance` schema via idempotent Liquibase formatted SQL: `kyc_sessions`, `aml_alerts`, `compliance_cases`, `aml_rules` (CREATE ... IF NOT EXISTS, one changeset per file, status CHECK constraints matching the domain enums, status indexes, unique rule_key).
- JPA entities (class, UUID id, `@Enumerated(STRING)`, `@Version` on the three mutable aggregates; `AmlRule` is insert-only with no version) + Spring Data repositories.
- A `@DataJpaTest` + Testcontainers persistence IT round-tripping each entity.
- Flips `services/compliance` from a pure-Kotlin module into a Spring Boot data-JPA module (no web/security yet - that is #270), mirroring the payments module setup.

## Column widths (match domain bounds, §8.15)
`subject_reference`/`reference` VARCHAR(140), `rule_key` VARCHAR(128), `status` VARCHAR(16) (longest enum value = 9).

## Clean-room (§5.3.1)
Generic columns and CHECK values only - no real providers, lists, PEP, or business thresholds.

## Gate chain
- critic: GO-WITH-CHANGES (full integrationTest+check block, verbatim @DataJpaTest @DynamicPropertySource, AmlRule no @Version - all applied).
- security-auditor (opus): PASS - clean-room clean, no secrets, @Version consistent, widths fit, 5/5 ACs.
- code-reviewer: APPROVED (8/8 checks; mirrors payments).
- evaluator: PASS (0.905).
All local gates green (test/detekt/spotless/assemble/compileIntegrationTestKotlin/jacoco 90% domain); integrationTest runs on CI.

Closes #262