### PR TITLE
test(compliance): end-to-end compliance lifecycle integration test

### DIFF
--- a/services/compliance/src/integrationTest/kotlin/com/fincore/compliance/api/ComplianceLifecycleIT.kt
+++ b/services/compliance/src/integrationTest/kotlin/com/fincore/compliance/api/ComplianceLifecycleIT.kt
@@ -1,0 +1,145 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.api
+
+import com.fincore.compliance.application.kyc.KycCheckRequest
+import com.fincore.compliance.application.kyc.KycCheckResult
+import com.fincore.compliance.application.kyc.KycProvider
+import com.fincore.compliance.infrastructure.persistence.ComplianceCaseRepository
+import com.fincore.test.containers.PostgresContainerExtension
+import io.mockk.mockk
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ExtendWith(PostgresContainerExtension::class)
+@Import(ComplianceLifecycleIT.TestBeans::class)
+class ComplianceLifecycleIT(
+    @Autowired private val mockMvc: MockMvc,
+    @Autowired private val cases: ComplianceCaseRepository,
+) {
+    @TestConfiguration
+    class TestBeans {
+        @Bean fun jwtDecoder(): JwtDecoder = mockk()
+
+        @Bean fun kycProvider(): KycProvider =
+            object : KycProvider {
+                override fun check(request: KycCheckRequest): KycCheckResult = KycCheckResult.Pending("ref-test")
+            }
+    }
+
+    @AfterEach
+    fun cleanUp() {
+        cases.deleteAll()
+    }
+
+    @Test
+    fun `should drive a case from open through claim to resolved over http`() {
+        val location = openCase()
+
+        mockMvc
+            .perform(post("$location/claim").with(jwt().authorities(SimpleGrantedAuthority(WRITE))))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value("CLAIMED"))
+
+        mockMvc
+            .perform(post("$location/resolve").with(jwt().authorities(SimpleGrantedAuthority(WRITE))))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value("RESOLVED"))
+
+        mockMvc
+            .perform(get(location).with(jwt().authorities(SimpleGrantedAuthority(READ))))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.status").value("RESOLVED"))
+    }
+
+    @Test
+    fun `should return 409 when resolving a case twice`() {
+        val location = openCase()
+        mockMvc
+            .perform(post("$location/claim").with(jwt().authorities(SimpleGrantedAuthority(WRITE))))
+            .andExpect(status().isOk)
+        mockMvc
+            .perform(post("$location/resolve").with(jwt().authorities(SimpleGrantedAuthority(WRITE))))
+            .andExpect(status().isOk)
+
+        mockMvc
+            .perform(post("$location/resolve").with(jwt().authorities(SimpleGrantedAuthority(WRITE))))
+            .andExpect(status().isConflict)
+    }
+
+    @Test
+    fun `should return 403 when opening a case with only the read scope`() {
+        mockMvc
+            .perform(
+                post("/v1/compliance/cases")
+                    .with(jwt().authorities(SimpleGrantedAuthority(READ)))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(VALID_BODY),
+            ).andExpect(status().isForbidden)
+    }
+
+    @Test
+    fun `should publish both kyc and compliance case paths in the openapi document`() {
+        mockMvc
+            .perform(get("/v3/api-docs"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.paths['/v1/kyc/sessions']").exists())
+            .andExpect(jsonPath("$.paths['/v1/compliance/cases']").exists())
+    }
+
+    @Test
+    fun `should expose the health endpoint without a token`() {
+        mockMvc.perform(get("/actuator/health")).andExpect(status().isOk)
+    }
+
+    private fun openCase(): String =
+        mockMvc
+            .perform(
+                post("/v1/compliance/cases")
+                    .with(jwt().authorities(SimpleGrantedAuthority(WRITE)))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(VALID_BODY),
+            ).andExpect(status().isCreated)
+            .andReturn()
+            .response
+            .getHeader("Location")!!
+
+    companion object {
+        private const val READ = "SCOPE_compliance:read"
+        private const val WRITE = "SCOPE_compliance:write"
+        private const val VALID_BODY = """{"reference":"case-ref-1"}"""
+
+        @JvmStatic
+        @DynamicPropertySource
+        fun properties(registry: DynamicPropertyRegistry) {
+            registry.add("spring.datasource.url") { PostgresContainerExtension.jdbcUrl }
+            registry.add("spring.datasource.username") { PostgresContainerExtension.username }
+            registry.add("spring.datasource.password") { PostgresContainerExtension.password }
+            registry.add("spring.jpa.hibernate.ddl-auto") { "none" }
+            registry.add("spring.security.oauth2.resourceserver.jwt.issuer-uri") { "https://issuer.test" }
+            // This context does not exercise the AML consumer; keep the Kafka listener from polling an absent broker.
+            registry.add("spring.kafka.listener.auto-startup") { "false" }
+        }
+    }
+}


### PR DESCRIPTION
Final ticketed E-04 slice (#270) - consolidation proven end-to-end.

## What #270 adds
`ComplianceLifecycleIT` (@SpringBootTest + Testcontainers Postgres + MockMvc, mirroring the merged KycApiContextIT full-context setup): drives a **case open -> claim -> resolve** over HTTP against real Postgres, asserts **double-resolve -> 409** (RFC7807 conflict end-to-end), **403** on open with only the read scope (paired with the 201 write path = non-vacuous deny/allow), the OpenAPI doc lists **both** `/v1/kyc/sessions` and `/v1/compliance/cases`, and `/actuator/health` is reachable **without a token** (permitAll + observability baseline).

## Honest scope - AC mapping (most production work shipped earlier)
- SecurityConfig (compliance:read/write, actuator+prometheus permitAll, csrf-disabled stateless) — **#275 + #268**.
- RFC7807 GlobalExceptionHandler + ProblemType (404/409/400) — **#275 + #268**.
- application.yml observability baseline (health/info/prometheus + readiness + percentiles-histogram + otlp + PII-masking) like #245 — **#275**.
- springdoc OpenAPI — **#275** (KYC paths asserted there; this slice adds the compliance-cases assertion).
- No HTTP webhook in compliance (AML ingress is Kafka).
- **#270 deliverable = the end-to-end consolidation IT** proving the above as a whole.

## Gate chain
- critic: GO-WITH-CHANGES (verbatim @DynamicPropertySource incl. `spring.kafka.listener.auto-startup=false`; exact scope consts; AC->prior-PR mapping - applied).
- security-auditor (opus): PASS - authz fails-closed (non-vacuous), health permitAll, §5.3 clean, no secrets, test-only close legitimate (verified SecurityConfig/handler exist from #275/#268).
- code-reviewer: 1 HIGH fixed - the double-resolve test was resolving an OPEN case directly (illegal OPEN->RESOLVED would 409, not 200, and red the CI); inserted the missing claim step so the path is OPEN->CLAIMED->RESOLVED->409.
- evaluator: PASS (0.86).
Local compile/detekt/spotless green; the IT runs on CI (Postgres). With this, all ticketed E-04 slices (#261-#270) are done.

Closes #270