### PR TITLE
feat(compliance): add the aml rules engine and rolling-window aggregator

### DIFF
--- a/services/compliance/build.gradle.kts
+++ b/services/compliance/build.gradle.kts
@@ -18,6 +18,7 @@ kotlin {
 dependencies {
     implementation(project(":libs:fincore-core"))
     implementation(project(":libs:fincore-observability"))
+    implementation(project(":libs:decision-engine"))
 
     implementation(libs.kotlin.stdlib)
     implementation(libs.kotlin.reflect)

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/application/aml/AmlDecision.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/application/aml/AmlDecision.kt
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.aml
+
+sealed interface AmlDecision {
+    data object Clear : AmlDecision
+
+    data class Flagged(
+        val reasonCodes: List<String>,
+    ) : AmlDecision
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/application/aml/AmlEvaluator.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/application/aml/AmlEvaluator.kt
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.aml
+
+import com.fincore.decision.domain.DecimalValue
+import com.fincore.decision.domain.DecisionRule
+import com.fincore.decision.domain.EvaluationInput
+import com.fincore.decision.domain.StringValue
+import com.fincore.decision.eval.RuleEvaluator
+import com.fincore.decision.parser.RuleParser
+import org.springframework.stereotype.Component
+
+/**
+ * Evaluates a transaction against the configured AML rule with the embedded decision engine. The rule is parsed
+ * fail-closed at construction, so an invalid rule fails startup rather than silently clearing.
+ */
+@Component
+class AmlEvaluator(
+    properties: AmlRulesProperties,
+) {
+    private val rule: DecisionRule = RuleParser().parse(properties.rule)
+    private val flagLabel: String = properties.flagLabel
+    private val evaluator = RuleEvaluator()
+
+    fun evaluate(view: AmlTransactionView): AmlDecision {
+        val input =
+            EvaluationInput(
+                mapOf(
+                    "amount" to DecimalValue(view.amount),
+                    "currency" to StringValue(view.currency),
+                    "subjectReference" to StringValue(view.subjectReference),
+                ),
+            )
+        val result = evaluator.evaluate(rule, input)
+        return if (result.matched && result.outcome?.label == flagLabel) {
+            AmlDecision.Flagged(result.outcome?.reasonCodes.orEmpty())
+        } else {
+            AmlDecision.Clear
+        }
+    }
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/application/aml/AmlObservation.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/application/aml/AmlObservation.kt
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.aml
+
+import java.math.BigDecimal
+import java.time.Instant
+
+data class AmlObservation(
+    val occurredAt: Instant,
+    val amount: BigDecimal,
+)

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/application/aml/AmlRulesProperties.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/application/aml/AmlRulesProperties.kt
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.aml
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "fincore.compliance.aml")
+data class AmlRulesProperties(
+    val rule: String = NEUTRAL_RULE,
+    val flagLabel: String = DEFAULT_FLAG_LABEL,
+) {
+    private companion object {
+        const val DEFAULT_FLAG_LABEL = "FLAG"
+
+        // Neutral default: always yields a non-flag label, so an unconfigured engine never flags. No business rule.
+        const val NEUTRAL_RULE =
+            """{"condition":{"attr":"amount","op":"gte","value":0},"outcome":{"label":"CLEAR"}}"""
+    }
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/application/aml/AmlTransactionView.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/application/aml/AmlTransactionView.kt
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.aml
+
+import java.math.BigDecimal
+import java.time.Instant
+
+/** Generic view of a transaction for AML evaluation. [subjectReference] is an opaque token, never raw PII. */
+data class AmlTransactionView(
+    val subjectReference: String,
+    val amount: BigDecimal,
+    val currency: String,
+    val occurredAt: Instant,
+)

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/application/aml/AmlWindow.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/application/aml/AmlWindow.kt
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.aml
+
+/**
+ * Aggregation windows. PER_TRANSACTION = the single most recent observation by occurrence time; MONTH = observations
+ * within the last 30 days; LIFETIME = all observations.
+ */
+enum class AmlWindow {
+    PER_TRANSACTION,
+    MONTH,
+    LIFETIME,
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/application/aml/RollingWindowAggregator.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/application/aml/RollingWindowAggregator.kt
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.aml
+
+import org.springframework.stereotype.Component
+import java.math.BigDecimal
+import java.time.Duration
+import java.time.Instant
+
+/** Generic count and sum of observations within an [AmlWindow]. No thresholds; the caller interprets the result. */
+@Component
+class RollingWindowAggregator {
+    fun aggregate(
+        observations: List<AmlObservation>,
+        window: AmlWindow,
+        now: Instant,
+    ): WindowAggregate {
+        val relevant =
+            when (window) {
+                AmlWindow.PER_TRANSACTION -> listOfNotNull(observations.maxByOrNull { it.occurredAt })
+                AmlWindow.MONTH -> {
+                    val cutoff = now.minus(MONTH_LOOKBACK)
+                    observations.filter { !it.occurredAt.isBefore(cutoff) }
+                }
+                AmlWindow.LIFETIME -> observations
+            }
+        return WindowAggregate(
+            count = relevant.size.toLong(),
+            total = relevant.fold(BigDecimal.ZERO) { acc, observation -> acc + observation.amount },
+        )
+    }
+
+    private companion object {
+        const val MONTH_LOOKBACK_DAYS = 30L
+        val MONTH_LOOKBACK: Duration = Duration.ofDays(MONTH_LOOKBACK_DAYS)
+    }
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/application/aml/WindowAggregate.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/application/aml/WindowAggregate.kt
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.aml
+
+import java.math.BigDecimal
+
+data class WindowAggregate(
+    val count: Long,
+    val total: BigDecimal,
+)

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/config/ComplianceConfig.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/config/ComplianceConfig.kt
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.config
+
+import com.fincore.compliance.application.aml.AmlRulesProperties
+import org.springframework.boot.context.properties.EnableConfigurationProperties
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+@EnableConfigurationProperties(AmlRulesProperties::class)
+class ComplianceConfig

--- a/services/compliance/src/test/kotlin/com/fincore/compliance/application/aml/AmlEvaluatorTest.kt
+++ b/services/compliance/src/test/kotlin/com/fincore/compliance/application/aml/AmlEvaluatorTest.kt
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.aml
+
+import com.fincore.decision.domain.DecisionDslException
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Instant
+
+class AmlEvaluatorTest {
+    private fun view(amount: BigDecimal) = AmlTransactionView("subject-1", amount, "USD", Instant.now())
+
+    @Test
+    fun `should clear with the neutral default rule for a positive amount`() {
+        val evaluator = AmlEvaluator(AmlRulesProperties())
+
+        evaluator.evaluate(view(BigDecimal("100.00"))) shouldBe AmlDecision.Clear
+    }
+
+    @Test
+    fun `should clear with the neutral default rule for a negative amount`() {
+        val evaluator = AmlEvaluator(AmlRulesProperties())
+
+        evaluator.evaluate(view(BigDecimal("-1.00"))) shouldBe AmlDecision.Clear
+    }
+
+    @Test
+    fun `should flag when the configured rule yields the flag label`() {
+        val rule = """{"condition":{"attr":"amount","op":"gte","value":0},"outcome":{"label":"FLAG","reasonCodes":["R1"]}}"""
+        val evaluator = AmlEvaluator(AmlRulesProperties(rule = rule, flagLabel = "FLAG"))
+
+        val decision = evaluator.evaluate(view(BigDecimal("100.00")))
+
+        decision.shouldBeInstanceOf<AmlDecision.Flagged>().reasonCodes shouldBe listOf("R1")
+    }
+
+    @Test
+    fun `should clear when the rule does not match`() {
+        val rule = """{"condition":{"attr":"amount","op":"gte","value":1000000},"outcome":{"label":"FLAG"}}"""
+        val evaluator = AmlEvaluator(AmlRulesProperties(rule = rule, flagLabel = "FLAG"))
+
+        evaluator.evaluate(view(BigDecimal("1.00"))) shouldBe AmlDecision.Clear
+    }
+
+    @Test
+    fun `should clear when the rule matches but its label is not the flag label`() {
+        val rule = """{"condition":{"attr":"amount","op":"gte","value":0},"outcome":{"label":"WARN"}}"""
+        val evaluator = AmlEvaluator(AmlRulesProperties(rule = rule, flagLabel = "FLAG"))
+
+        evaluator.evaluate(view(BigDecimal("100.00"))) shouldBe AmlDecision.Clear
+    }
+
+    @Test
+    fun `should fail closed when the configured rule is invalid`() {
+        shouldThrow<DecisionDslException> { AmlEvaluator(AmlRulesProperties(rule = "not-json")) }
+    }
+}

--- a/services/compliance/src/test/kotlin/com/fincore/compliance/application/aml/AmlRollingWindowAggregatorTest.kt
+++ b/services/compliance/src/test/kotlin/com/fincore/compliance/application/aml/AmlRollingWindowAggregatorTest.kt
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.aml
+
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import java.math.BigDecimal
+import java.time.Duration
+import java.time.Instant
+
+class AmlRollingWindowAggregatorTest {
+    private val aggregator = RollingWindowAggregator()
+    private val now = Instant.parse("2026-06-19T00:00:00Z")
+
+    private fun obs(
+        daysAgo: Long,
+        amount: String,
+    ) = AmlObservation(now.minus(Duration.ofDays(daysAgo)), BigDecimal(amount))
+
+    @Test
+    fun `should return zero count and total for empty observations`() {
+        val result = aggregator.aggregate(emptyList(), AmlWindow.LIFETIME, now)
+
+        result.count shouldBe 0L
+        result.total shouldBe BigDecimal.ZERO
+    }
+
+    @Test
+    fun `should sum all observations over the lifetime window`() {
+        val result = aggregator.aggregate(listOf(obs(1, "10"), obs(400, "5")), AmlWindow.LIFETIME, now)
+
+        result.count shouldBe 2L
+        result.total shouldBe BigDecimal("15")
+    }
+
+    @Test
+    fun `should include the boundary and exclude older over the month window`() {
+        val result = aggregator.aggregate(listOf(obs(30, "10"), obs(31, "5")), AmlWindow.MONTH, now)
+
+        result.count shouldBe 1L
+        result.total shouldBe BigDecimal("10")
+    }
+
+    @Test
+    fun `should take the most recent observation by time for per transaction regardless of order`() {
+        val result = aggregator.aggregate(listOf(obs(5, "5"), obs(1, "9"), obs(10, "10")), AmlWindow.PER_TRANSACTION, now)
+
+        result.count shouldBe 1L
+        result.total shouldBe BigDecimal("9")
+    }
+}


### PR DESCRIPTION
E-04 Compliance #266 - generic AML building blocks (the event consumer that composes them is #267).

## What
- **AmlEvaluator** (`@Component`): embeds the decision-engine lib in-process (like payments screening), parses the configured rule **fail-closed at construction**, and maps a match on the configured `flagLabel` to `Flagged(reasonCodes)`, else `Clear`. The default rule is **neutral** (always yields CLEAR != flagLabel) so an unconfigured engine never flags - no business logic baked in.
- **RollingWindowAggregator** (pure `@Component`): generic count + BigDecimal sum over `PER_TRANSACTION` (most recent by time), `MONTH` (>= now-30d, boundary inclusive) and `LIFETIME` windows. No thresholds - the caller interprets the result.
- Value types (`AmlTransactionView`, `AmlDecision`, `AmlObservation`, `WindowAggregate`, `AmlWindow`), `AmlRulesProperties` + `ComplianceConfig` (@EnableConfigurationProperties), decision-engine added as a project dependency.

## Clean-room (§5.3.1)
No real AML rules, thresholds, score-bands, lists, PEP, or foreign IP. Generic attributes (amount/currency/subjectReference) + neutral labels (CLEAR/FLAG). subjectReference opaque.

## Gate chain
- critic: GO-WITH-CHANGES (ComplianceConfig binding, neutral-label inertness + tests, 30 named const, per-tx by-time - all applied).
- security-auditor (opus): PASS - the epic's highest §5.3 risk, audited clean; BigDecimal money; fail-closed; 4/4 ACs.
- code-reviewer: 2 must-fix applied (specific `DecisionDslException` in the fail-closed test; a label-discriminator test).
- evaluator: PASS (0.90).
All local gates green; pure unit tests (no new IT).

Closes #266