### PR TITLE
feat(compliance): consume ledger transactions and raise aml alerts

### DIFF
--- a/services/compliance/build.gradle.kts
+++ b/services/compliance/build.gradle.kts
@@ -17,6 +17,8 @@ kotlin {
 
 dependencies {
     implementation(project(":libs:fincore-core"))
+    implementation(project(":libs:fincore-events"))
+    implementation(project(":libs:fincore-eventbus"))
     implementation(project(":libs:fincore-observability"))
     implementation(project(":libs:decision-engine"))
 
@@ -48,6 +50,7 @@ dependencies {
     testImplementation(libs.mockk)
     testImplementation(libs.testcontainers.core)
     testImplementation(libs.testcontainers.postgres)
+    testImplementation(libs.testcontainers.redpanda)
     testImplementation(libs.testcontainers.junit5)
 }
 

--- a/services/compliance/src/integrationTest/kotlin/com/fincore/compliance/api/KycApiContextIT.kt
+++ b/services/compliance/src/integrationTest/kotlin/com/fincore/compliance/api/KycApiContextIT.kt
@@ -88,6 +88,8 @@ class KycApiContextIT(
             registry.add("spring.datasource.password") { PostgresContainerExtension.password }
             registry.add("spring.jpa.hibernate.ddl-auto") { "none" }
             registry.add("spring.security.oauth2.resourceserver.jwt.issuer-uri") { "https://issuer.test" }
+            // This context does not exercise the AML consumer; keep the Kafka listener from polling an absent broker.
+            registry.add("spring.kafka.listener.auto-startup") { "false" }
         }
     }
 }

--- a/services/compliance/src/integrationTest/kotlin/com/fincore/compliance/infrastructure/messaging/AmlConsumerIT.kt
+++ b/services/compliance/src/integrationTest/kotlin/com/fincore/compliance/infrastructure/messaging/AmlConsumerIT.kt
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.infrastructure.messaging
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fincore.compliance.application.kyc.KycCheckRequest
+import com.fincore.compliance.application.kyc.KycCheckResult
+import com.fincore.compliance.application.kyc.KycProvider
+import com.fincore.compliance.infrastructure.persistence.AmlAlertRepository
+import com.fincore.events.EventEnvelope
+import com.fincore.events.LedgerEvents
+import com.fincore.test.containers.PostgresContainerExtension
+import com.fincore.test.containers.RedpandaContainerExtension
+import io.kotest.matchers.shouldBe
+import io.mockk.mockk
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import java.time.Instant
+
+@SpringBootTest
+@ExtendWith(PostgresContainerExtension::class, RedpandaContainerExtension::class)
+@Import(AmlConsumerIT.TestBeans::class)
+class AmlConsumerIT(
+    @Autowired private val kafkaTemplate: KafkaTemplate<String, String>,
+    @Autowired private val objectMapper: ObjectMapper,
+    @Autowired private val amlAlerts: AmlAlertRepository,
+) {
+    @TestConfiguration
+    class TestBeans {
+        @Bean fun jwtDecoder(): JwtDecoder = mockk()
+
+        @Bean fun kycProvider(): KycProvider =
+            object : KycProvider {
+                override fun check(request: KycCheckRequest): KycCheckResult = KycCheckResult.Pending("ref-test")
+            }
+    }
+
+    @AfterEach
+    fun cleanUp() {
+        amlAlerts.deleteAll()
+    }
+
+    @Test
+    fun `should raise an alert when a posted transaction is consumed`() {
+        val transactionId = "tx_consume_1"
+
+        publish(envelopeJson(transactionId))
+
+        awaitAlertCount(transactionId, 1)
+    }
+
+    @Test
+    fun `should raise only one alert for a duplicate envelope`() {
+        val transactionId = "tx_dedupe_1"
+        val json = envelopeJson(transactionId)
+
+        publish(json)
+        publish(json)
+
+        awaitAlertCount(transactionId, 1)
+        // Let the duplicate be consumed and skipped, then confirm no second alert appeared.
+        Thread.sleep(SETTLE_MS)
+        amlAlerts.findBySubjectReference(transactionId).size shouldBe 1
+    }
+
+    private fun publish(json: String) {
+        kafkaTemplate.send(TOPIC, json).get()
+    }
+
+    private fun awaitAlertCount(
+        subjectReference: String,
+        expected: Int,
+    ) {
+        val deadline = System.currentTimeMillis() + AWAIT_TIMEOUT_MS
+        while (System.currentTimeMillis() < deadline &&
+            amlAlerts.findBySubjectReference(subjectReference).size < expected
+        ) {
+            Thread.sleep(POLL_INTERVAL_MS)
+        }
+        amlAlerts.findBySubjectReference(subjectReference).size shouldBe expected
+    }
+
+    private fun envelopeJson(transactionId: String): String {
+        val envelope =
+            EventEnvelope.of(
+                source = "ledger-service",
+                type = LedgerEvents.TransactionPosted,
+                data =
+                    LedgerTransactionPosted(
+                        transactionId = transactionId,
+                        reference = "order-1",
+                        currency = "USD",
+                        postedAt = Instant.now(),
+                        entries = listOf(LedgerEntryLine("acc_1", "DEBIT", "100.00")),
+                    ),
+            )
+        return objectMapper.writeValueAsString(envelope)
+    }
+
+    companion object {
+        private const val TOPIC = "fincore.transaction"
+        private const val AWAIT_TIMEOUT_MS = 15_000L
+        private const val POLL_INTERVAL_MS = 250L
+        private const val SETTLE_MS = 2_000L
+        private const val FLAGGING_RULE =
+            """{"condition":{"attr":"amount","op":"gte","value":0},"outcome":{"label":"FLAG","reasonCodes":["aml.test"]}}"""
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun properties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { PostgresContainerExtension.jdbcUrl }
+            registry.add("spring.datasource.username") { PostgresContainerExtension.username }
+            registry.add("spring.datasource.password") { PostgresContainerExtension.password }
+            registry.add("spring.jpa.hibernate.ddl-auto") { "none" }
+            registry.add("spring.kafka.bootstrap-servers") { RedpandaContainerExtension.bootstrapServers }
+            // Producer config is test-only: the service consumes; the test publishes the input events.
+            registry.add("spring.kafka.producer.key-serializer") { "org.apache.kafka.common.serialization.StringSerializer" }
+            registry.add("spring.kafka.producer.value-serializer") { "org.apache.kafka.common.serialization.StringSerializer" }
+            registry.add("spring.security.oauth2.resourceserver.jwt.issuer-uri") { "https://issuer.test" }
+            registry.add("fincore.compliance.aml.rule") { FLAGGING_RULE }
+            registry.add("fincore.compliance.aml.flag-label") { "FLAG" }
+        }
+    }
+}

--- a/services/compliance/src/integrationTest/kotlin/com/fincore/compliance/infrastructure/persistence/ComplianceSchemaPersistenceIT.kt
+++ b/services/compliance/src/integrationTest/kotlin/com/fincore/compliance/infrastructure/persistence/ComplianceSchemaPersistenceIT.kt
@@ -52,7 +52,9 @@ class ComplianceSchemaPersistenceIT(
 
     @Test
     fun `should find aml alerts by status`() {
-        amlAlerts.saveAndFlush(AmlAlertEntity(UUID.randomUUID(), "aml.velocity", AmlAlertStatus.OPEN, Instant.now(), 0L))
+        amlAlerts.saveAndFlush(
+            AmlAlertEntity(UUID.randomUUID(), "aml.velocity", "subject-1", AmlAlertStatus.OPEN, Instant.now(), 0L),
+        )
 
         amlAlerts.findByStatus(AmlAlertStatus.OPEN).size shouldBe 1
     }

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/application/aml/AmlEventHandler.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/application/aml/AmlEventHandler.kt
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.aml
+
+import com.fincore.compliance.domain.enum.AmlAlertStatus
+import com.fincore.compliance.infrastructure.messaging.LedgerTransactionPosted
+import com.fincore.compliance.infrastructure.persistence.AmlAlertEntity
+import com.fincore.compliance.infrastructure.persistence.AmlAlertRepository
+import com.fincore.eventbus.consumer.IdempotentEventProcessor
+import com.fincore.events.EventEnvelope
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Handles a ledger TransactionPosted event for AML: deduplicated by envelope id within one transaction, so a thrown
+ * handler rolls back the claim and the event is retried. Raises an AmlAlert when the evaluator flags the transaction.
+ * No external call runs inside the transaction.
+ */
+@Service
+class AmlEventHandler(
+    private val processor: IdempotentEventProcessor,
+    private val evaluator: AmlEvaluator,
+    private val amlAlerts: AmlAlertRepository,
+) {
+    @Transactional
+    fun handle(envelope: EventEnvelope<LedgerTransactionPosted>) {
+        processor.process(envelope.id, CONSUMER_GROUP) {
+            val view = toView(envelope.data)
+            val decision = evaluator.evaluate(view)
+            if (decision is AmlDecision.Flagged) {
+                amlAlerts.saveAndFlush(
+                    AmlAlertEntity(
+                        id = UUID.randomUUID(),
+                        ruleKey = decision.reasonCodes.firstOrNull()?.takeIf { it.isNotBlank() } ?: DEFAULT_RULE_KEY,
+                        subjectReference = view.subjectReference,
+                        status = AmlAlertStatus.OPEN,
+                        createdAt = Instant.now(),
+                        version = 0,
+                    ),
+                )
+            }
+        }
+    }
+
+    private fun toView(payload: LedgerTransactionPosted): AmlTransactionView =
+        AmlTransactionView(
+            subjectReference = payload.transactionId,
+            amount =
+                payload.entries
+                    .filter { it.direction == DEBIT }
+                    .fold(BigDecimal.ZERO) { acc, line -> acc + BigDecimal(line.amount) },
+            currency = payload.currency,
+            occurredAt = payload.postedAt,
+        )
+
+    private companion object {
+        const val CONSUMER_GROUP = "compliance-aml"
+        const val DEBIT = "DEBIT"
+        const val DEFAULT_RULE_KEY = "aml.rule"
+    }
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/config/EventConsumerConfig.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/config/EventConsumerConfig.kt
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.config
+
+import com.fincore.eventbus.consumer.IdempotentEventProcessor
+import com.fincore.eventbus.consumer.JdbcProcessedEventStore
+import com.fincore.eventbus.consumer.ProcessedEventStore
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.jdbc.core.JdbcTemplate
+
+@Configuration
+class EventConsumerConfig {
+    @Bean
+    fun processedEventStore(jdbcTemplate: JdbcTemplate): ProcessedEventStore = JdbcProcessedEventStore(jdbcTemplate)
+
+    @Bean
+    fun idempotentEventProcessor(store: ProcessedEventStore): IdempotentEventProcessor = IdempotentEventProcessor(store)
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/messaging/AmlTransactionConsumer.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/messaging/AmlTransactionConsumer.kt
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.infrastructure.messaging
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fincore.compliance.application.aml.AmlEventHandler
+import com.fincore.events.EventEnvelope
+import com.fincore.events.LedgerEvents
+import org.springframework.kafka.annotation.KafkaListener
+import org.springframework.stereotype.Component
+
+/**
+ * Subscribes to the ledger transaction topic and forwards posted transactions to the AML handler. The topic also
+ * carries other Transaction events, so only TransactionPosted is handled; everything else is ignored.
+ */
+@Component
+class AmlTransactionConsumer(
+    private val objectMapper: ObjectMapper,
+    private val handler: AmlEventHandler,
+) {
+    @KafkaListener(topics = ["fincore.transaction"], groupId = "compliance-aml")
+    fun onMessage(payload: String) {
+        val envelope = objectMapper.readValue(payload, ENVELOPE_TYPE)
+        if (envelope.type == LedgerEvents.TransactionPosted.fullType) {
+            handler.handle(envelope)
+        }
+    }
+
+    private companion object {
+        val ENVELOPE_TYPE = object : TypeReference<EventEnvelope<LedgerTransactionPosted>>() {}
+    }
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/messaging/LedgerTransactionPosted.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/messaging/LedgerTransactionPosted.kt
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.infrastructure.messaging
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import java.time.Instant
+
+// Compliance's own view of the ledger transaction-posted wire payload; the JSON contract is the boundary, not a
+// shared class (services do not depend on each other). Unknown fields are ignored for forward compatibility.
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class LedgerEntryLine(
+    val accountId: String,
+    val direction: String,
+    val amount: String,
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class LedgerTransactionPosted(
+    val transactionId: String,
+    val reference: String,
+    val currency: String,
+    val postedAt: Instant,
+    val entries: List<LedgerEntryLine>,
+)

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/persistence/AmlAlertEntity.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/persistence/AmlAlertEntity.kt
@@ -22,6 +22,8 @@ class AmlAlertEntity(
     var id: UUID,
     @Column(name = "rule_key", nullable = false, updatable = false)
     var ruleKey: String,
+    @Column(name = "subject_reference", nullable = false, updatable = false)
+    var subjectReference: String,
     @Enumerated(EnumType.STRING)
     @Column(name = "status", nullable = false)
     var status: AmlAlertStatus,

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/persistence/AmlAlertRepository.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/persistence/AmlAlertRepository.kt
@@ -9,4 +9,6 @@ import java.util.UUID
 
 interface AmlAlertRepository : JpaRepository<AmlAlertEntity, UUID> {
     fun findByStatus(status: AmlAlertStatus): List<AmlAlertEntity>
+
+    fun findBySubjectReference(subjectReference: String): List<AmlAlertEntity>
 }

--- a/services/compliance/src/main/resources/application.yml
+++ b/services/compliance/src/main/resources/application.yml
@@ -11,6 +11,13 @@ spring:
       ddl-auto: none
   liquibase:
     change-log: classpath:db/changelog/db.changelog-master.yaml
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+    consumer:
+      group-id: compliance-aml
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
   security:
     oauth2:
       resourceserver:

--- a/services/compliance/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/compliance/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -16,3 +16,9 @@ databaseChangeLog:
   - include:
       file: v0.1/013-aml-rules.sql
       relativeToChangelogFile: true
+  - include:
+      file: v0.1/020-processed-events.sql
+      relativeToChangelogFile: true
+  - include:
+      file: v0.1/021-aml-alerts-subject-reference.sql
+      relativeToChangelogFile: true

--- a/services/compliance/src/main/resources/db/changelog/v0.1/020-processed-events.sql
+++ b/services/compliance/src/main/resources/db/changelog/v0.1/020-processed-events.sql
@@ -1,0 +1,14 @@
+--liquibase formatted sql
+-- SPDX-License-Identifier: BUSL-1.1
+-- SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+-- Consumer dedup ledger for JdbcProcessedEventStore. Lives in the default (public) schema, unqualified, because the
+-- store's table-name guard forbids a schema-qualified name; create and runtime insert must resolve to the same schema,
+-- so do NOT set a connection currentSchema / hibernate default_schema for this service.
+--changeset fincore:compliance-020-processed-events dbms:postgresql
+CREATE TABLE IF NOT EXISTS processed_events (
+    envelope_id    UUID         NOT NULL,
+    consumer_group VARCHAR(120) NOT NULL,
+    processed_at   TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    CONSTRAINT pk_processed_events PRIMARY KEY (envelope_id, consumer_group)
+);

--- a/services/compliance/src/main/resources/db/changelog/v0.1/021-aml-alerts-subject-reference.sql
+++ b/services/compliance/src/main/resources/db/changelog/v0.1/021-aml-alerts-subject-reference.sql
@@ -1,0 +1,11 @@
+--liquibase formatted sql
+-- SPDX-License-Identifier: BUSL-1.1
+-- SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+-- No column default: aml_alerts is insert-only and every alert is written with its subject reference, so a blank
+-- value is never valid (no default to silently poison the column).
+--changeset fincore:compliance-021-aml-alerts-subject-reference dbms:postgresql
+ALTER TABLE compliance.aml_alerts
+    ADD COLUMN IF NOT EXISTS subject_reference VARCHAR(140) NOT NULL;
+
+CREATE INDEX IF NOT EXISTS ix_aml_alerts_subject_reference ON compliance.aml_alerts (subject_reference);

--- a/services/compliance/src/test/kotlin/com/fincore/compliance/application/aml/AmlEventHandlerTest.kt
+++ b/services/compliance/src/test/kotlin/com/fincore/compliance/application/aml/AmlEventHandlerTest.kt
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.aml
+
+import com.fincore.compliance.infrastructure.messaging.LedgerEntryLine
+import com.fincore.compliance.infrastructure.messaging.LedgerTransactionPosted
+import com.fincore.compliance.infrastructure.persistence.AmlAlertEntity
+import com.fincore.compliance.infrastructure.persistence.AmlAlertRepository
+import com.fincore.eventbus.consumer.IdempotentEventProcessor
+import com.fincore.eventbus.consumer.InMemoryProcessedEventStore
+import com.fincore.events.EventEnvelope
+import com.fincore.events.LedgerEvents
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class AmlEventHandlerTest {
+    private val evaluator = mockk<AmlEvaluator>()
+    private val alerts = mockk<AmlAlertRepository>(relaxed = true)
+    private val processor = IdempotentEventProcessor(InMemoryProcessedEventStore())
+    private val handler = AmlEventHandler(processor, evaluator, alerts)
+
+    @Test
+    fun `should raise an alert carrying the subject when the evaluator flags`() {
+        every { evaluator.evaluate(any()) } returns AmlDecision.Flagged(listOf("aml.velocity"))
+        val saved = slot<AmlAlertEntity>()
+        every { alerts.saveAndFlush(capture(saved)) } answers { firstArg() }
+
+        handler.handle(envelope("tx_1"))
+
+        saved.captured.subjectReference shouldBe "tx_1"
+        saved.captured.ruleKey shouldBe "aml.velocity"
+    }
+
+    @Test
+    fun `should not raise an alert when the evaluator clears`() {
+        every { evaluator.evaluate(any()) } returns AmlDecision.Clear
+
+        handler.handle(envelope("tx_2"))
+
+        verify(exactly = 0) { alerts.saveAndFlush(any()) }
+    }
+
+    @Test
+    fun `should sum only the debit entries into the evaluated amount`() {
+        val view = slot<AmlTransactionView>()
+        every { evaluator.evaluate(capture(view)) } returns AmlDecision.Clear
+
+        handler.handle(envelope("tx_3"))
+
+        view.captured.amount shouldBe java.math.BigDecimal("100.00")
+    }
+
+    @Test
+    fun `should skip a duplicate envelope`() {
+        every { evaluator.evaluate(any()) } returns AmlDecision.Flagged(listOf("aml.velocity"))
+        every { alerts.saveAndFlush(any()) } answers { firstArg() }
+        val duplicate = envelope("tx_4")
+
+        handler.handle(duplicate)
+        handler.handle(duplicate)
+
+        verify(exactly = 1) { alerts.saveAndFlush(any()) }
+    }
+
+    private fun envelope(transactionId: String): EventEnvelope<LedgerTransactionPosted> =
+        EventEnvelope.of(
+            source = "ledger-service",
+            type = LedgerEvents.TransactionPosted,
+            data =
+                LedgerTransactionPosted(
+                    transactionId = transactionId,
+                    reference = "order-1",
+                    currency = "USD",
+                    postedAt = Instant.now(),
+                    entries =
+                        listOf(
+                            LedgerEntryLine("acc_1", "DEBIT", "100.00"),
+                            LedgerEntryLine("acc_2", "CREDIT", "-100.00"),
+                        ),
+                ),
+        )
+}

--- a/services/compliance/src/test/kotlin/com/fincore/compliance/infrastructure/messaging/AmlTransactionConsumerTest.kt
+++ b/services/compliance/src/test/kotlin/com/fincore/compliance/infrastructure/messaging/AmlTransactionConsumerTest.kt
@@ -1,0 +1,63 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.infrastructure.messaging
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import com.fincore.compliance.application.aml.AmlEventHandler
+import com.fincore.events.EventEnvelope
+import com.fincore.events.EventType
+import com.fincore.events.LedgerEvents
+import io.kotest.matchers.shouldBe
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class AmlTransactionConsumerTest {
+    private val mapper = ObjectMapper().registerKotlinModule().registerModule(JavaTimeModule())
+    private val handler = mockk<AmlEventHandler>(relaxed = true)
+    private val consumer = AmlTransactionConsumer(mapper, handler)
+
+    @Test
+    fun `should deserialize a typed payload and forward a transaction-posted event`() {
+        val captured = slot<EventEnvelope<LedgerTransactionPosted>>()
+        every { handler.handle(capture(captured)) } just Runs
+
+        consumer.onMessage(mapper.writeValueAsString(envelope(LedgerEvents.TransactionPosted)))
+
+        captured.captured.data.transactionId shouldBe "tx_1"
+        captured.captured.data.entries.size shouldBe 2
+    }
+
+    @Test
+    fun `should ignore a non transaction-posted event on the same topic`() {
+        consumer.onMessage(mapper.writeValueAsString(envelope(LedgerEvents.TransactionReversed)))
+
+        verify(exactly = 0) { handler.handle(any()) }
+    }
+
+    private fun envelope(type: EventType): EventEnvelope<LedgerTransactionPosted> =
+        EventEnvelope.of(
+            source = "ledger-service",
+            type = type,
+            data =
+                LedgerTransactionPosted(
+                    transactionId = "tx_1",
+                    reference = "order-1",
+                    currency = "USD",
+                    postedAt = Instant.parse("2026-06-19T00:00:00Z"),
+                    entries =
+                        listOf(
+                            LedgerEntryLine("acc_1", "DEBIT", "100.00"),
+                            LedgerEntryLine("acc_2", "CREDIT", "-100.00"),
+                        ),
+                ),
+        )
+}


### PR DESCRIPTION
E-04 Compliance #267 - the AML event consumer (the first event consumer in the repo).

## What
- **AmlTransactionConsumer** (`@KafkaListener` on `fincore.transaction`, group `compliance-aml`): deserializes the envelope via a Jackson `TypeReference` into a compliance-owned wire DTO (`LedgerTransactionPosted`, `@JsonIgnoreProperties` - services don't share classes), filters `TransactionPosted` (the topic also carries reversals), and delegates. Thin, no `@Transactional`.
- **AmlEventHandler** (`@Service @Transactional`): deduplicates by envelope id (`IdempotentEventProcessor` + `JdbcProcessedEventStore`, #192), maps the event to an `AmlTransactionView` (amount = sum of DEBIT entries as BigDecimal), evaluates with the embedded AML engine (#266), and persists an `AmlAlert` when flagged - **all in one transaction**, so a thrown handler rolls back the claim and the event retries (at-least-once + idempotent). No external call inside the transaction.
- Migrations: `processed_events` (default schema, matching the store's unqualified table name) + `subject_reference` on `aml_alerts` (an alert now records its subject).
- Consumer-only Kafka config; the eventbus producer auto-config stays off (`fincore.eventbus.bootstrap-servers` unset).

## Tests
Unit: handler (dedup, DEBIT-sum, flag/clear), consumer (typed deserialization + type filtering). IT: `@SpringBootTest` + Testcontainers (Redpanda + Postgres) publishing via `KafkaTemplate` -> asserts an alert by subject, and a duplicate envelope raises only one alert (await + settle).

## Notes / deferred
Rolling-window composition (no history source yet) and a DLQ/error-handler (the #193 toolkit exists) are explicit follow-ups; documented, state-safe (poison message never commits).

## Gate chain
- critic: GO-WITH-CHANGES (subject_reference column, KycApiContextIT listener auto-startup=false, processed_events schema-invariant comment, exact DEBIT toView + typed round-trip test - all applied).
- security-auditor (opus): PASS - dedup+evaluate+persist in one tx, no external call in tx, no SQL injection (constant table + bound params), deserialization safe, §5.3 clean.
- code-reviewer: 2 must-fix applied (removed the DEFAULT '' poison; moved producer config to the IT) + strengthened the dedup test; 1 declined with reasoning.
- evaluator: PASS (0.918).
All local gates green; the Redpanda+Postgres IT runs on CI.

Closes #267