### PR TITLE
feat(compliance): add case management with rest

### DIFF
--- a/services/compliance/src/integrationTest/kotlin/com/fincore/compliance/application/case/CaseServicePersistenceIT.kt
+++ b/services/compliance/src/integrationTest/kotlin/com/fincore/compliance/application/case/CaseServicePersistenceIT.kt
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.case
+
+import com.fincore.compliance.domain.enum.CaseStatus
+import com.fincore.compliance.infrastructure.persistence.ComplianceCasePersistenceAdapter
+import com.fincore.compliance.infrastructure.persistence.ComplianceCaseRepository
+import com.fincore.test.containers.PostgresContainerExtension
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Transactional(propagation = Propagation.NOT_SUPPORTED)
+@ExtendWith(PostgresContainerExtension::class)
+@Import(ComplianceCaseServiceImpl::class, ComplianceCasePersistenceAdapter::class)
+class CaseServicePersistenceIT(
+    @Autowired private val service: ComplianceCaseService,
+    @Autowired private val repository: ComplianceCaseRepository,
+) {
+    @AfterEach
+    fun cleanUp() {
+        repository.deleteAll()
+    }
+
+    @Test
+    fun `should open then get a case round-tripping through postgres`() {
+        val opened = service.open(OpenCaseCommand("case-ref-1"))
+
+        val reloaded = service.get(opened.id)
+        reloaded.id shouldBe opened.id
+        reloaded.reference shouldBe "case-ref-1"
+        reloaded.status shouldBe CaseStatus.OPEN
+    }
+
+    @Test
+    fun `should persist the claim transition`() {
+        val opened = service.open(OpenCaseCommand("case-ref-2"))
+
+        service.claim(opened.id)
+
+        service.get(opened.id).status shouldBe CaseStatus.CLAIMED
+    }
+
+    companion object {
+        @JvmStatic
+        @DynamicPropertySource
+        fun datasourceProperties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { PostgresContainerExtension.jdbcUrl }
+            registry.add("spring.datasource.username") { PostgresContainerExtension.username }
+            registry.add("spring.datasource.password") { PostgresContainerExtension.password }
+            registry.add("spring.jpa.hibernate.ddl-auto") { "none" }
+        }
+    }
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/api/CaseController.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/api/CaseController.kt
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.api
+
+import com.fincore.compliance.api.dto.request.OpenCaseRequest
+import com.fincore.compliance.api.dto.response.CaseResponse
+import com.fincore.compliance.api.mapper.CaseApiMapper
+import com.fincore.compliance.application.case.ComplianceCaseService
+import com.fincore.compliance.domain.enum.CaseStatus
+import com.fincore.core.ComplianceCaseId
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import java.net.URI
+
+@Tag(name = "Compliance", description = "Open, read and transition compliance cases")
+@RestController
+@RequestMapping("/v1/compliance/cases")
+class CaseController(
+    private val caseService: ComplianceCaseService,
+    private val mapper: CaseApiMapper,
+) {
+    @Operation(summary = "Open a compliance case", description = "Creates a case in the OPEN state.")
+    @PostMapping
+    fun open(
+        @Valid @RequestBody request: OpenCaseRequest,
+    ): ResponseEntity<CaseResponse> {
+        val response = mapper.toResponse(caseService.open(mapper.toCommand(request)))
+        return ResponseEntity.created(URI.create("/v1/compliance/cases/${response.id}")).body(response)
+    }
+
+    @Operation(summary = "List cases by status")
+    @GetMapping
+    fun list(
+        @RequestParam status: CaseStatus,
+    ): List<CaseResponse> = caseService.list(status).map(mapper::toResponse)
+
+    @Operation(summary = "Get a case", description = "Returns the case or 404.")
+    @GetMapping("/{id}")
+    fun get(
+        @PathVariable id: String,
+    ): CaseResponse = mapper.toResponse(caseService.get(ComplianceCaseId.fromString(id)))
+
+    @Operation(summary = "Claim a case", description = "OPEN to CLAIMED, or 409 if illegal.")
+    @PostMapping("/{id}/claim")
+    fun claim(
+        @PathVariable id: String,
+    ): CaseResponse = mapper.toResponse(caseService.claim(ComplianceCaseId.fromString(id)))
+
+    @Operation(summary = "Resolve a case", description = "Marks the case RESOLVED, or 409 if illegal.")
+    @PostMapping("/{id}/resolve")
+    fun resolve(
+        @PathVariable id: String,
+    ): CaseResponse = mapper.toResponse(caseService.resolve(ComplianceCaseId.fromString(id)))
+
+    @Operation(summary = "Escalate a case", description = "Marks the case ESCALATED, or 409 if illegal.")
+    @PostMapping("/{id}/escalate")
+    fun escalate(
+        @PathVariable id: String,
+    ): CaseResponse = mapper.toResponse(caseService.escalate(ComplianceCaseId.fromString(id)))
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/api/dto/request/OpenCaseRequest.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/api/dto/request/OpenCaseRequest.kt
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.api.dto.request
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Size
+
+data class OpenCaseRequest(
+    @field:NotBlank
+    @field:Size(max = 140)
+    val reference: String,
+)

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/api/dto/response/CaseResponse.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/api/dto/response/CaseResponse.kt
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.api.dto.response
+
+data class CaseResponse(
+    val id: String,
+    val reference: String,
+    val status: String,
+)

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/api/error/ProblemType.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/api/error/ProblemType.kt
@@ -13,7 +13,13 @@ enum class ProblemType(
     val title: String,
 ) {
     KYC_NOT_FOUND("kyc-session-not-found", HttpStatus.NOT_FOUND, "KYC_NOT_FOUND", "kyc session not found"),
-    KYC_CONFLICT("kyc-conflict", HttpStatus.CONFLICT, "KYC_CONFLICT", "illegal kyc state transition"),
+    CASE_NOT_FOUND("compliance-case-not-found", HttpStatus.NOT_FOUND, "CASE_NOT_FOUND", "compliance case not found"),
+    COMPLIANCE_CONFLICT(
+        "compliance-conflict",
+        HttpStatus.CONFLICT,
+        "COMPLIANCE_CONFLICT",
+        "illegal compliance state transition",
+    ),
     VALIDATION_FAILED("validation-failed", HttpStatus.BAD_REQUEST, "VALIDATION_FAILED", "invalid request"),
     MALFORMED_REQUEST("malformed-request", HttpStatus.BAD_REQUEST, "MALFORMED_REQUEST", "invalid request"),
     INVALID_REQUEST("invalid-request", HttpStatus.BAD_REQUEST, "INVALID_REQUEST", "invalid request"),

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/api/mapper/CaseApiMapper.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/api/mapper/CaseApiMapper.kt
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.api.mapper
+
+import com.fincore.compliance.api.dto.request.OpenCaseRequest
+import com.fincore.compliance.api.dto.response.CaseResponse
+import com.fincore.compliance.application.case.OpenCaseCommand
+import com.fincore.compliance.domain.ComplianceCase
+import org.springframework.stereotype.Component
+
+// Hand-written: the value-class ComplianceCaseId crosses the wire as a prefixed-ULID string.
+@Component
+class CaseApiMapper {
+    fun toCommand(request: OpenCaseRequest): OpenCaseCommand = OpenCaseCommand(reference = request.reference)
+
+    fun toResponse(case: ComplianceCase): CaseResponse =
+        CaseResponse(
+            id = case.id.toString(),
+            reference = case.reference,
+            status = case.status.name,
+        )
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/application/case/CaseNotFoundException.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/application/case/CaseNotFoundException.kt
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.case
+
+import com.fincore.core.ComplianceCaseId
+
+class CaseNotFoundException(
+    id: ComplianceCaseId,
+) : RuntimeException("Compliance case not found: $id")

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/application/case/ComplianceCaseService.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/application/case/ComplianceCaseService.kt
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.case
+
+import com.fincore.compliance.domain.ComplianceCase
+import com.fincore.compliance.domain.enum.CaseStatus
+import com.fincore.core.ComplianceCaseId
+
+interface ComplianceCaseService {
+    fun open(command: OpenCaseCommand): ComplianceCase
+
+    fun get(id: ComplianceCaseId): ComplianceCase
+
+    fun claim(id: ComplianceCaseId): ComplianceCase
+
+    fun resolve(id: ComplianceCaseId): ComplianceCase
+
+    fun escalate(id: ComplianceCaseId): ComplianceCase
+
+    fun list(status: CaseStatus): List<ComplianceCase>
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/application/case/ComplianceCaseServiceImpl.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/application/case/ComplianceCaseServiceImpl.kt
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.case
+
+import com.fincore.compliance.domain.ComplianceCase
+import com.fincore.compliance.domain.enum.CaseStatus
+import com.fincore.compliance.infrastructure.persistence.ComplianceCasePersistenceAdapter
+import com.fincore.compliance.infrastructure.persistence.ComplianceCaseRepository
+import com.fincore.core.ComplianceCaseId
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+@Service
+class ComplianceCaseServiceImpl(
+    private val repository: ComplianceCaseRepository,
+    private val adapter: ComplianceCasePersistenceAdapter,
+) : ComplianceCaseService {
+    @Transactional
+    override fun open(command: OpenCaseCommand): ComplianceCase {
+        val case = ComplianceCase(ComplianceCaseId.generate(), command.reference)
+        repository.saveAndFlush(adapter.toNewEntity(case, Instant.now()))
+        return case
+    }
+
+    @Transactional(readOnly = true)
+    override fun get(id: ComplianceCaseId): ComplianceCase =
+        adapter.toDomain(repository.findById(id.value).orElseThrow { CaseNotFoundException(id) })
+
+    @Transactional
+    override fun claim(id: ComplianceCaseId): ComplianceCase = transition(id, CaseStatus.CLAIMED)
+
+    @Transactional
+    override fun resolve(id: ComplianceCaseId): ComplianceCase = transition(id, CaseStatus.RESOLVED)
+
+    @Transactional
+    override fun escalate(id: ComplianceCaseId): ComplianceCase = transition(id, CaseStatus.ESCALATED)
+
+    @Transactional(readOnly = true)
+    override fun list(status: CaseStatus): List<ComplianceCase> = repository.findByStatus(status).map(adapter::toDomain)
+
+    private fun transition(
+        id: ComplianceCaseId,
+        target: CaseStatus,
+    ): ComplianceCase {
+        val entity = repository.findById(id.value).orElseThrow { CaseNotFoundException(id) }
+        val case = adapter.toDomain(entity)
+        case.transitionTo(target)
+        entity.status = case.status
+        repository.saveAndFlush(entity)
+        return case
+    }
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/application/case/OpenCaseCommand.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/application/case/OpenCaseCommand.kt
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.case
+
+/** Command to open a compliance case. [reference] is a generic, opaque case reference (validated by the domain). */
+data class OpenCaseCommand(
+    val reference: String,
+)

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/config/SecurityConfig.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/config/SecurityConfig.kt
@@ -30,6 +30,10 @@ class SecurityConfig {
                     .hasAuthority(SCOPE_READ)
                     .requestMatchers(KYC_PATHS)
                     .hasAuthority(SCOPE_WRITE)
+                    .requestMatchers(HttpMethod.GET, COMPLIANCE_PATHS)
+                    .hasAuthority(SCOPE_READ)
+                    .requestMatchers(COMPLIANCE_PATHS)
+                    .hasAuthority(SCOPE_WRITE)
                     .anyRequest()
                     .authenticated()
             }.oauth2ResourceServer { resource ->
@@ -43,6 +47,7 @@ class SecurityConfig {
 
     private companion object {
         const val KYC_PATHS = "/v1/kyc/**"
+        const val COMPLIANCE_PATHS = "/v1/compliance/**"
         const val SCOPE_READ = "SCOPE_compliance:read"
         const val SCOPE_WRITE = "SCOPE_compliance:write"
         val PUBLIC_PATHS =

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/exception/GlobalExceptionHandler.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/exception/GlobalExceptionHandler.kt
@@ -4,6 +4,7 @@
 package com.fincore.compliance.exception
 
 import com.fincore.compliance.api.error.ProblemType
+import com.fincore.compliance.application.case.CaseNotFoundException
 import com.fincore.compliance.application.kyc.KycSessionNotFoundException
 import com.fincore.compliance.domain.ComplianceDomainException
 import jakarta.servlet.http.HttpServletRequest
@@ -14,6 +15,7 @@ import org.springframework.validation.FieldError
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
 import java.net.URI
 
 @RestControllerAdvice
@@ -24,15 +26,21 @@ class GlobalExceptionHandler {
         request: HttpServletRequest,
     ): ProblemDetail = problem(ProblemType.KYC_NOT_FOUND, ex.message, request)
 
+    @ExceptionHandler(CaseNotFoundException::class)
+    fun handleCaseNotFound(
+        ex: CaseNotFoundException,
+        request: HttpServletRequest,
+    ): ProblemDetail = problem(ProblemType.CASE_NOT_FOUND, ex.message, request)
+
     @ExceptionHandler(ComplianceDomainException::class)
     fun handleDomain(
         ex: ComplianceDomainException,
         request: HttpServletRequest,
-    ): ProblemDetail = problem(ProblemType.KYC_CONFLICT, ex.message, request)
+    ): ProblemDetail = problem(ProblemType.COMPLIANCE_CONFLICT, ex.message, request)
 
     @ExceptionHandler(OptimisticLockingFailureException::class)
     fun handleOptimisticLock(request: HttpServletRequest): ProblemDetail =
-        problem(ProblemType.KYC_CONFLICT, "Concurrent update conflict", request)
+        problem(ProblemType.COMPLIANCE_CONFLICT, "Concurrent update conflict", request)
 
     @ExceptionHandler(MethodArgumentNotValidException::class)
     fun handleValidation(
@@ -46,6 +54,12 @@ class GlobalExceptionHandler {
     @ExceptionHandler(HttpMessageNotReadableException::class)
     fun handleUnreadable(request: HttpServletRequest): ProblemDetail =
         problem(ProblemType.MALFORMED_REQUEST, "Request body is missing or malformed", request)
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException::class)
+    fun handleTypeMismatch(
+        ex: MethodArgumentTypeMismatchException,
+        request: HttpServletRequest,
+    ): ProblemDetail = problem(ProblemType.INVALID_REQUEST, "Invalid value for parameter '${ex.name}'", request)
 
     @ExceptionHandler(IllegalArgumentException::class)
     fun handleIllegalArgument(

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/persistence/ComplianceCasePersistenceAdapter.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/persistence/ComplianceCasePersistenceAdapter.kt
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.infrastructure.persistence
+
+import com.fincore.compliance.domain.ComplianceCase
+import com.fincore.core.ComplianceCaseId
+import org.springframework.stereotype.Component
+import java.time.Instant
+
+// Hand-written because MapStruct cannot construct the value-class domain aggregate; the domain stays pure.
+@Component
+class ComplianceCasePersistenceAdapter {
+    fun toDomain(entity: ComplianceCaseEntity): ComplianceCase =
+        ComplianceCase(
+            id = ComplianceCaseId(entity.id),
+            reference = entity.reference,
+            status = entity.status,
+        )
+
+    fun toNewEntity(
+        case: ComplianceCase,
+        now: Instant,
+    ): ComplianceCaseEntity =
+        ComplianceCaseEntity(
+            id = case.id.value,
+            reference = case.reference,
+            status = case.status,
+            createdAt = now,
+            version = 0,
+        )
+}

--- a/services/compliance/src/test/kotlin/com/fincore/compliance/api/CaseControllerTest.kt
+++ b/services/compliance/src/test/kotlin/com/fincore/compliance/api/CaseControllerTest.kt
@@ -1,0 +1,146 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.api
+
+import com.fincore.compliance.api.mapper.CaseApiMapper
+import com.fincore.compliance.application.case.CaseNotFoundException
+import com.fincore.compliance.application.case.ComplianceCaseService
+import com.fincore.compliance.config.SecurityConfig
+import com.fincore.compliance.domain.ComplianceCase
+import com.fincore.compliance.domain.ComplianceDomainException
+import com.fincore.compliance.domain.enum.CaseStatus
+import com.fincore.compliance.exception.GlobalExceptionHandler
+import com.fincore.core.ComplianceCaseId
+import io.mockk.clearMocks
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@WebMvcTest(CaseController::class)
+@Import(SecurityConfig::class, CaseApiMapper::class, GlobalExceptionHandler::class, CaseControllerTest.Mocks::class)
+class CaseControllerTest(
+    @Autowired private val mockMvc: MockMvc,
+    @Autowired private val caseService: ComplianceCaseService,
+) {
+    @TestConfiguration
+    class Mocks {
+        @Bean fun caseService(): ComplianceCaseService = mockk()
+
+        @Bean fun jwtDecoder(): JwtDecoder = mockk()
+    }
+
+    @BeforeEach
+    fun resetMocks() {
+        clearMocks(caseService)
+    }
+
+    @Test
+    fun `should open a case and return 201 with write scope`() {
+        every { caseService.open(any()) } returns case(CaseStatus.OPEN)
+
+        mockMvc
+            .perform(
+                post("/v1/compliance/cases")
+                    .with(jwt().authorities(SimpleGrantedAuthority(WRITE)))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(VALID_BODY),
+            ).andExpect(status().isCreated)
+            .andExpect(jsonPath("$.status").value("OPEN"))
+    }
+
+    @Test
+    fun `should return 401 when opening without a token`() {
+        mockMvc
+            .perform(post("/v1/compliance/cases").contentType(MediaType.APPLICATION_JSON).content(VALID_BODY))
+            .andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    fun `should return 403 when opening with only the read scope`() {
+        mockMvc
+            .perform(
+                post("/v1/compliance/cases")
+                    .with(jwt().authorities(SimpleGrantedAuthority(READ)))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(VALID_BODY),
+            ).andExpect(status().isForbidden)
+    }
+
+    @Test
+    fun `should get a case with read scope`() {
+        val case = case(CaseStatus.OPEN)
+        every { caseService.get(any()) } returns case
+
+        mockMvc
+            .perform(get("/v1/compliance/cases/${case.id}").with(jwt().authorities(SimpleGrantedAuthority(READ))))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.id").value(case.id.toString()))
+    }
+
+    @Test
+    fun `should return 400 for an unparseable case id`() {
+        mockMvc
+            .perform(get("/v1/compliance/cases/not-a-ulid").with(jwt().authorities(SimpleGrantedAuthority(READ))))
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `should return 400 for an unknown status filter`() {
+        mockMvc
+            .perform(get("/v1/compliance/cases?status=BOGUS").with(jwt().authorities(SimpleGrantedAuthority(READ))))
+            .andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `should return 404 when getting an unknown case`() {
+        every { caseService.get(any()) } throws CaseNotFoundException(ComplianceCaseId.generate())
+
+        mockMvc
+            .perform(get("/v1/compliance/cases/${ComplianceCaseId.generate()}").with(jwt().authorities(SimpleGrantedAuthority(READ))))
+            .andExpect(status().isNotFound)
+    }
+
+    @Test
+    fun `should return 409 when a transition is illegal`() {
+        every { caseService.claim(any()) } throws ComplianceDomainException("illegal transition")
+
+        mockMvc
+            .perform(
+                post("/v1/compliance/cases/${ComplianceCaseId.generate()}/claim").with(jwt().authorities(SimpleGrantedAuthority(WRITE))),
+            ).andExpect(status().isConflict)
+    }
+
+    @Test
+    fun `should list cases by status with read scope`() {
+        every { caseService.list(CaseStatus.OPEN) } returns listOf(case(CaseStatus.OPEN))
+
+        mockMvc
+            .perform(get("/v1/compliance/cases?status=OPEN").with(jwt().authorities(SimpleGrantedAuthority(READ))))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$[0].status").value("OPEN"))
+    }
+
+    private fun case(status: CaseStatus): ComplianceCase = ComplianceCase(ComplianceCaseId.generate(), "case-ref-1", status)
+
+    private companion object {
+        const val READ = "SCOPE_compliance:read"
+        const val WRITE = "SCOPE_compliance:write"
+        const val VALID_BODY = """{"reference":"case-ref-1"}"""
+    }
+}

--- a/services/compliance/src/test/kotlin/com/fincore/compliance/application/case/ComplianceCasePersistenceAdapterTest.kt
+++ b/services/compliance/src/test/kotlin/com/fincore/compliance/application/case/ComplianceCasePersistenceAdapterTest.kt
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.case
+
+import com.fincore.compliance.domain.ComplianceCase
+import com.fincore.compliance.domain.enum.CaseStatus
+import com.fincore.compliance.infrastructure.persistence.ComplianceCasePersistenceAdapter
+import com.fincore.core.ComplianceCaseId
+import io.kotest.matchers.shouldBe
+import org.junit.jupiter.api.Test
+import java.time.Instant
+
+class ComplianceCasePersistenceAdapterTest {
+    private val adapter = ComplianceCasePersistenceAdapter()
+
+    @Test
+    fun `should round-trip a case through new entity and back`() {
+        val case = ComplianceCase(ComplianceCaseId.generate(), "case-ref-1")
+
+        val domain = adapter.toDomain(adapter.toNewEntity(case, Instant.now()))
+
+        domain.id shouldBe case.id
+        domain.reference shouldBe "case-ref-1"
+        domain.status shouldBe CaseStatus.OPEN
+    }
+}

--- a/services/compliance/src/test/kotlin/com/fincore/compliance/application/case/ComplianceCaseServiceImplTest.kt
+++ b/services/compliance/src/test/kotlin/com/fincore/compliance/application/case/ComplianceCaseServiceImplTest.kt
@@ -1,0 +1,76 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.case
+
+import com.fincore.compliance.domain.ComplianceDomainException
+import com.fincore.compliance.domain.enum.CaseStatus
+import com.fincore.compliance.infrastructure.persistence.ComplianceCaseEntity
+import com.fincore.compliance.infrastructure.persistence.ComplianceCasePersistenceAdapter
+import com.fincore.compliance.infrastructure.persistence.ComplianceCaseRepository
+import com.fincore.core.ComplianceCaseId
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+import java.time.Instant
+import java.util.Optional
+import java.util.UUID
+
+class ComplianceCaseServiceImplTest {
+    private val repository = mockk<ComplianceCaseRepository>()
+    private val service = ComplianceCaseServiceImpl(repository, ComplianceCasePersistenceAdapter())
+
+    @Test
+    fun `should open a case in the open state`() {
+        every { repository.saveAndFlush(any()) } answers { firstArg() }
+
+        service.open(OpenCaseCommand("case-ref-1")).status shouldBe CaseStatus.OPEN
+    }
+
+    @Test
+    fun `should throw not found when getting a missing case`() {
+        every { repository.findById(any()) } returns Optional.empty()
+
+        shouldThrow<CaseNotFoundException> { service.get(ComplianceCaseId.generate()) }
+    }
+
+    @Test
+    fun `should claim an open case`() {
+        val id = ComplianceCaseId.generate()
+        every { repository.findById(id.value) } returns Optional.of(entity(id.value, CaseStatus.OPEN))
+        every { repository.saveAndFlush(any()) } answers { firstArg() }
+
+        service.claim(id).status shouldBe CaseStatus.CLAIMED
+    }
+
+    @Test
+    fun `should escalate a claimed case then resolve it`() {
+        val id = ComplianceCaseId.generate()
+        every { repository.findById(id.value) } returns Optional.of(entity(id.value, CaseStatus.CLAIMED))
+        every { repository.saveAndFlush(any()) } answers { firstArg() }
+
+        service.escalate(id).status shouldBe CaseStatus.ESCALATED
+    }
+
+    @Test
+    fun `should reject claiming a resolved case`() {
+        val id = ComplianceCaseId.generate()
+        every { repository.findById(id.value) } returns Optional.of(entity(id.value, CaseStatus.RESOLVED))
+
+        shouldThrow<ComplianceDomainException> { service.claim(id) }
+    }
+
+    @Test
+    fun `should list cases by status`() {
+        every { repository.findByStatus(CaseStatus.OPEN) } returns listOf(entity(UUID.randomUUID(), CaseStatus.OPEN))
+
+        service.list(CaseStatus.OPEN).size shouldBe 1
+    }
+
+    private fun entity(
+        id: UUID,
+        status: CaseStatus,
+    ) = ComplianceCaseEntity(id, "case-ref-1", status, Instant.now(), 0)
+}


### PR DESCRIPTION
E-04 Compliance #268 - the case-management vertical, mirroring the KYC vertical.

## What
- **ComplianceCaseService** (interface+impl, @Transactional in impl only): open (OPEN), get, claim (OPEN->CLAIMED), resolve (->RESOLVED), escalate (->ESCALATED), list(status) - all through the domain `transitionTo` guard; repository + a pure `ComplianceCasePersistenceAdapter` (value-class id<->UUID), same shape as `KycServiceImpl`.
- **CaseController** (`/v1/compliance/cases`): POST open (compliance:write, 201+Location), GET `?status=` (read, bounded - status required), GET /{id}, POST /{id}/claim|resolve|escalate (write). Thin; String path -> `ComplianceCaseId.fromString`; hand `CaseApiMapper`.
- **SecurityConfig**: adds GET /v1/compliance/** = compliance:read, mutating = compliance:write (after the KYC rules, before anyRequest - fails closed).
- **ProblemType / GlobalExceptionHandler**: `KYC_CONFLICT` -> `COMPLIANCE_CONFLICT` (the domain exception is shared by KYC + cases; same 409), added `CASE_NOT_FOUND` (404) and a `MethodArgumentTypeMismatchException` handler so a bad `?status=` returns 400 (was 500).

## Decisions (umbrella drift documented)
Domain `CaseStatus` (CLAIMED) wins over the OpenAPI `IN_REVIEW`; cursor pagination, decision/reason capture and alert/payment/kyc links are deferred follow-ups. Idempotency-Key on open is deferred (consistent with KYC #277).

## Gate chain
- critic: GO-WITH-CHANGES (atomic ProblemType rename keeping KYC_NOT_FOUND; CaseControllerTest scope-order assertions - applied).
- security-auditor (opus): PASS - authz fails-closed (401/403 asserted, no fall-through), §5.3 clean, rename keeps 409, list bounded.
- code-reviewer: the bad-status 500->400 fix + value-class test robustness adopted; the adapter-as-port HIGH declined with evidence (mirrors merged KycServiceImpl/PaymentServiceImpl; store-port rejected in #265).
- evaluator: PASS (0.86).
All local gates green (@WebMvcTest + @DataJpaTest slice-scoped; the KYC #275 tests stayed green after the rename).

Closes #268