### PR TITLE
feat(compliance): add the deterministic sandbox sanctions provider

### DIFF
--- a/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/sanctions/SandboxSanctionsProvider.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/sanctions/SandboxSanctionsProvider.kt
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.infrastructure.sanctions
+
+import com.fincore.compliance.application.sanctions.SanctionsProvider
+import com.fincore.compliance.application.sanctions.SanctionsScreeningRequest
+import com.fincore.compliance.application.sanctions.SanctionsScreeningResult
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.stereotype.Component
+
+/**
+ * Deterministic in-tree sandbox sanctions provider, off by default. Encodes no real sanctions list; the outcome is a
+ * pure function of documented case-insensitive markers. An "insufficient" marker in the opaque subject reference yields
+ * InsufficientData; otherwise the provided attribute keys carrying the "match" marker are the matched dimensions, and a
+ * potential hit is reported when at least the requested number of them match. The score is a fixed sandbox confidence,
+ * not the m-of-n ratio.
+ */
+@Component
+@ConditionalOnProperty(
+    prefix = "fincore.compliance.sanctions.sandbox",
+    name = ["enabled"],
+    havingValue = "true",
+    matchIfMissing = false,
+)
+class SandboxSanctionsProvider : SanctionsProvider {
+    override fun screen(request: SanctionsScreeningRequest): SanctionsScreeningResult {
+        if (request.subjectReference.contains(INSUFFICIENT_MARKER, ignoreCase = true)) {
+            return SanctionsScreeningResult.InsufficientData(listOf("sandbox.insufficient"))
+        }
+        val matched = request.attributes.filter { it.contains(MATCH_MARKER, ignoreCase = true) }
+        return if (matched.size >= request.requiredMatches) {
+            SanctionsScreeningResult.PotentialMatch(matched, MATCH_SCORE)
+        } else {
+            SanctionsScreeningResult.Clear
+        }
+    }
+
+    private companion object {
+        const val MATCH_MARKER = "match"
+        const val INSUFFICIENT_MARKER = "insufficient"
+        const val MATCH_SCORE = 0.75
+    }
+}

--- a/services/compliance/src/test/kotlin/com/fincore/compliance/infrastructure/sanctions/SandboxSanctionsProviderTest.kt
+++ b/services/compliance/src/test/kotlin/com/fincore/compliance/infrastructure/sanctions/SandboxSanctionsProviderTest.kt
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.infrastructure.sanctions
+
+import com.fincore.compliance.application.sanctions.SanctionsScreeningRequest
+import com.fincore.compliance.application.sanctions.SanctionsScreeningResult
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.jupiter.api.Test
+
+class SandboxSanctionsProviderTest {
+    private val provider = SandboxSanctionsProvider()
+
+    @Test
+    fun `should clear when no attribute carries the match marker`() {
+        val request = SanctionsScreeningRequest("subject-1", setOf("attr-a", "attr-b"), 1)
+
+        provider.screen(request) shouldBe SanctionsScreeningResult.Clear
+    }
+
+    @Test
+    fun `should report a potential match when enough attributes match`() {
+        val request = SanctionsScreeningRequest("subject-1", setOf("match-a", "match-b"), 2)
+
+        val result = provider.screen(request).shouldBeInstanceOf<SanctionsScreeningResult.PotentialMatch>()
+        result.matchedAttributes.toSet() shouldBe setOf("match-a", "match-b")
+    }
+
+    @Test
+    fun `should clear when matched attributes are below the required count`() {
+        val request = SanctionsScreeningRequest("subject-1", setOf("match-a", "attr-b"), 2)
+
+        provider.screen(request) shouldBe SanctionsScreeningResult.Clear
+    }
+
+    @Test
+    fun `should return insufficient data when the subject reference is marked`() {
+        val request = SanctionsScreeningRequest("insufficient-subject", setOf("attr-a"), 1)
+
+        provider.screen(request).shouldBeInstanceOf<SanctionsScreeningResult.InsufficientData>()
+    }
+
+    @Test
+    fun `should be deterministic for the same request`() {
+        val request = SanctionsScreeningRequest("subject-1", setOf("match-a", "match-b"), 1)
+
+        provider.screen(request) shouldBe provider.screen(request)
+    }
+}


### PR DESCRIPTION
E-04 / E-06 #240 - an in-tree sandbox impl of the SanctionsProvider port (unblocked now that port #264 exists). Mirrors the merged #239 SandboxKycProvider.

## What
- `infrastructure/sanctions/SandboxSanctionsProvider` - `@Component @ConditionalOnProperty(prefix="fincore.compliance.sanctions.sandbox", name=[enabled], havingValue=true, matchIfMissing=false)`, **off by default**. Deterministic, marker-based, exercising the port's m-of-n contract: `insufficient` in the opaque subjectReference -> InsufficientData; otherwise the provided attribute keys carrying the `match` marker are the matched dimensions, and a PotentialMatch is reported once `matched.size >= requiredMatches`, else Clear. The score is a fixed confidence const (not the m-of-n ratio, per the port KDoc).
- Unit test: Clear / PotentialMatch / below-threshold-Clear / InsufficientData / determinism.

## Bean-conflict (verified clean)
Nothing injects `SanctionsProvider` (only the port files + its contract test). Off-by-default => no bean unless enabled, and no context requires it => neither a NoUniqueBeanDefinitionException nor a missing-bean failure. The ITs are untouched.

## Gate chain
- critic: GO (bean-conflict verified airtight; m-of-n + invariants sound).
- security-auditor (opus): PASS - §5.3 clean (generic markers, no real lists/names/PEP/PII; output echoes only caller attribute keys), off-by-default safe, score is a generic confidence const, 4/4 ACs.
- code-reviewer: APPROVED, no must-fix.
- evaluator: PASS (0.88).
All local gates green (unit test; infrastructure/sanctions so the domain jacoco gate is unaffected).

With this, only #277 (KYC idempotency) remains before epic E-04 #162 can close.

Closes #240