### PR TITLE
feat(compliance): add the kyc orchestration application layer

### DIFF
--- a/services/compliance/src/integrationTest/kotlin/com/fincore/compliance/application/kyc/KycServicePersistenceIT.kt
+++ b/services/compliance/src/integrationTest/kotlin/com/fincore/compliance/application/kyc/KycServicePersistenceIT.kt
@@ -15,6 +15,8 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
 import org.springframework.context.annotation.Import
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
 import org.springframework.transaction.annotation.Propagation
 import org.springframework.transaction.annotation.Transactional
 
@@ -49,5 +51,16 @@ class KycServicePersistenceIT(
         service.beginScreening(initiated.id)
 
         service.get(initiated.id).status shouldBe KycStatus.SCREENING
+    }
+
+    companion object {
+        @JvmStatic
+        @DynamicPropertySource
+        fun datasourceProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { PostgresContainerExtension.jdbcUrl }
+            registry.add("spring.datasource.username") { PostgresContainerExtension.username }
+            registry.add("spring.datasource.password") { PostgresContainerExtension.password }
+            registry.add("spring.jpa.hibernate.ddl-auto") { "none" }
+        }
     }
 }

--- a/services/compliance/src/integrationTest/kotlin/com/fincore/compliance/application/kyc/KycServicePersistenceIT.kt
+++ b/services/compliance/src/integrationTest/kotlin/com/fincore/compliance/application/kyc/KycServicePersistenceIT.kt
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.kyc
+
+import com.fincore.compliance.domain.enum.KycStatus
+import com.fincore.compliance.infrastructure.persistence.KycSessionPersistenceAdapter
+import com.fincore.compliance.infrastructure.persistence.KycSessionRepository
+import com.fincore.test.containers.PostgresContainerExtension
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@ExtendWith(PostgresContainerExtension::class)
+@Import(KycServiceImpl::class, KycSessionPersistenceAdapter::class)
+class KycServicePersistenceIT(
+    @Autowired private val service: KycService,
+    @Autowired private val repository: KycSessionRepository,
+) {
+    @AfterEach
+    fun cleanUp() {
+        repository.deleteAll()
+    }
+
+    @Test
+    fun `should initiate then get a session round-tripping through postgres`() {
+        val initiated = service.initiate(InitiateKycSessionCommand("subject-1"))
+
+        val reloaded = service.get(initiated.id)
+        reloaded.id shouldBe initiated.id
+        reloaded.subjectReference shouldBe "subject-1"
+        reloaded.status shouldBe KycStatus.INITIATED
+    }
+
+    @Test
+    fun `should persist the screening transition`() {
+        val initiated = service.initiate(InitiateKycSessionCommand("subject-2"))
+
+        service.beginScreening(initiated.id)
+
+        service.get(initiated.id).status shouldBe KycStatus.SCREENING
+    }
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/application/kyc/InitiateKycSessionCommand.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/application/kyc/InitiateKycSessionCommand.kt
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.kyc
+
+/** Command to start a KYC session. [subjectReference] is an opaque token (validated by the KycSession domain). */
+data class InitiateKycSessionCommand(
+    val subjectReference: String,
+)

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/application/kyc/KycOrchestrator.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/application/kyc/KycOrchestrator.kt
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.kyc
+
+import com.fincore.compliance.domain.KycSession
+import com.fincore.core.KycSessionId
+import org.springframework.stereotype.Service
+
+/**
+ * Drives an initiated KYC session through screening. NOT transactional: each persisted transition is its own short
+ * transaction on [KycService], and the external [KycProvider.check] runs between them, never inside a transaction
+ * (CLAUDE.md 8.10). A [KycProviderException] propagates and leaves the session in SCREENING for a future re-attempt.
+ *
+ * Concurrent process calls on the same session resolve via the entity's optimistic lock: the loser's
+ * OptimisticLockingFailureException propagates. Pending and InsufficientData leave the session in SCREENING (there is
+ * no PENDING status); a later re-screen advances it. The provider reference is not persisted in this slice.
+ */
+@Service
+class KycOrchestrator(
+    private val kycService: KycService,
+    private val kycProvider: KycProvider,
+) {
+    fun process(id: KycSessionId): KycSession {
+        val screening = kycService.beginScreening(id)
+        return when (kycProvider.check(KycCheckRequest(screening.subjectReference))) {
+            is KycCheckResult.Approved -> kycService.approve(id)
+            is KycCheckResult.Rejected -> kycService.reject(id)
+            is KycCheckResult.Pending, is KycCheckResult.InsufficientData -> screening
+        }
+    }
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/application/kyc/KycService.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/application/kyc/KycService.kt
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.kyc
+
+import com.fincore.compliance.domain.KycSession
+import com.fincore.core.KycSessionId
+
+interface KycService {
+    fun initiate(command: InitiateKycSessionCommand): KycSession
+
+    fun get(id: KycSessionId): KycSession
+
+    fun beginScreening(id: KycSessionId): KycSession
+
+    fun approve(id: KycSessionId): KycSession
+
+    fun reject(id: KycSessionId): KycSession
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/application/kyc/KycServiceImpl.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/application/kyc/KycServiceImpl.kt
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.kyc
+
+import com.fincore.compliance.domain.KycSession
+import com.fincore.compliance.domain.enum.KycStatus
+import com.fincore.compliance.infrastructure.persistence.KycSessionPersistenceAdapter
+import com.fincore.compliance.infrastructure.persistence.KycSessionRepository
+import com.fincore.core.KycSessionId
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+@Service
+class KycServiceImpl(
+    private val repository: KycSessionRepository,
+    private val adapter: KycSessionPersistenceAdapter,
+) : KycService {
+    @Transactional
+    override fun initiate(command: InitiateKycSessionCommand): KycSession {
+        val session = KycSession(KycSessionId.generate(), command.subjectReference)
+        repository.saveAndFlush(adapter.toNewEntity(session, Instant.now()))
+        return session
+    }
+
+    @Transactional(readOnly = true)
+    override fun get(id: KycSessionId): KycSession =
+        adapter.toDomain(repository.findById(id.value).orElseThrow { KycSessionNotFoundException(id) })
+
+    @Transactional
+    override fun beginScreening(id: KycSessionId): KycSession = transition(id, KycStatus.SCREENING)
+
+    @Transactional
+    override fun approve(id: KycSessionId): KycSession = transition(id, KycStatus.APPROVED)
+
+    @Transactional
+    override fun reject(id: KycSessionId): KycSession = transition(id, KycStatus.REJECTED)
+
+    private fun transition(
+        id: KycSessionId,
+        target: KycStatus,
+    ): KycSession {
+        val entity = repository.findById(id.value).orElseThrow { KycSessionNotFoundException(id) }
+        val session = adapter.toDomain(entity)
+        session.transitionTo(target)
+        entity.status = session.status
+        repository.saveAndFlush(entity)
+        return session
+    }
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/application/kyc/KycSessionNotFoundException.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/application/kyc/KycSessionNotFoundException.kt
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.kyc
+
+import com.fincore.core.KycSessionId
+
+class KycSessionNotFoundException(
+    id: KycSessionId,
+) : RuntimeException("KYC session not found: $id")

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/persistence/KycSessionPersistenceAdapter.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/persistence/KycSessionPersistenceAdapter.kt
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.infrastructure.persistence
+
+import com.fincore.compliance.domain.KycSession
+import com.fincore.core.KycSessionId
+import org.springframework.stereotype.Component
+import java.time.Instant
+
+// Hand-written because MapStruct cannot construct the value-class domain aggregate; the domain stays pure.
+@Component
+class KycSessionPersistenceAdapter {
+    fun toDomain(entity: KycSessionEntity): KycSession =
+        KycSession(
+            id = KycSessionId(entity.id),
+            subjectReference = entity.subjectReference,
+            status = entity.status,
+        )
+
+    fun toNewEntity(
+        session: KycSession,
+        now: Instant,
+    ): KycSessionEntity =
+        KycSessionEntity(
+            id = session.id.value,
+            subjectReference = session.subjectReference,
+            status = session.status,
+            createdAt = now,
+            version = 0,
+        )
+}

--- a/services/compliance/src/test/kotlin/com/fincore/compliance/application/kyc/KycOrchestratorTest.kt
+++ b/services/compliance/src/test/kotlin/com/fincore/compliance/application/kyc/KycOrchestratorTest.kt
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.kyc
+
+import com.fincore.compliance.domain.ComplianceDomainException
+import com.fincore.compliance.domain.KycSession
+import com.fincore.compliance.domain.enum.KycStatus
+import com.fincore.core.KycSessionId
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+
+class KycOrchestratorTest {
+    private val service = mockk<KycService>()
+    private val provider = mockk<KycProvider>()
+    private val orchestrator = KycOrchestrator(service, provider)
+
+    private val id = KycSessionId.generate()
+
+    @Test
+    fun `should approve when the provider approves`() {
+        screeningReturns()
+        every { provider.check(any()) } returns KycCheckResult.Approved("ref-1")
+        every { service.approve(id) } returns session(KycStatus.APPROVED)
+
+        orchestrator.process(id).status shouldBe KycStatus.APPROVED
+        verify { provider.check(any()) }
+    }
+
+    @Test
+    fun `should reject when the provider rejects`() {
+        screeningReturns()
+        every { provider.check(any()) } returns KycCheckResult.Rejected("declined")
+        every { service.reject(id) } returns session(KycStatus.REJECTED)
+
+        orchestrator.process(id).status shouldBe KycStatus.REJECTED
+    }
+
+    @Test
+    fun `should stay screening when the provider is pending`() {
+        screeningReturns()
+        every { provider.check(any()) } returns KycCheckResult.Pending("ref-2")
+
+        orchestrator.process(id).status shouldBe KycStatus.SCREENING
+        verify(exactly = 0) { service.approve(any()) }
+        verify(exactly = 0) { service.reject(any()) }
+    }
+
+    @Test
+    fun `should stay screening when the provider has insufficient data`() {
+        screeningReturns()
+        every { provider.check(any()) } returns KycCheckResult.InsufficientData(listOf("attr-a"))
+
+        orchestrator.process(id).status shouldBe KycStatus.SCREENING
+        verify(exactly = 0) { service.approve(any()) }
+        verify(exactly = 0) { service.reject(any()) }
+    }
+
+    @Test
+    fun `should propagate a provider exception`() {
+        screeningReturns()
+        every { provider.check(any()) } throws KycProviderException("upstream unavailable")
+
+        shouldThrow<KycProviderException> { orchestrator.process(id) }
+    }
+
+    @Test
+    fun `should propagate a domain exception when the session is already terminal at decision`() {
+        screeningReturns()
+        every { provider.check(any()) } returns KycCheckResult.Approved("ref-1")
+        every { service.approve(id) } throws ComplianceDomainException("illegal transition")
+
+        shouldThrow<ComplianceDomainException> { orchestrator.process(id) }
+    }
+
+    private fun screeningReturns() {
+        every { service.beginScreening(id) } returns session(KycStatus.SCREENING)
+    }
+
+    private fun session(status: KycStatus) = KycSession(id, "subject-1", status)
+}

--- a/services/compliance/src/test/kotlin/com/fincore/compliance/application/kyc/KycServiceImplTest.kt
+++ b/services/compliance/src/test/kotlin/com/fincore/compliance/application/kyc/KycServiceImplTest.kt
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.kyc
+
+import com.fincore.compliance.domain.ComplianceDomainException
+import com.fincore.compliance.domain.enum.KycStatus
+import com.fincore.compliance.infrastructure.persistence.KycSessionEntity
+import com.fincore.compliance.infrastructure.persistence.KycSessionPersistenceAdapter
+import com.fincore.compliance.infrastructure.persistence.KycSessionRepository
+import com.fincore.core.KycSessionId
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.Optional
+import java.util.UUID
+
+class KycServiceImplTest {
+    private val repository = mockk<KycSessionRepository>()
+    private val service = KycServiceImpl(repository, KycSessionPersistenceAdapter())
+
+    @Test
+    fun `should create an initiated session when initiating`() {
+        every { repository.saveAndFlush(any()) } answers { firstArg() }
+
+        val session = service.initiate(InitiateKycSessionCommand("subject-1"))
+
+        session.status shouldBe KycStatus.INITIATED
+        session.subjectReference shouldBe "subject-1"
+    }
+
+    @Test
+    fun `should throw not found when getting a missing session`() {
+        every { repository.findById(any()) } returns Optional.empty()
+
+        shouldThrow<KycSessionNotFoundException> { service.get(KycSessionId.generate()) }
+    }
+
+    @Test
+    fun `should move an initiated session to screening`() {
+        val id = KycSessionId.generate()
+        every { repository.findById(id.value) } returns Optional.of(entity(id.value, KycStatus.INITIATED))
+        val saved = slot<KycSessionEntity>()
+        every { repository.saveAndFlush(capture(saved)) } answers { firstArg() }
+
+        service.beginScreening(id).status shouldBe KycStatus.SCREENING
+        saved.captured.status shouldBe KycStatus.SCREENING
+    }
+
+    @Test
+    fun `should move a screening session to approved`() {
+        val id = KycSessionId.generate()
+        every { repository.findById(id.value) } returns Optional.of(entity(id.value, KycStatus.SCREENING))
+        every { repository.saveAndFlush(any()) } answers { firstArg() }
+
+        service.approve(id).status shouldBe KycStatus.APPROVED
+    }
+
+    @Test
+    fun `should move a screening session to rejected`() {
+        val id = KycSessionId.generate()
+        every { repository.findById(id.value) } returns Optional.of(entity(id.value, KycStatus.SCREENING))
+        every { repository.saveAndFlush(any()) } answers { firstArg() }
+
+        service.reject(id).status shouldBe KycStatus.REJECTED
+    }
+
+    @Test
+    fun `should reject an illegal transition`() {
+        val id = KycSessionId.generate()
+        every { repository.findById(id.value) } returns Optional.of(entity(id.value, KycStatus.INITIATED))
+
+        shouldThrow<ComplianceDomainException> { service.approve(id) }
+    }
+
+    private fun entity(
+        id: UUID,
+        status: KycStatus,
+    ) = KycSessionEntity(id, "subject-1", status, Instant.now(), 0)
+}

--- a/services/compliance/src/test/kotlin/com/fincore/compliance/application/kyc/KycSessionPersistenceAdapterTest.kt
+++ b/services/compliance/src/test/kotlin/com/fincore/compliance/application/kyc/KycSessionPersistenceAdapterTest.kt
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.kyc
+
+import com.fincore.compliance.domain.KycSession
+import com.fincore.compliance.domain.enum.KycStatus
+import com.fincore.compliance.infrastructure.persistence.KycSessionPersistenceAdapter
+import com.fincore.core.KycSessionId
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class KycSessionPersistenceAdapterTest {
+    private val adapter = KycSessionPersistenceAdapter()
+
+    @Test
+    fun `should round-trip a session through new entity and back`() {
+        val session = KycSession(KycSessionId.generate(), "subject-1")
+
+        val domain = adapter.toDomain(adapter.toNewEntity(session, Instant.now()))
+
+        domain.id shouldBe session.id
+        domain.subjectReference shouldBe "subject-1"
+        domain.status shouldBe KycStatus.INITIATED
+    }
+}


### PR DESCRIPTION
Fifth slice of E-04 Compliance (#265) - the KYC application layer. The web layer (REST + security + OpenAPI + Idempotency-Key) is split into #275.

## What
- `KycService` / `KycServiceImpl`: initiate (creates an INITIATED session), get, and the guarded status transitions (beginScreening / approve / reject). `@Transactional` only in the impl; each transition is its own short transaction enforcing the domain `transitionTo` guard. Repository + pure adapter directly (no store port), mirroring PaymentServiceImpl.
- `KycOrchestrator` (`@Service`, NOT `@Transactional`): `process` = beginScreening (tx) -> `KycProvider.check` **outside any transaction** (the E-02 invariant) -> map result: Approved -> approve, Rejected -> reject, Pending / InsufficientData -> stay SCREENING. A `KycProviderException` propagates, leaving the session SCREENING; concurrent `process` resolves via the entity `@Version` optimistic lock (documented).
- `KycSessionPersistenceAdapter`: pure hand mapper (value-class id <-> UUID), MapStruct can't build the value-class aggregate.
- Tests: adapter round-trip, service (initiate / get-not-found / each transition + illegal), orchestrator (all 4 provider variants + provider exception + already-terminal-at-decision), and a `@DataJpaTest` persistence IT (boots without a KycProvider bean - only the orchestrator depends on the provider).

## Architect split
#265 as ticketed bundled application + REST + security + idempotency. Per the E-02 precedent (#211/#213 service vs #216 web), split into this application slice + #275 (web). Keeps the module data-JPA-only here and each commit reviewable.

## Gate chain
- critic: GO-WITH-CHANGES (split validated; no store port, pure adapter, inline Instant.now(), documented optimistic-lock + already-terminal test, providerReference dropped - all applied).
- security-auditor (opus): PASS - clean-room clean, provider call outside tx, status machine sound, lost-update bounded by @Version, 4/4 ACs.
- code-reviewer: APPROVED (advisories applied: symmetric no-reject assertions; IT injects the interface).
- evaluator: PASS (0.892); plus the approve/reject happy-path unit tests added.
All local gates green; integrationTest runs on CI.

Closes #265