### PR TITLE
feat(compliance): add the sanctions provider port

### DIFF
--- a/services/compliance/src/main/kotlin/com/fincore/compliance/application/sanctions/SanctionsProvider.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/application/sanctions/SanctionsProvider.kt
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.sanctions
+
+/**
+ * Plug-in port for screening a subject against a sanctions source.
+ *
+ * Real screening adapters and lists are supplied out of tree and are NOT part of this open-source service; the only
+ * in-tree implementation is a deterministic sandbox. The contract is generic and encodes no real list, entry, format,
+ * or business threshold.
+ *
+ * Implementations perform no persistence; the caller decides what to do with the result, outside any transaction.
+ * A business outcome is returned as a [SanctionsScreeningResult]; a technical or transient failure is thrown as a
+ * [SanctionsProviderException].
+ */
+interface SanctionsProvider {
+    fun screen(request: SanctionsScreeningRequest): SanctionsScreeningResult
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/application/sanctions/SanctionsProviderException.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/application/sanctions/SanctionsProviderException.kt
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.sanctions
+
+/** Signals a technical or transient failure running a sanctions screening, distinct from a business decision. */
+class SanctionsProviderException(
+    message: String,
+    cause: Throwable? = null,
+) : RuntimeException(message, cause)

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/application/sanctions/SanctionsScreeningRequest.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/application/sanctions/SanctionsScreeningRequest.kt
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.sanctions
+
+import com.fincore.compliance.domain.KycSession
+
+/**
+ * A request to screen a subject with a configurable m-of-n partial match.
+ *
+ * [subjectReference] is an opaque token identifying the subject, never raw PII; the provider resolves the actual
+ * subject data out of tree by this reference (same model as the KYC port). [attributes] is the set of generic
+ * attribute-key dimensions to screen ("n"), never raw PII values. [requiredMatches] is the minimum dimensions that
+ * must match for a potential hit ("m"), where 1 <= m <= n.
+ */
+data class SanctionsScreeningRequest(
+    val subjectReference: String,
+    val attributes: Set<String>,
+    val requiredMatches: Int,
+) {
+    init {
+        require(subjectReference.isNotBlank() && subjectReference.length <= KycSession.MAX_SUBJECT_REFERENCE_LENGTH) {
+            "subjectReference must be non-blank and at most ${KycSession.MAX_SUBJECT_REFERENCE_LENGTH} characters"
+        }
+        require(attributes.isNotEmpty()) { "attributes must not be empty" }
+        require(requiredMatches in 1..attributes.size) {
+            "requiredMatches must be between 1 and the number of attributes"
+        }
+    }
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/application/sanctions/SanctionsScreeningResult.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/application/sanctions/SanctionsScreeningResult.kt
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.sanctions
+
+/**
+ * Outcome of a [SanctionsProvider] screening: a business decision, distinct from a technical failure (a thrown
+ * [SanctionsProviderException]).
+ *
+ * [matchedAttributes] and [missing] carry generic attribute keys, never PII or raw subject values.
+ * [InsufficientData] is a first-class outcome: the screening could not be decided for want of the listed attributes.
+ */
+sealed interface SanctionsScreeningResult {
+    data object Clear : SanctionsScreeningResult
+
+    /**
+     * A potential hit. [score] is a generic provider-reported match confidence in [0, 1] (higher means a stronger
+     * match); it is not an m-of-n ratio and not a business risk band.
+     */
+    data class PotentialMatch(
+        val matchedAttributes: List<String>,
+        val score: Double,
+    ) : SanctionsScreeningResult {
+        init {
+            require(matchedAttributes.isNotEmpty()) { "matchedAttributes must not be empty" }
+            require(score in MIN_SCORE..MAX_SCORE) { "score must be within [$MIN_SCORE, $MAX_SCORE]" }
+        }
+
+        private companion object {
+            const val MIN_SCORE = 0.0
+            const val MAX_SCORE = 1.0
+        }
+    }
+
+    data class InsufficientData(
+        val missing: List<String>,
+    ) : SanctionsScreeningResult {
+        init {
+            require(missing.isNotEmpty()) { "missing must not be empty" }
+        }
+    }
+}

--- a/services/compliance/src/test/kotlin/com/fincore/compliance/application/sanctions/SanctionsProviderContractTest.kt
+++ b/services/compliance/src/test/kotlin/com/fincore/compliance/application/sanctions/SanctionsProviderContractTest.kt
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.sanctions
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+
+private class FixedSanctionsProvider(
+    private val result: SanctionsScreeningResult,
+) : SanctionsProvider {
+    override fun screen(request: SanctionsScreeningRequest): SanctionsScreeningResult = result
+}
+
+class SanctionsProviderContractTest {
+    private val request = SanctionsScreeningRequest("subject-1", setOf("attr-a", "attr-b"), 1)
+
+    @Test
+    fun `should expose a single screen method when inspected`() {
+        SanctionsProvider::class.java.isInterface shouldBe true
+
+        val method =
+            SanctionsProvider::class.java.declaredMethods
+                .filter { !it.isBridge && !it.isSynthetic }
+                .single { it.name == "screen" }
+
+        method.returnType shouldBe SanctionsScreeningResult::class.java
+        method.parameterTypes.toList() shouldBe listOf(SanctionsScreeningRequest::class.java)
+    }
+
+    @Test
+    fun `should return clear when the implementation finds no hit`() {
+        FixedSanctionsProvider(SanctionsScreeningResult.Clear)
+            .screen(request)
+            .shouldBeInstanceOf<SanctionsScreeningResult.Clear>()
+    }
+
+    @Test
+    fun `should carry matched attributes and score on a potential match`() {
+        val result = FixedSanctionsProvider(SanctionsScreeningResult.PotentialMatch(listOf("attr-a"), 0.5)).screen(request)
+
+        val match = result.shouldBeInstanceOf<SanctionsScreeningResult.PotentialMatch>()
+        match.matchedAttributes shouldBe listOf("attr-a")
+        match.score shouldBe 0.5
+    }
+
+    @Test
+    fun `should carry the missing attributes when data is insufficient`() {
+        val result = FixedSanctionsProvider(SanctionsScreeningResult.InsufficientData(listOf("attr-b"))).screen(request)
+
+        result.shouldBeInstanceOf<SanctionsScreeningResult.InsufficientData>().missing shouldBe listOf("attr-b")
+    }
+
+    @Test
+    fun `should reject a blank subject reference`() {
+        shouldThrow<IllegalArgumentException> { SanctionsScreeningRequest(" ", setOf("attr-a"), 1) }
+    }
+
+    @Test
+    fun `should reject empty attributes`() {
+        shouldThrow<IllegalArgumentException> { SanctionsScreeningRequest("subject-1", emptySet(), 1) }
+    }
+
+    @Test
+    fun `should reject required matches below one`() {
+        shouldThrow<IllegalArgumentException> { SanctionsScreeningRequest("subject-1", setOf("attr-a"), 0) }
+    }
+
+    @Test
+    fun `should reject required matches above the attribute count`() {
+        shouldThrow<IllegalArgumentException> { SanctionsScreeningRequest("subject-1", setOf("attr-a"), 2) }
+    }
+
+    @Test
+    fun `should reject a potential match with no matched attributes`() {
+        shouldThrow<IllegalArgumentException> { SanctionsScreeningResult.PotentialMatch(emptyList(), 0.5) }
+    }
+
+    @Test
+    fun `should reject a potential match score out of range`() {
+        shouldThrow<IllegalArgumentException> { SanctionsScreeningResult.PotentialMatch(listOf("attr-a"), 1.5) }
+    }
+
+    @Test
+    fun `should reject insufficient data with no missing attributes`() {
+        shouldThrow<IllegalArgumentException> { SanctionsScreeningResult.InsufficientData(emptyList()) }
+    }
+
+    @Test
+    fun `should reject a not-a-number score`() {
+        shouldThrow<IllegalArgumentException> { SanctionsScreeningResult.PotentialMatch(listOf("attr-a"), Double.NaN) }
+    }
+
+    @Test
+    fun `should propagate a provider exception on technical failure`() {
+        val provider =
+            object : SanctionsProvider {
+                override fun screen(request: SanctionsScreeningRequest): SanctionsScreeningResult =
+                    throw SanctionsProviderException("upstream unavailable")
+            }
+
+        shouldThrow<SanctionsProviderException> { provider.screen(request) }
+    }
+}


### PR DESCRIPTION
Fourth slice of E-04 Compliance (#264). Unblocks #240 SandboxSanctionsProvider.

## What
- `SanctionsProvider` port (interface-only, clean-room) in `com.fincore.compliance.application.sanctions`, mirroring KycProvider (#263): `screen(request): SanctionsScreeningResult`.
- `SanctionsScreeningRequest(subjectReference, attributes: Set<String>, requiredMatches)` - a generic **m-of-n partial-match** contract: screen N attribute-key dimensions, flag a potential hit when at least m match. The request carries **keys only, no values** (zero PII surface); the provider resolves subject data out of tree by the opaque `subjectReference`. The m threshold is caller-configurable (not a hardcoded business value).
- `SanctionsScreeningResult` sealed: `Clear`, `PotentialMatch(matchedAttributes, score)` (bounded confidence in [0,1] via named consts), `InsufficientData(missing)` (§5.1 typed contract). Matched/missing keys are generic, never PII.
- `SanctionsProviderException` for technical/transient failures.
- No in-tree implementation (sandbox is #240); no Spring, no persistence.

## Clean-room (§5.3.1)
No real sanctions lists, PEP data, provider names, entry formats, or business thresholds. The epic's highest §5.3 risk - audited clean.

## Gate chain
- critic: GO-WITH-CHANGES (neutral keys, out-of-tree resolution KDoc, score-semantics KDoc, keep InsufficientData + domain const reuse - applied).
- security-auditor (opus): PASS - clean-room clean, zero PII surface, caller-configurable threshold, 4/4 ACs.
- code-reviewer: APPROVED (2 optional coverage adds applied: NaN-score + exception-throw-path tests).
- evaluator: PASS (0.91).
All local gates green (test/detekt/spotless/assemble); 13 contract tests.

Closes #264