### PR TITLE
feat(compliance): expose the kyc rest api with oauth2 security

### DIFF
--- a/services/compliance/build.gradle.kts
+++ b/services/compliance/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
     alias(libs.plugins.spring.dependency.management)
 }
 
-description = "FinCore Compliance service: KYC, AML and case-management domain and persistence"
+description = "FinCore Compliance service: KYC, AML and case management"
 
 kotlin {
     jvmToolchain(21)
@@ -17,16 +17,31 @@ kotlin {
 
 dependencies {
     implementation(project(":libs:fincore-core"))
+    implementation(project(":libs:fincore-observability"))
 
     implementation(libs.kotlin.stdlib)
     implementation(libs.kotlin.reflect)
+    implementation(libs.jackson.module.kotlin)
 
+    implementation(libs.spring.boot.starter.web)
     implementation(libs.spring.boot.starter.data.jpa)
+    implementation(libs.spring.boot.starter.security)
+    implementation(libs.spring.boot.starter.oauth2.resource.server)
+    implementation(libs.spring.boot.starter.actuator)
+    implementation(libs.spring.boot.starter.validation)
+    implementation(libs.springdoc.openapi.starter)
+
     implementation(libs.liquibase.core)
     runtimeOnly(libs.postgres.jdbc)
 
+    implementation(libs.micrometer.registry.prometheus)
+    implementation(libs.micrometer.tracing.bridge.otel)
+    implementation(libs.opentelemetry.api)
+    implementation(libs.opentelemetry.exporter.otlp)
+
     testImplementation(project(":libs:fincore-test-support"))
     testImplementation(libs.spring.boot.starter.test)
+    testImplementation(libs.spring.security.test)
     testImplementation(libs.kotest.assertions.core)
     testImplementation(libs.kotest.runner.junit5)
     testImplementation(libs.mockk)

--- a/services/compliance/src/integrationTest/kotlin/com/fincore/compliance/api/KycApiContextIT.kt
+++ b/services/compliance/src/integrationTest/kotlin/com/fincore/compliance/api/KycApiContextIT.kt
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.api
+
+import com.fincore.compliance.application.kyc.KycCheckRequest
+import com.fincore.compliance.application.kyc.KycCheckResult
+import com.fincore.compliance.application.kyc.KycProvider
+import com.fincore.test.containers.PostgresContainerExtension
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ExtendWith(PostgresContainerExtension::class)
+@Import(KycApiContextIT.TestBeans::class)
+class KycApiContextIT(
+    @Autowired private val mockMvc: MockMvc,
+) {
+    @TestConfiguration
+    class TestBeans {
+        @Bean fun jwtDecoder(): JwtDecoder = mockk()
+
+        // No in-tree KycProvider yet (sandbox is #239); a fake satisfies the orchestrator's dependency so the
+        // full web context boots.
+        @Bean fun kycProvider(): KycProvider =
+            object : KycProvider {
+                override fun check(request: KycCheckRequest): KycCheckResult = KycCheckResult.Pending("ref-test")
+            }
+    }
+
+    @Test
+    fun `should serve the openapi document listing the kyc operations`() {
+        mockMvc
+            .perform(get("/v3/api-docs"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.paths['/v1/kyc/sessions']").exists())
+    }
+
+    @Test
+    fun `should initiate then get a session end to end through the web stack`() {
+        val location =
+            mockMvc
+                .perform(
+                    post("/v1/kyc/sessions")
+                        .with(jwt().authorities(SimpleGrantedAuthority(WRITE)))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""{"subjectReference":"subject-1"}"""),
+                ).andExpect(status().isCreated)
+                .andExpect(jsonPath("$.status").value("INITIATED"))
+                .andReturn()
+                .response
+                .getHeader("Location")
+
+        mockMvc
+            .perform(get(location!!).with(jwt().authorities(SimpleGrantedAuthority(READ))))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.subjectReference").value("subject-1"))
+    }
+
+    companion object {
+        private const val READ = "SCOPE_compliance:read"
+        private const val WRITE = "SCOPE_compliance:write"
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun properties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { PostgresContainerExtension.jdbcUrl }
+            registry.add("spring.datasource.username") { PostgresContainerExtension.username }
+            registry.add("spring.datasource.password") { PostgresContainerExtension.password }
+            registry.add("spring.jpa.hibernate.ddl-auto") { "none" }
+            registry.add("spring.security.oauth2.resourceserver.jwt.issuer-uri") { "https://issuer.test" }
+        }
+    }
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/api/KycController.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/api/KycController.kt
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.api
+
+import com.fincore.compliance.api.dto.request.CreateKycSessionRequest
+import com.fincore.compliance.api.dto.response.KycSessionResponse
+import com.fincore.compliance.api.mapper.KycApiMapper
+import com.fincore.compliance.application.kyc.KycService
+import com.fincore.core.KycSessionId
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.net.URI
+
+@Tag(name = "Compliance", description = "Start and read KYC sessions")
+@RestController
+@RequestMapping("/v1/kyc/sessions")
+class KycController(
+    private val kycService: KycService,
+    private val mapper: KycApiMapper,
+) {
+    @Operation(summary = "Start a KYC session", description = "Creates a session in the INITIATED state.")
+    @PostMapping
+    fun initiate(
+        @Valid @RequestBody request: CreateKycSessionRequest,
+    ): ResponseEntity<KycSessionResponse> {
+        val response = mapper.toResponse(kycService.initiate(mapper.toCommand(request)))
+        return ResponseEntity.created(URI.create("/v1/kyc/sessions/${response.id}")).body(response)
+    }
+
+    @Operation(summary = "Get a KYC session", description = "Returns the session or 404.")
+    @GetMapping("/{id}")
+    fun get(
+        @PathVariable id: String,
+    ): KycSessionResponse = mapper.toResponse(kycService.get(KycSessionId.fromString(id)))
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/api/dto/request/CreateKycSessionRequest.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/api/dto/request/CreateKycSessionRequest.kt
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.api.dto.request
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class CreateKycSessionRequest(
+    @field:NotBlank
+    @field:Size(max = 140)
+    val subjectReference: String,
+)

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/api/dto/response/KycSessionResponse.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/api/dto/response/KycSessionResponse.kt
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.api.dto.response
+
+data class KycSessionResponse(
+    val id: String,
+    val subjectReference: String,
+    val status: String,
+)

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/api/error/ProblemType.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/api/error/ProblemType.kt
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.api.error
+
+import org.springframework.http.HttpStatus
+import java.net.URI
+
+enum class ProblemType(
+    val slug: String,
+    val status: HttpStatus,
+    val code: String,
+    val title: String,
+) {
+    KYC_NOT_FOUND("kyc-session-not-found", HttpStatus.NOT_FOUND, "KYC_NOT_FOUND", "kyc session not found"),
+    KYC_CONFLICT("kyc-conflict", HttpStatus.CONFLICT, "KYC_CONFLICT", "illegal kyc state transition"),
+    VALIDATION_FAILED("validation-failed", HttpStatus.BAD_REQUEST, "VALIDATION_FAILED", "invalid request"),
+    MALFORMED_REQUEST("malformed-request", HttpStatus.BAD_REQUEST, "MALFORMED_REQUEST", "invalid request"),
+    INVALID_REQUEST("invalid-request", HttpStatus.BAD_REQUEST, "INVALID_REQUEST", "invalid request"),
+    INTERNAL_ERROR("internal-error", HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL_ERROR", "internal error"),
+    ;
+
+    val type: URI get() = URI.create(BASE_URI + slug)
+
+    companion object {
+        const val BASE_URI = "https://fincore.dev/errors/"
+    }
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/api/mapper/KycApiMapper.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/api/mapper/KycApiMapper.kt
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.api.mapper
+
+import com.fincore.compliance.api.dto.request.CreateKycSessionRequest
+import com.fincore.compliance.api.dto.response.KycSessionResponse
+import com.fincore.compliance.application.kyc.InitiateKycSessionCommand
+import com.fincore.compliance.domain.KycSession
+import org.springframework.stereotype.Component
+
+// Hand-written: the value-class KycSessionId crosses the wire as a prefixed-ULID string.
+@Component
+class KycApiMapper {
+    fun toCommand(request: CreateKycSessionRequest): InitiateKycSessionCommand =
+        InitiateKycSessionCommand(subjectReference = request.subjectReference)
+
+    fun toResponse(session: KycSession): KycSessionResponse =
+        KycSessionResponse(
+            id = session.id.toString(),
+            subjectReference = session.subjectReference,
+            status = session.status.name,
+        )
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/config/SecurityConfig.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/config/SecurityConfig.kt
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter
+import org.springframework.security.oauth2.server.resource.authentication.JwtGrantedAuthoritiesConverter
+import org.springframework.security.web.SecurityFilterChain
+
+@Configuration
+@EnableWebSecurity
+class SecurityConfig {
+    // Order matters (first match wins): public paths, then the GET read rule before the catch-all write rule.
+    @Bean
+    fun filterChain(http: HttpSecurity): SecurityFilterChain =
+        http
+            .csrf { it.disable() }
+            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            .authorizeHttpRequests {
+                it
+                    .requestMatchers(*PUBLIC_PATHS)
+                    .permitAll()
+                    .requestMatchers(HttpMethod.GET, KYC_PATHS)
+                    .hasAuthority(SCOPE_READ)
+                    .requestMatchers(KYC_PATHS)
+                    .hasAuthority(SCOPE_WRITE)
+                    .anyRequest()
+                    .authenticated()
+            }.oauth2ResourceServer { resource ->
+                resource.jwt { it.jwtAuthenticationConverter(jwtAuthenticationConverter()) }
+            }.build()
+
+    private fun jwtAuthenticationConverter(): JwtAuthenticationConverter =
+        JwtAuthenticationConverter().apply {
+            setJwtGrantedAuthoritiesConverter(JwtGrantedAuthoritiesConverter())
+        }
+
+    private companion object {
+        const val KYC_PATHS = "/v1/kyc/**"
+        const val SCOPE_READ = "SCOPE_compliance:read"
+        const val SCOPE_WRITE = "SCOPE_compliance:write"
+        val PUBLIC_PATHS =
+            arrayOf(
+                "/v3/api-docs/**",
+                "/swagger-ui/**",
+                "/swagger-ui.html",
+                "/actuator/health",
+                "/actuator/health/**",
+                "/actuator/prometheus",
+            )
+    }
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/exception/GlobalExceptionHandler.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/exception/GlobalExceptionHandler.kt
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.exception
+
+import com.fincore.compliance.api.error.ProblemType
+import com.fincore.compliance.application.kyc.KycSessionNotFoundException
+import com.fincore.compliance.domain.ComplianceDomainException
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.dao.OptimisticLockingFailureException
+import org.springframework.http.ProblemDetail
+import org.springframework.http.converter.HttpMessageNotReadableException
+import org.springframework.validation.FieldError
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import java.net.URI
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+    @ExceptionHandler(KycSessionNotFoundException::class)
+    fun handleNotFound(
+        ex: KycSessionNotFoundException,
+        request: HttpServletRequest,
+    ): ProblemDetail = problem(ProblemType.KYC_NOT_FOUND, ex.message, request)
+
+    @ExceptionHandler(ComplianceDomainException::class)
+    fun handleDomain(
+        ex: ComplianceDomainException,
+        request: HttpServletRequest,
+    ): ProblemDetail = problem(ProblemType.KYC_CONFLICT, ex.message, request)
+
+    @ExceptionHandler(OptimisticLockingFailureException::class)
+    fun handleOptimisticLock(request: HttpServletRequest): ProblemDetail =
+        problem(ProblemType.KYC_CONFLICT, "Concurrent update conflict", request)
+
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleValidation(
+        ex: MethodArgumentNotValidException,
+        request: HttpServletRequest,
+    ): ProblemDetail =
+        problem(ProblemType.VALIDATION_FAILED, "Request validation failed", request).apply {
+            setProperty("errors", ex.bindingResult.fieldErrors.map(::toFieldError))
+        }
+
+    @ExceptionHandler(HttpMessageNotReadableException::class)
+    fun handleUnreadable(request: HttpServletRequest): ProblemDetail =
+        problem(ProblemType.MALFORMED_REQUEST, "Request body is missing or malformed", request)
+
+    @ExceptionHandler(IllegalArgumentException::class)
+    fun handleIllegalArgument(
+        ex: IllegalArgumentException,
+        request: HttpServletRequest,
+    ): ProblemDetail = problem(ProblemType.INVALID_REQUEST, ex.message, request)
+
+    @ExceptionHandler(Exception::class)
+    fun handleUnexpected(request: HttpServletRequest): ProblemDetail =
+        problem(ProblemType.INTERNAL_ERROR, "An unexpected error occurred", request)
+
+    private fun toFieldError(error: FieldError): Map<String, String> =
+        mapOf("field" to error.field, "message" to (error.defaultMessage ?: "invalid"))
+
+    private fun problem(
+        type: ProblemType,
+        detail: String?,
+        request: HttpServletRequest,
+    ): ProblemDetail =
+        ProblemDetail.forStatusAndDetail(type.status, detail ?: type.title).apply {
+            this.title = type.title
+            this.type = type.type
+            this.instance = URI.create(request.requestURI)
+            setProperty("code", type.code)
+        }
+}

--- a/services/compliance/src/main/resources/application.yml
+++ b/services/compliance/src/main/resources/application.yml
@@ -1,8 +1,50 @@
+server:
+  port: 8080
+  shutdown: graceful
 spring:
   application:
     name: compliance
+  lifecycle:
+    timeout-per-shutdown-phase: 30s
   jpa:
     hibernate:
       ddl-auto: none
   liquibase:
     change-log: classpath:db/changelog/db.changelog-master.yaml
+  security:
+    oauth2:
+      resourceserver:
+        jwt:
+          issuer-uri: ${KEYCLOAK_ISSUER_URI}
+management:
+  endpoint:
+    health:
+      probes:
+        enabled: true
+      show-components: always
+      show-details: never
+      group:
+        liveness:
+          include: livenessState
+        readiness:
+          include: readinessState,db
+  endpoints:
+    web:
+      exposure:
+        include: health,info,prometheus
+  metrics:
+    distribution:
+      percentiles-histogram:
+        http.server.requests: true
+  tracing:
+    sampling:
+      probability: 0.1
+  otlp:
+    tracing:
+      endpoint: ${OTLP_TRACING_ENDPOINT:http://localhost:4318/v1/traces}
+logging:
+  structured:
+    format:
+      console: logstash
+    json:
+      customizer: com.fincore.observability.PiiMaskingMembersCustomizer

--- a/services/compliance/src/test/kotlin/com/fincore/compliance/api/KycControllerTest.kt
+++ b/services/compliance/src/test/kotlin/com/fincore/compliance/api/KycControllerTest.kt
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.api
+
+import com.fincore.compliance.api.mapper.KycApiMapper
+import com.fincore.compliance.application.kyc.KycService
+import com.fincore.compliance.application.kyc.KycSessionNotFoundException
+import com.fincore.compliance.config.SecurityConfig
+import com.fincore.compliance.domain.KycSession
+import com.fincore.compliance.exception.GlobalExceptionHandler
+import com.fincore.core.KycSessionId
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest(KycController::class)
+@Import(SecurityConfig::class, KycApiMapper::class, GlobalExceptionHandler::class, KycControllerTest.Mocks::class)
+class KycControllerTest(
+    @Autowired private val mockMvc: MockMvc,
+    @Autowired private val kycService: KycService,
+) {
+    @TestConfiguration
+    class Mocks {
+        @Bean fun kycService(): KycService = mockk()
+
+        @Bean fun jwtDecoder(): JwtDecoder = mockk()
+    }
+
+    @BeforeEach
+    fun resetMocks() {
+        clearMocks(kycService)
+    }
+
+    @Test
+    fun `should initiate and return 201 when authorized with write scope`() {
+        every { kycService.initiate(any()) } returns session()
+
+        mockMvc
+            .perform(
+                post("/v1/kyc/sessions")
+                    .with(jwt().authorities(SimpleGrantedAuthority(WRITE)))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(VALID_BODY),
+            ).andExpect(status().isCreated)
+            .andExpect(jsonPath("$.status").value("INITIATED"))
+    }
+
+    @Test
+    fun `should return 401 when initiating without a token`() {
+        mockMvc
+            .perform(post("/v1/kyc/sessions").contentType(MediaType.APPLICATION_JSON).content(VALID_BODY))
+            .andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    fun `should return 403 when initiating with only the read scope`() {
+        mockMvc
+            .perform(
+                post("/v1/kyc/sessions")
+                    .with(jwt().authorities(SimpleGrantedAuthority(READ)))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(VALID_BODY),
+            ).andExpect(status().isForbidden)
+    }
+
+    @Test
+    fun `should return 400 when the body is invalid`() {
+        mockMvc
+            .perform(
+                post("/v1/kyc/sessions")
+                    .with(jwt().authorities(SimpleGrantedAuthority(WRITE)))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content("""{"subjectReference":""}"""),
+            ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `should return the session when getting with read scope`() {
+        val session = session()
+        every { kycService.get(session.id) } returns session
+
+        mockMvc
+            .perform(get("/v1/kyc/sessions/${session.id}").with(jwt().authorities(SimpleGrantedAuthority(READ))))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value(session.id.toString()))
+    }
+
+    @Test
+    fun `should return 404 when getting an unknown session`() {
+        every { kycService.get(any()) } throws KycSessionNotFoundException(KycSessionId.generate())
+
+        mockMvc
+            .perform(get("/v1/kyc/sessions/${KycSessionId.generate()}").with(jwt().authorities(SimpleGrantedAuthority(READ))))
+            .andExpect(status().isNotFound)
+    }
+
+    private fun session(): KycSession = KycSession(KycSessionId.generate(), "subject-1")
+
+    private companion object {
+        const val READ = "SCOPE_compliance:read"
+        const val WRITE = "SCOPE_compliance:write"
+        const val VALID_BODY = """{"subjectReference":"subject-1"}"""
+    }
+}


### PR DESCRIPTION
Completes the KYC vertical of E-04 Compliance (#275, the web layer split from #265).

## What
- `KycController`: POST /v1/kyc/sessions (compliance:write, 201 + Location) and GET /{id} (compliance:read); thin methods, value-class id crosses the wire as a prefixed-ULID string via a hand `KycApiMapper`.
- `SecurityConfig`: OAuth2 resource server; GET /v1/kyc/** = compliance:read, mutating = compliance:write; public = swagger/api-docs + actuator health + prometheus; stateless, csrf disabled.
- RFC7807 `GlobalExceptionHandler` + `ProblemType`: not-found -> 404, illegal transition / optimistic-lock -> 409, validation / unreadable / bad id -> 400, fallback -> 500.
- `build.gradle.kts`: data-JPA -> full web (web/security/oauth2/actuator/validation/springdoc/micrometer/otel + observability). `application.yml`: oauth2 issuer-uri, management health/info/prometheus, structured logging + PII masking (keeps the Liquibase change-log).
- Tests: `@WebMvcTest` (201/401/403/200/404/400 scope cases, mock service + JwtDecoder) + a `@SpringBootTest` context IT (Testcontainers + fake `KycProvider` + mock JwtDecoder + `@DynamicPropertySource`) asserting the OpenAPI doc and an end-to-end POST+GET round-trip through Postgres.

## Notes
- Idempotency-Key dedup is a substantial separate concern -> split to **#277** (no false promise here; initiate is a plain create this slice).
- Mirrors the merged payments web layer (#216). Applied the #265 CI lesson: the context IT has its own `@DynamicPropertySource` + a fake provider bean (the orchestrator `@Service` needs one).

## Gate chain
- critic: GO (3 LOW care notes honored).
- security-auditor (opus): PASS - authz fails-closed, no public KYC data path, no PII in errors, 5/5 ACs.
- code-reviewer: 1 substantive must-fix adopted (end-to-end round-trip IT); 2 declined with payments-parity evidence.
- evaluator: PASS (0.87).
All local gates green; the context IT runs on CI.

Closes #275