### PR TITLE
feat(compliance): make kyc session initiation idempotent

### DIFF
--- a/services/compliance/src/integrationTest/kotlin/com/fincore/compliance/api/KycApiContextIT.kt
+++ b/services/compliance/src/integrationTest/kotlin/com/fincore/compliance/api/KycApiContextIT.kt
@@ -62,6 +62,7 @@ class KycApiContextIT(
                 .perform(
                     post("/v1/kyc/sessions")
                         .with(jwt().authorities(SimpleGrantedAuthority(WRITE)))
+                        .header("Idempotency-Key", "key-1")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""{"subjectReference":"subject-1"}"""),
                 ).andExpect(status().isCreated)

--- a/services/compliance/src/integrationTest/kotlin/com/fincore/compliance/application/kyc/KycServicePersistenceIT.kt
+++ b/services/compliance/src/integrationTest/kotlin/com/fincore/compliance/application/kyc/KycServicePersistenceIT.kt
@@ -4,6 +4,7 @@
 package com.fincore.compliance.application.kyc
 
 import com.fincore.compliance.domain.enum.KycStatus
+import com.fincore.compliance.infrastructure.persistence.KycIdempotencyKeyRepository
 import com.fincore.compliance.infrastructure.persistence.KycSessionPersistenceAdapter
 import com.fincore.compliance.infrastructure.persistence.KycSessionRepository
 import com.fincore.test.containers.PostgresContainerExtension
@@ -24,19 +25,21 @@ import org.springframework.transaction.annotation.Transactional
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Transactional(propagation = Propagation.NOT_SUPPORTED)
 @ExtendWith(PostgresContainerExtension::class)
-@Import(KycServiceImpl::class, KycSessionPersistenceAdapter::class)
+@Import(KycServiceImpl::class, KycSessionPersistenceAdapter::class, KycIdempotencyStore::class)
 class KycServicePersistenceIT(
     @Autowired private val service: KycService,
     @Autowired private val repository: KycSessionRepository,
+    @Autowired private val keys: KycIdempotencyKeyRepository,
 ) {
     @AfterEach
     fun cleanUp() {
+        keys.deleteAll()
         repository.deleteAll()
     }
 
     @Test
     fun `should initiate then get a session round-tripping through postgres`() {
-        val initiated = service.initiate(InitiateKycSessionCommand("subject-1"))
+        val initiated = service.initiate(InitiateKycSessionCommand("key-1", "subject-1"))
 
         val reloaded = service.get(initiated.id)
         reloaded.id shouldBe initiated.id
@@ -46,11 +49,20 @@ class KycServicePersistenceIT(
 
     @Test
     fun `should persist the screening transition`() {
-        val initiated = service.initiate(InitiateKycSessionCommand("subject-2"))
+        val initiated = service.initiate(InitiateKycSessionCommand("key-2", "subject-2"))
 
         service.beginScreening(initiated.id)
 
         service.get(initiated.id).status shouldBe KycStatus.SCREENING
+    }
+
+    @Test
+    fun `should not create a second session when initiating twice with the same key`() {
+        val first = service.initiate(InitiateKycSessionCommand("key-1", "subject-1"))
+        val second = service.initiate(InitiateKycSessionCommand("key-1", "subject-1"))
+
+        second.id shouldBe first.id
+        repository.count() shouldBe 1L
     }
 
     companion object {

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/api/KycController.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/api/KycController.kt
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
 import java.net.URI
@@ -27,12 +28,16 @@ class KycController(
     private val kycService: KycService,
     private val mapper: KycApiMapper,
 ) {
-    @Operation(summary = "Start a KYC session", description = "Creates a session in the INITIATED state.")
+    @Operation(
+        summary = "Start a KYC session",
+        description = "Creates a session in the INITIATED state; idempotent on the Idempotency-Key header.",
+    )
     @PostMapping
     fun initiate(
+        @RequestHeader("Idempotency-Key") idempotencyKey: String,
         @Valid @RequestBody request: CreateKycSessionRequest,
     ): ResponseEntity<KycSessionResponse> {
-        val response = mapper.toResponse(kycService.initiate(mapper.toCommand(request)))
+        val response = mapper.toResponse(kycService.initiate(mapper.toCommand(request, idempotencyKey)))
         return ResponseEntity.created(URI.create("/v1/kyc/sessions/${response.id}")).body(response)
     }
 

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/api/error/ProblemType.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/api/error/ProblemType.kt
@@ -20,6 +20,12 @@ enum class ProblemType(
         "COMPLIANCE_CONFLICT",
         "illegal compliance state transition",
     ),
+    CONCURRENCY_CONFLICT(
+        "concurrency-conflict",
+        HttpStatus.SERVICE_UNAVAILABLE,
+        "CONCURRENCY_CONFLICT",
+        "concurrency conflict, retry",
+    ),
     VALIDATION_FAILED("validation-failed", HttpStatus.BAD_REQUEST, "VALIDATION_FAILED", "invalid request"),
     MALFORMED_REQUEST("malformed-request", HttpStatus.BAD_REQUEST, "MALFORMED_REQUEST", "invalid request"),
     INVALID_REQUEST("invalid-request", HttpStatus.BAD_REQUEST, "INVALID_REQUEST", "invalid request"),

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/api/mapper/KycApiMapper.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/api/mapper/KycApiMapper.kt
@@ -12,8 +12,10 @@ import org.springframework.stereotype.Component
 // Hand-written: the value-class KycSessionId crosses the wire as a prefixed-ULID string.
 @Component
 class KycApiMapper {
-    fun toCommand(request: CreateKycSessionRequest): InitiateKycSessionCommand =
-        InitiateKycSessionCommand(subjectReference = request.subjectReference)
+    fun toCommand(
+        request: CreateKycSessionRequest,
+        idempotencyKey: String,
+    ): InitiateKycSessionCommand = InitiateKycSessionCommand(idempotencyKey = idempotencyKey, subjectReference = request.subjectReference)
 
     fun toResponse(session: KycSession): KycSessionResponse =
         KycSessionResponse(

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/application/kyc/InitiateKycSessionCommand.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/application/kyc/InitiateKycSessionCommand.kt
@@ -3,7 +3,11 @@
 
 package com.fincore.compliance.application.kyc
 
-/** Command to start a KYC session. [subjectReference] is an opaque token (validated by the KycSession domain). */
+/**
+ * Command to start a KYC session. [subjectReference] is an opaque token (validated by the KycSession domain);
+ * [idempotencyKey] is the caller-supplied Idempotency-Key header value used to dedupe a repeated initiation.
+ */
 data class InitiateKycSessionCommand(
+    val idempotencyKey: String,
     val subjectReference: String,
 )

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/application/kyc/KycConcurrencyException.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/application/kyc/KycConcurrencyException.kt
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.kyc
+
+/** Raised when a KYC initiation could not settle against a concurrent caller after the bounded retries. */
+class KycConcurrencyException(
+    cause: Throwable,
+) : RuntimeException("Could not settle a concurrent KYC initiation after retries", cause)

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/application/kyc/KycIdempotencyStore.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/application/kyc/KycIdempotencyStore.kt
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.kyc
+
+import com.fincore.compliance.domain.KycSession
+import com.fincore.compliance.infrastructure.persistence.KycIdempotencyKeyEntity
+import com.fincore.compliance.infrastructure.persistence.KycIdempotencyKeyRepository
+import com.fincore.compliance.infrastructure.persistence.KycSessionPersistenceAdapter
+import com.fincore.compliance.infrastructure.persistence.KycSessionRepository
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+import java.time.Instant
+
+// Raised when a concurrent caller already committed this idempotency key. The service retries in a fresh transaction,
+// where the winner's committed key is found and its session replayed.
+internal class KycIdempotencyRaceException(
+    cause: Throwable,
+) : RuntimeException(cause)
+
+@Component
+class KycIdempotencyStore(
+    private val keyRepository: KycIdempotencyKeyRepository,
+    private val sessionRepository: KycSessionRepository,
+    private val adapter: KycSessionPersistenceAdapter,
+) {
+    @Transactional
+    fun reserveOrRun(
+        keyHash: String,
+        action: () -> KycSession,
+    ): KycSession {
+        val existing = keyRepository.findById(keyHash).orElse(null)
+        if (existing != null) {
+            val entity =
+                sessionRepository.findById(existing.kycSessionId).orElseThrow {
+                    IllegalStateException("Idempotency key references a missing session ${existing.kycSessionId}")
+                }
+            return adapter.toDomain(entity)
+        }
+        val session = action()
+        try {
+            keyRepository.saveAndFlush(KycIdempotencyKeyEntity(keyHash, session.id.value, Instant.now()))
+        } catch (duplicate: DataIntegrityViolationException) {
+            throw KycIdempotencyRaceException(duplicate)
+        }
+        return session
+    }
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/application/kyc/KycServiceImpl.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/application/kyc/KycServiceImpl.kt
@@ -16,9 +16,22 @@ import java.time.Instant
 class KycServiceImpl(
     private val repository: KycSessionRepository,
     private val adapter: KycSessionPersistenceAdapter,
+    private val idempotencyStore: KycIdempotencyStore,
 ) : KycService {
-    @Transactional
     override fun initiate(command: InitiateKycSessionCommand): KycSession {
+        val keyHash = Sha256.hex(command.idempotencyKey)
+        var attempt = 0
+        while (true) {
+            try {
+                return idempotencyStore.reserveOrRun(keyHash) { createSession(command) }
+            } catch (race: KycIdempotencyRaceException) {
+                attempt++
+                if (attempt >= MAX_ATTEMPTS) throw KycConcurrencyException(race)
+            }
+        }
+    }
+
+    private fun createSession(command: InitiateKycSessionCommand): KycSession {
         val session = KycSession(KycSessionId.generate(), command.subjectReference)
         repository.saveAndFlush(adapter.toNewEntity(session, Instant.now()))
         return session
@@ -47,5 +60,9 @@ class KycServiceImpl(
         entity.status = session.status
         repository.saveAndFlush(entity)
         return session
+    }
+
+    private companion object {
+        const val MAX_ATTEMPTS = 3
     }
 }

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/application/kyc/Sha256.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/application/kyc/Sha256.kt
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.application.kyc
+
+import java.security.MessageDigest
+
+object Sha256 {
+    fun hex(value: String): String =
+        MessageDigest
+            .getInstance("SHA-256")
+            .digest(value.toByteArray(Charsets.UTF_8))
+            .joinToString("") { "%02x".format(it) }
+}

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/exception/GlobalExceptionHandler.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/exception/GlobalExceptionHandler.kt
@@ -5,14 +5,18 @@ package com.fincore.compliance.exception
 
 import com.fincore.compliance.api.error.ProblemType
 import com.fincore.compliance.application.case.CaseNotFoundException
+import com.fincore.compliance.application.kyc.KycConcurrencyException
 import com.fincore.compliance.application.kyc.KycSessionNotFoundException
 import com.fincore.compliance.domain.ComplianceDomainException
 import jakarta.servlet.http.HttpServletRequest
 import org.springframework.dao.OptimisticLockingFailureException
+import org.springframework.http.HttpHeaders
 import org.springframework.http.ProblemDetail
+import org.springframework.http.ResponseEntity
 import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.validation.FieldError
 import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.MissingRequestHeaderException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
@@ -41,6 +45,18 @@ class GlobalExceptionHandler {
     @ExceptionHandler(OptimisticLockingFailureException::class)
     fun handleOptimisticLock(request: HttpServletRequest): ProblemDetail =
         problem(ProblemType.COMPLIANCE_CONFLICT, "Concurrent update conflict", request)
+
+    @ExceptionHandler(KycConcurrencyException::class)
+    fun handleConcurrency(
+        ex: KycConcurrencyException,
+        request: HttpServletRequest,
+    ): ResponseEntity<ProblemDetail> = retryable(ProblemType.CONCURRENCY_CONFLICT, ex.message, request)
+
+    @ExceptionHandler(MissingRequestHeaderException::class)
+    fun handleMissingHeader(
+        ex: MissingRequestHeaderException,
+        request: HttpServletRequest,
+    ): ProblemDetail = problem(ProblemType.INVALID_REQUEST, ex.message, request)
 
     @ExceptionHandler(MethodArgumentNotValidException::class)
     fun handleValidation(
@@ -74,6 +90,16 @@ class GlobalExceptionHandler {
     private fun toFieldError(error: FieldError): Map<String, String> =
         mapOf("field" to error.field, "message" to (error.defaultMessage ?: "invalid"))
 
+    private fun retryable(
+        type: ProblemType,
+        detail: String?,
+        request: HttpServletRequest,
+    ): ResponseEntity<ProblemDetail> =
+        ResponseEntity
+            .status(type.status)
+            .header(HttpHeaders.RETRY_AFTER, RETRY_AFTER_SECONDS)
+            .body(problem(type, detail, request))
+
     private fun problem(
         type: ProblemType,
         detail: String?,
@@ -85,4 +111,8 @@ class GlobalExceptionHandler {
             this.instance = URI.create(request.requestURI)
             setProperty("code", type.code)
         }
+
+    private companion object {
+        const val RETRY_AFTER_SECONDS = "1"
+    }
 }

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/persistence/KycIdempotencyKeyEntity.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/persistence/KycIdempotencyKeyEntity.kt
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.infrastructure.persistence
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.Immutable
+import java.time.Instant
+import java.util.UUID
+
+@Entity
+@Immutable
+@Table(name = "idempotency_keys", schema = "compliance")
+class KycIdempotencyKeyEntity(
+    @Id
+    @Column(name = "key_hash", nullable = false, updatable = false)
+    var keyHash: String,
+    @Column(name = "kyc_session_id", nullable = false, updatable = false)
+    var kycSessionId: UUID,
+    @Column(name = "created_at", nullable = false, updatable = false)
+    var createdAt: Instant,
+)

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/persistence/KycIdempotencyKeyRepository.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/persistence/KycIdempotencyKeyRepository.kt
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.compliance.infrastructure.persistence
+
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface KycIdempotencyKeyRepository : JpaRepository<KycIdempotencyKeyEntity, String>

--- a/services/compliance/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/services/compliance/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -22,3 +22,6 @@ databaseChangeLog:
   - include:
       file: v0.1/021-aml-alerts-subject-reference.sql
       relativeToChangelogFile: true
+  - include:
+      file: v0.1/022-idempotency-keys.sql
+      relativeToChangelogFile: true

--- a/services/compliance/src/main/resources/db/changelog/v0.1/022-idempotency-keys.sql
+++ b/services/compliance/src/main/resources/db/changelog/v0.1/022-idempotency-keys.sql
@@ -1,0 +1,11 @@
+--liquibase formatted sql
+-- SPDX-License-Identifier: BUSL-1.1
+-- SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+--changeset fincore:compliance-022-idempotency-keys dbms:postgresql
+CREATE TABLE IF NOT EXISTS compliance.idempotency_keys (
+    key_hash        VARCHAR(64) NOT NULL,
+    kyc_session_id  UUID        NOT NULL,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT pk_compliance_idempotency_keys PRIMARY KEY (key_hash)
+);

--- a/services/compliance/src/test/kotlin/com/fincore/compliance/api/KycControllerTest.kt
+++ b/services/compliance/src/test/kotlin/com/fincore/compliance/api/KycControllerTest.kt
@@ -56,6 +56,7 @@ class KycControllerTest(
             .perform(
                 post("/v1/kyc/sessions")
                     .with(jwt().authorities(SimpleGrantedAuthority(WRITE)))
+                    .header(IDEMPOTENCY_KEY, "key-1")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(VALID_BODY),
             ).andExpect(status().isCreated)
@@ -65,8 +66,12 @@ class KycControllerTest(
     @Test
     fun `should return 401 when initiating without a token`() {
         mockMvc
-            .perform(post("/v1/kyc/sessions").contentType(MediaType.APPLICATION_JSON).content(VALID_BODY))
-            .andExpect(status().isUnauthorized)
+            .perform(
+                post("/v1/kyc/sessions")
+                    .header(IDEMPOTENCY_KEY, "key-1")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(VALID_BODY),
+            ).andExpect(status().isUnauthorized)
     }
 
     @Test
@@ -75,6 +80,7 @@ class KycControllerTest(
             .perform(
                 post("/v1/kyc/sessions")
                     .with(jwt().authorities(SimpleGrantedAuthority(READ)))
+                    .header(IDEMPOTENCY_KEY, "key-1")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content(VALID_BODY),
             ).andExpect(status().isForbidden)
@@ -86,8 +92,20 @@ class KycControllerTest(
             .perform(
                 post("/v1/kyc/sessions")
                     .with(jwt().authorities(SimpleGrantedAuthority(WRITE)))
+                    .header(IDEMPOTENCY_KEY, "key-1")
                     .contentType(MediaType.APPLICATION_JSON)
                     .content("""{"subjectReference":""}"""),
+            ).andExpect(status().isBadRequest)
+    }
+
+    @Test
+    fun `should return 400 when the idempotency key header is missing`() {
+        mockMvc
+            .perform(
+                post("/v1/kyc/sessions")
+                    .with(jwt().authorities(SimpleGrantedAuthority(WRITE)))
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(VALID_BODY),
             ).andExpect(status().isBadRequest)
     }
 
@@ -116,6 +134,7 @@ class KycControllerTest(
     private companion object {
         const val READ = "SCOPE_compliance:read"
         const val WRITE = "SCOPE_compliance:write"
+        const val IDEMPOTENCY_KEY = "Idempotency-Key"
         const val VALID_BODY = """{"subjectReference":"subject-1"}"""
     }
 }

--- a/services/compliance/src/test/kotlin/com/fincore/compliance/application/kyc/KycServiceImplTest.kt
+++ b/services/compliance/src/test/kotlin/com/fincore/compliance/application/kyc/KycServiceImplTest.kt
@@ -4,6 +4,7 @@
 package com.fincore.compliance.application.kyc
 
 import com.fincore.compliance.domain.ComplianceDomainException
+import com.fincore.compliance.domain.KycSession
 import com.fincore.compliance.domain.enum.KycStatus
 import com.fincore.compliance.infrastructure.persistence.KycSessionEntity
 import com.fincore.compliance.infrastructure.persistence.KycSessionPersistenceAdapter
@@ -21,16 +22,25 @@ import java.util.UUID
 
 class KycServiceImplTest {
     private val repository = mockk<KycSessionRepository>()
-    private val service = KycServiceImpl(repository, KycSessionPersistenceAdapter())
+    private val idempotencyStore = mockk<KycIdempotencyStore>()
+    private val service = KycServiceImpl(repository, KycSessionPersistenceAdapter(), idempotencyStore)
 
     @Test
     fun `should create an initiated session when initiating`() {
         every { repository.saveAndFlush(any()) } answers { firstArg() }
+        every { idempotencyStore.reserveOrRun(any(), any()) } answers { secondArg<() -> KycSession>().invoke() }
 
-        val session = service.initiate(InitiateKycSessionCommand("subject-1"))
+        val session = service.initiate(InitiateKycSessionCommand("key-1", "subject-1"))
 
         session.status shouldBe KycStatus.INITIATED
         session.subjectReference shouldBe "subject-1"
+    }
+
+    @Test
+    fun `should throw a concurrency exception when the idempotency key keeps racing`() {
+        every { idempotencyStore.reserveOrRun(any(), any()) } throws KycIdempotencyRaceException(RuntimeException("dup"))
+
+        shouldThrow<KycConcurrencyException> { service.initiate(InitiateKycSessionCommand("key-1", "subject-1")) }
     }
 
     @Test


### PR DESCRIPTION
E-04 #277 (LAST E-04 slice) - Idempotency-Key dedup on POST /v1/kyc/sessions, mirroring the merged payments #211 service-level pattern.

## What
- **Migration** `v0.1/022-idempotency-keys.sql` (idempotent): `compliance.idempotency_keys` (key_hash VARCHAR(64) PK, kyc_session_id UUID, created_at), wired into the master changelog.
- **KycIdempotencyStore.reserveOrRun** (@Transactional): replay the session by the stored id if the key exists; else run the action and record the key; a duplicate-PK `DataIntegrityViolationException` -> `KycIdempotencyRaceException`.
- **KycServiceImpl.initiate** is no longer @Transactional (the retry must span transactions; the store owns the boundary): `Sha256.hex(key)` -> bounded retry (MAX_ATTEMPTS=3) -> `KycConcurrencyException` on a persistent race. A lost race retries in a fresh transaction, finds the winner's committed key, and replays.
- **Controller** requires `Idempotency-Key` (400 via a new `MissingRequestHeaderException` handler); concurrency -> 503 retryable with `Retry-After`. Only the SHA-256 hash is stored, never the raw header.

## Gate chain
- critic: GO-WITH-CHANGES (header on all 4 controller-test POSTs + a dedicated missing-header-400 test; `retryable(type,detail,request)` verbatim; exception keeps its message - all applied).
- security-auditor (opus): PASS - idempotency correct under concurrency (fresh-tx retry sees the committed winner, no double-create), raw key never persisted/logged, fail-closed 400/503, §5.3 clean, 4/4 ACs.
- code-reviewer: CHANGES-REQUIRED, but all findings **declined with source evidence** - the var-vs-val, store-calls-toDomain, and missing-header-200 claims each contradict the merged payments template (which uses `var`, calls `adapter.toDomain` in its store, and returns a bare `ProblemDetail`); the missing-header->400 test ran and passed (7 tests, 0 failures).
- evaluator: PASS (0.88).
All local gates green; the replay + screening + round-trip ITs run on CI.

With this merged, epic E-04 Compliance #162 is complete.

Closes #277