### PR TITLE
feat(compliance): add the kyc provider port

### DIFF
--- a/services/compliance/src/main/kotlin/com/fincore/compliance/application/kyc/KycCheckRequest.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/application/kyc/KycCheckRequest.kt
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.kyc
+
+import com.fincore.compliance.domain.KycSession
+
+/**
+ * A request to check a subject. [subjectReference] is an opaque token identifying the subject under check, never raw
+ * PII; the provider resolves the actual subject data out of tree. Its bound is the KycSession domain invariant.
+ */
+data class KycCheckRequest(
+    val subjectReference: String,
+) {
+    init {
+        require(subjectReference.isNotBlank() && subjectReference.length <= KycSession.MAX_SUBJECT_REFERENCE_LENGTH) {
+            "subjectReference must be non-blank and at most ${KycSession.MAX_SUBJECT_REFERENCE_LENGTH} characters"
+        }
+    }
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/application/kyc/KycCheckResult.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/application/kyc/KycCheckResult.kt
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.kyc
+
+/**
+ * Outcome of a [KycProvider] check: a business decision, distinct from a technical failure (a thrown
+ * [KycProviderException]).
+ *
+ * [reason] and [missing] carry generic codes or field identifiers, never PII or raw subject values.
+ * [Approved] and [Pending] are accepted at submission; a final state may arrive asynchronously.
+ * [InsufficientData] is a first-class outcome: the check could not be decided for want of the listed attributes.
+ */
+sealed interface KycCheckResult {
+    data class Approved(
+        val providerReference: String,
+    ) : KycCheckResult
+
+    data class Rejected(
+        val reason: String,
+    ) : KycCheckResult
+
+    data class Pending(
+        val providerReference: String,
+    ) : KycCheckResult
+
+    data class InsufficientData(
+        val missing: List<String>,
+    ) : KycCheckResult {
+        init {
+            require(missing.isNotEmpty()) { "missing must not be empty" }
+        }
+    }
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/application/kyc/KycProvider.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/application/kyc/KycProvider.kt
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.kyc
+
+/**
+ * Plug-in port for submitting a KYC check to an external provider.
+ *
+ * Real provider adapters are supplied out of tree and are NOT part of this open-source service; the only in-tree
+ * implementation is a deterministic sandbox. The contract is generic and encodes no real-provider protocol, field,
+ * or result code.
+ *
+ * Implementations perform no persistence; the caller decides what to do with the result, outside any transaction.
+ * A business outcome is returned as a [KycCheckResult]; a technical or transient failure is thrown as a
+ * [KycProviderException].
+ */
+interface KycProvider {
+    fun check(request: KycCheckRequest): KycCheckResult
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/application/kyc/KycProviderException.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/application/kyc/KycProviderException.kt
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.kyc
+
+/** Signals a technical or transient failure running a KYC check, distinct from a business decision. */
+class KycProviderException(
+    message: String,
+    cause: Throwable? = null,
+) : RuntimeException(message, cause)

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/domain/KycSession.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/domain/KycSession.kt
@@ -34,7 +34,7 @@ class KycSession(
         return value
     }
 
-    private companion object {
+    companion object {
         const val MAX_SUBJECT_REFERENCE_LENGTH = 140
     }
 }

--- a/services/compliance/src/test/kotlin/com/fincore/compliance/application/kyc/KycProviderContractTest.kt
+++ b/services/compliance/src/test/kotlin/com/fincore/compliance/application/kyc/KycProviderContractTest.kt
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.kyc
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+
+private class FixedKycProvider(
+    private val result: KycCheckResult,
+) : KycProvider {
+    override fun check(request: KycCheckRequest): KycCheckResult = result
+}
+
+class KycProviderContractTest {
+    private val request = KycCheckRequest("subject-1")
+
+    @Test
+    fun `should expose a single check method when inspected`() {
+        KycProvider::class.java.isInterface shouldBe true
+
+        val method =
+            KycProvider::class.java.declaredMethods
+                .filter { !it.isBridge && !it.isSynthetic }
+                .single { it.name == "check" }
+
+        method.returnType shouldBe KycCheckResult::class.java
+        method.parameterTypes.toList() shouldBe listOf(KycCheckRequest::class.java)
+    }
+
+    @Test
+    fun `should return an approved result when the implementation approves`() {
+        FixedKycProvider(KycCheckResult.Approved("ref-1"))
+            .check(request)
+            .shouldBeInstanceOf<KycCheckResult.Approved>()
+    }
+
+    @Test
+    fun `should return a rejected result when the implementation rejects`() {
+        FixedKycProvider(KycCheckResult.Rejected("declined"))
+            .check(request)
+            .shouldBeInstanceOf<KycCheckResult.Rejected>()
+    }
+
+    @Test
+    fun `should return a pending result when the implementation defers`() {
+        FixedKycProvider(KycCheckResult.Pending("ref-2"))
+            .check(request)
+            .shouldBeInstanceOf<KycCheckResult.Pending>()
+    }
+
+    @Test
+    fun `should carry the missing attributes when data is insufficient`() {
+        val result = FixedKycProvider(KycCheckResult.InsufficientData(listOf("attr-a"))).check(request)
+
+        result.shouldBeInstanceOf<KycCheckResult.InsufficientData>().missing shouldBe listOf("attr-a")
+    }
+
+    @Test
+    fun `should reject an empty missing list`() {
+        shouldThrow<IllegalArgumentException> { KycCheckResult.InsufficientData(emptyList()) }
+    }
+
+    @Test
+    fun `should reject a blank subject reference`() {
+        shouldThrow<IllegalArgumentException> { KycCheckRequest(" ") }
+    }
+
+    @Test
+    fun `should reject a subject reference over the length limit`() {
+        shouldThrow<IllegalArgumentException> { KycCheckRequest("x".repeat(141)) }
+    }
+}


### PR DESCRIPTION
Third slice of E-04 Compliance (#263). Unblocks #239 SandboxKycProvider.

## What
- `KycProvider` port (interface-only, clean-room) in `com.fincore.compliance.application.kyc`, mirroring `BankProvider` (#212): `check(request): KycCheckResult`.
- `KycCheckRequest(subjectReference)` - an opaque token (never PII), bounded by the `KycSession` domain invariant (single source of truth, `MAX_SUBJECT_REFERENCE_LENGTH`).
- `KycCheckResult` sealed interface: `Approved`, `Rejected`, `Pending`, `InsufficientData(missing)` - the typed INSUFFICIENT_DATA outcome (§5.1); `reason`/`missing` carry generic codes, never PII.
- `KycProviderException` for technical/transient failures (distinct from a business decision).
- No in-tree implementation (sandbox is #239); no Spring, no persistence.

## Gate chain
- critic: GO-WITH-CHANGES (length bound matching the domain, no-PII KDoc, all 4 variants tested - applied).
- security-auditor (opus): PASS - clean-room clean, no secrets, PII documented, sound typed contract, 4/4 ACs.
- code-reviewer: 2 must-fix addressed (de-duplicated the 140 bound by sourcing it from the domain layer; `InsufficientData` empty-list guard + test).
- evaluator: PASS (0.92).
All local gates green (test/detekt/spotless/assemble/jacoco domain).

Closes #263