### PR TITLE
feat(compliance): add the deterministic sandbox kyc provider

### DIFF
--- a/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/kyc/SandboxKycProvider.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/kyc/SandboxKycProvider.kt
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.infrastructure.kyc
+
+import com.fincore.compliance.application.kyc.KycCheckRequest
+import com.fincore.compliance.application.kyc.KycCheckResult
+import com.fincore.compliance.application.kyc.KycProvider
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+
+/**
+ * Deterministic in-tree sandbox KYC provider, off by default. Encodes no real provider logic; the outcome is keyed on
+ * documented case-insensitive markers in the opaque subject reference: "reject" -> Rejected, "pending" -> Pending,
+ * "insufficient" -> InsufficientData, otherwise -> Approved. The same reference always yields the same result.
+ */
+@Component
+@ConditionalOnProperty(
+    prefix = "fincore.compliance.kyc.sandbox",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = false,
+)
+class SandboxKycProvider : KycProvider {
+    override fun check(request: KycCheckRequest): KycCheckResult {
+        val reference = request.subjectReference
+        val providerReference = "sbx-kyc-${reference.hashCode().toUInt()}"
+        return when {
+            reference.contains(REJECT_MARKER, ignoreCase = true) ->
+                KycCheckResult.Rejected("sandbox rejected by subject marker")
+            reference.contains(PENDING_MARKER, ignoreCase = true) ->
+                KycCheckResult.Pending(providerReference)
+            reference.contains(INSUFFICIENT_MARKER, ignoreCase = true) ->
+                KycCheckResult.InsufficientData(listOf("sandbox.insufficient"))
+            else -> KycCheckResult.Approved(providerReference)
+        }
+    }
+
+    private companion object {
+        const val REJECT_MARKER = "reject"
+        const val PENDING_MARKER = "pending"
+        const val INSUFFICIENT_MARKER = "insufficient"
+    }
+}

--- a/services/compliance/src/test/kotlin/com/fincore/compliance/infrastructure/kyc/SandboxKycProviderTest.kt
+++ b/services/compliance/src/test/kotlin/com/fincore/compliance/infrastructure/kyc/SandboxKycProviderTest.kt
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.infrastructure.kyc
+
+import com.fincore.compliance.application.kyc.KycCheckRequest
+import com.fincore.compliance.application.kyc.KycCheckResult
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+
+class SandboxKycProviderTest {
+    private val provider = SandboxKycProvider()
+
+    @Test
+    fun `should approve a plain subject reference`() {
+        provider.check(KycCheckRequest("subject-1")).shouldBeInstanceOf<KycCheckResult.Approved>()
+    }
+
+    @Test
+    fun `should reject when the reference carries the reject marker`() {
+        provider.check(KycCheckRequest("reject-subject")).shouldBeInstanceOf<KycCheckResult.Rejected>()
+    }
+
+    @Test
+    fun `should return pending when the reference carries the pending marker`() {
+        provider.check(KycCheckRequest("pending-subject")).shouldBeInstanceOf<KycCheckResult.Pending>()
+    }
+
+    @Test
+    fun `should return insufficient data with a non-empty list when marked`() {
+        val result = provider.check(KycCheckRequest("insufficient-subject"))
+
+        result.shouldBeInstanceOf<KycCheckResult.InsufficientData>().missing shouldBe listOf("sandbox.insufficient")
+    }
+
+    @Test
+    fun `should be deterministic for the same subject reference`() {
+        val first = provider.check(KycCheckRequest("subject-1"))
+        val second = provider.check(KycCheckRequest("subject-1"))
+
+        first shouldBe second
+    }
+}


### PR DESCRIPTION
E-04 / E-06 #239 - an in-tree sandbox impl of the KycProvider port (unblocked now that port #263 exists). Mirrors the merged SandboxBankProvider (#212).

## What
- `infrastructure/kyc/SandboxKycProvider` - `@Component @ConditionalOnProperty(prefix="fincore.compliance.kyc.sandbox", name=[enabled], havingValue=true, matchIfMissing=false)`, **off by default**. Deterministic, marker-based on the opaque `subjectReference`: `reject` -> Rejected, `pending` -> Pending, `insufficient` -> InsufficientData, otherwise Approved. The same reference always yields the same result; the provider reference is an opaque token (`sbx-kyc-<hash>`), not the input echoed back.
- Unit test: each variant + determinism. No properties object (marker consts), so no config wiring change.

## Bean-conflict avoidance (the key CI risk - designed out)
Off-by-default + the existing @SpringBootTest ITs (KycApiContextIT/AmlConsumerIT/ComplianceLifecycleIT) do NOT set the flag -> SandboxKycProvider stays inactive there -> their test-fake KycProvider remains the single bean -> no NoUniqueBeanDefinitionException. The ITs are untouched.

## Gate chain
- critic: GO (bean-conflict reasoning verified airtight; 1 LOW deferred to the future chart slice).
- security-auditor (opus): PASS - §5.3 clean (generic markers, no real provider/logic/PII), off-by-default safe, deterministic+documented, 4/4 ACs.
- code-reviewer: APPROVED; 1 LOW applied - the provider reference no longer echoes the raw subject value (opaque deterministic token), satisfying the result-field invariant.
- evaluator: PASS (0.91).
All local gates green (unit test; infrastructure/kyc so the domain jacoco gate is unaffected).

Closes #239