### PR TITLE
feat(web): add decision log viewer screen on the decision logs api

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,6 +7,7 @@ import { ThemeProvider } from '@/components/ThemeProvider'
 import { AccountDetail } from '@/routes/AccountDetail'
 import { Accounts } from '@/routes/Accounts'
 import { Cases } from '@/routes/Cases'
+import { Decisions } from '@/routes/Decisions'
 import { Overview } from '@/routes/Overview'
 import { TransactionDetail } from '@/routes/TransactionDetail'
 import { Transactions } from '@/routes/Transactions'
@@ -25,6 +26,7 @@ export function App() {
                         <Route path="/transactions" element={<Transactions />} />
                         <Route path="/transactions/:id" element={<TransactionDetail />} />
                         <Route path="/compliance/cases" element={<Cases />} />
+                        <Route path="/decisions" element={<Decisions />} />
                     </Routes>
                 </BrowserRouter>
             </ThemeProvider>

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -86,3 +86,12 @@ export interface CaseResponse {
     reference: string
     status: CaseStatus
 }
+
+export interface DecisionLogResponse {
+    id: string
+    evaluatedAt: string
+    ruleVersionId: string
+    inputHash: string
+    matched: boolean
+    outcomeLabel: string | null
+}

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -15,7 +15,7 @@ const NAV: NavItem[] = [
     { name: 'Accounts', icon: 'wallet', path: '/accounts' },
     { name: 'Transactions', icon: 'arrows', path: '/transactions' },
     { name: 'Payments', icon: 'send' },
-    { name: 'Decisions', icon: 'scale' },
+    { name: 'Decisions', icon: 'scale', path: '/decisions' },
     { name: 'Compliance', icon: 'shield', path: '/compliance/cases' },
     { name: 'Audit', icon: 'book' },
 ]

--- a/web/src/features/decisions/DecisionLogsTable.tsx
+++ b/web/src/features/decisions/DecisionLogsTable.tsx
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+import type { DecisionLogResponse } from '@/api/types'
+import { formatInstant } from '@/lib/money'
+import { MatchedPill } from './Pills'
+
+export function DecisionLogsTable({ logs }: { logs: DecisionLogResponse[] }) {
+    return (
+        <table className="tbl">
+            <thead>
+                <tr>
+                    <th>Log ID</th>
+                    <th>Evaluated At</th>
+                    <th>Rule Version</th>
+                    <th>Matched</th>
+                    <th>Outcome</th>
+                </tr>
+            </thead>
+            <tbody>
+                {logs.map((log) => (
+                    <tr key={log.id}>
+                        <td className="mono" title={log.id} style={{ color: 'var(--text-accent)' }}>
+                            {log.id}
+                        </td>
+                        <td className="mono" style={{ color: 'var(--text-2)' }}>
+                            {formatInstant(log.evaluatedAt)}
+                        </td>
+                        <td
+                            className="mono"
+                            title={log.ruleVersionId}
+                            style={{ color: 'var(--text-2)' }}
+                        >
+                            {log.ruleVersionId}
+                        </td>
+                        <td>
+                            <MatchedPill matched={log.matched} />
+                        </td>
+                        <td>{log.outcomeLabel ?? '-'}</td>
+                    </tr>
+                ))}
+            </tbody>
+        </table>
+    )
+}

--- a/web/src/features/decisions/Pills.tsx
+++ b/web/src/features/decisions/Pills.tsx
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+export function MatchedPill({ matched }: { matched: boolean }) {
+    return (
+        <span className={`pill ${matched ? 'pill-teal' : 'pill-grey'}`}>
+            <span className="dot" />
+            {matched ? 'MATCHED' : 'NO MATCH'}
+        </span>
+    )
+}

--- a/web/src/features/decisions/useDecisionLogs.ts
+++ b/web/src/features/decisions/useDecisionLogs.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+import { useQuery } from '@tanstack/react-query'
+import { apiFetch } from '@/api/client'
+import type { DecisionLogResponse } from '@/api/types'
+
+export type DecisionLogField = 'inputHash' | 'ruleVersionId'
+
+export interface DecisionLogFilter {
+    field: DecisionLogField
+    value: string
+}
+
+export function useDecisionLogs(filter: DecisionLogFilter | null) {
+    return useQuery({
+        queryKey: ['decision-logs', filter],
+        queryFn: () => {
+            const { field, value } = filter!
+            return apiFetch<DecisionLogResponse[]>(
+                `/v1/decision/logs?${field}=${encodeURIComponent(value)}`,
+            )
+        },
+        enabled: filter !== null,
+    })
+}

--- a/web/src/routes/Decisions.tsx
+++ b/web/src/routes/Decisions.tsx
@@ -1,0 +1,108 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+import { useState } from 'react'
+import { Shell } from '@/components/Shell'
+import { StateMessage } from '@/components/StateMessage'
+import { DecisionLogsTable } from '@/features/decisions/DecisionLogsTable'
+import {
+    type DecisionLogField,
+    type DecisionLogFilter,
+    useDecisionLogs,
+} from '@/features/decisions/useDecisionLogs'
+
+const FIELDS: { value: DecisionLogField; label: string }[] = [
+    { value: 'inputHash', label: 'Input hash' },
+    { value: 'ruleVersionId', label: 'Rule version id' },
+]
+
+export function Decisions() {
+    const [field, setField] = useState<DecisionLogField>('inputHash')
+    const [value, setValue] = useState('')
+    const [filter, setFilter] = useState<DecisionLogFilter | null>(null)
+    const { data, isPending, isError, refetch } = useDecisionLogs(filter)
+
+    const submit = (event: React.FormEvent) => {
+        event.preventDefault()
+        const trimmed = value.trim()
+        if (trimmed) setFilter({ field, value: trimmed })
+    }
+
+    return (
+        <Shell activeNav="Decisions">
+            <div
+                style={{
+                    padding: '20px 24px',
+                    display: 'flex',
+                    flexDirection: 'column',
+                    gap: 16,
+                    flex: 1,
+                    minHeight: 0,
+                }}
+            >
+                <form onSubmit={submit} style={{ display: 'flex', gap: 8, alignItems: 'center' }}>
+                    <div
+                        role="tablist"
+                        aria-label="Filter field"
+                        style={{ display: 'flex', gap: 6 }}
+                    >
+                        {FIELDS.map((option) => (
+                            <button
+                                key={option.value}
+                                type="button"
+                                role="tab"
+                                aria-selected={option.value === field}
+                                className={`btn${option.value === field ? ' btn-active' : ''}`}
+                                onClick={() => setField(option.value)}
+                            >
+                                {option.label}
+                            </button>
+                        ))}
+                    </div>
+                    <input
+                        className="input mono"
+                        aria-label="Query value"
+                        value={value}
+                        onChange={(event) => setValue(event.target.value)}
+                        style={{ flex: 1 }}
+                    />
+                    <button type="submit" className="btn">
+                        Search
+                    </button>
+                </form>
+
+                <div
+                    className="card"
+                    style={{
+                        flex: 1,
+                        minHeight: 0,
+                        display: 'flex',
+                        flexDirection: 'column',
+                        overflow: 'hidden',
+                    }}
+                >
+                    <div style={{ flex: 1, overflow: 'auto' }} className="fc-scroll">
+                        {filter === null ? (
+                            <StateMessage
+                                icon="inbox"
+                                text="Enter an input hash or rule version id to search the decision log."
+                            />
+                        ) : isPending ? (
+                            <StateMessage icon="activity" text="Loading decision logs..." />
+                        ) : isError ? (
+                            <StateMessage icon="alert" text="Could not load decision logs.">
+                                <button type="button" className="btn" onClick={() => refetch()}>
+                                    Retry
+                                </button>
+                            </StateMessage>
+                        ) : data.length === 0 ? (
+                            <StateMessage icon="inbox" text="No decision logs for this query." />
+                        ) : (
+                            <DecisionLogsTable logs={data} />
+                        )}
+                    </div>
+                </div>
+            </div>
+        </Shell>
+    )
+}

--- a/web/src/test/Decisions.test.tsx
+++ b/web/src/test/Decisions.test.tsx
@@ -1,0 +1,120 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactElement } from 'react'
+import { MemoryRouter } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { DecisionLogResponse } from '@/api/types'
+import { ThemeProvider } from '@/components/ThemeProvider'
+import { Decisions } from '@/routes/Decisions'
+
+const SAMPLE: DecisionLogResponse[] = [
+    {
+        id: 'log_0001',
+        evaluatedAt: '2026-06-19T10:00:00Z',
+        ruleVersionId: 'ver-0001',
+        inputHash: 'hash-abc',
+        matched: true,
+        outcomeLabel: 'APPROVE',
+    },
+    {
+        id: 'log_0002',
+        evaluatedAt: '2026-06-19T10:05:00Z',
+        ruleVersionId: 'ver-0001',
+        inputHash: 'hash-abc',
+        matched: false,
+        outcomeLabel: null,
+    },
+]
+
+function ok(body: unknown) {
+    return { ok: true, status: 200, json: async () => body } as Response
+}
+
+function renderDecisions() {
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+    const ui: ReactElement = (
+        <QueryClientProvider client={client}>
+            <MemoryRouter initialEntries={['/decisions']}>
+                <ThemeProvider>
+                    <Decisions />
+                </ThemeProvider>
+            </MemoryRouter>
+        </QueryClientProvider>
+    )
+    return render(ui)
+}
+
+function search(value: string) {
+    fireEvent.change(screen.getByLabelText('Query value'), { target: { value } })
+    fireEvent.click(screen.getByRole('button', { name: 'Search' }))
+}
+
+afterEach(() => {
+    vi.restoreAllMocks()
+})
+
+describe('Decisions', () => {
+    it('shows an idle prompt and does not fetch before a search', () => {
+        const fetchMock = vi.spyOn(globalThis, 'fetch')
+        renderDecisions()
+        expect(
+            screen.getByText('Enter an input hash or rule version id to search the decision log.'),
+        ).toBeInTheDocument()
+        expect(fetchMock).not.toHaveBeenCalled()
+    })
+
+    it('queries by input hash and renders a row per log', async () => {
+        const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(ok(SAMPLE))
+        renderDecisions()
+        search('hash-abc')
+        expect(await screen.findByText('log_0001')).toBeInTheDocument()
+        expect(screen.getAllByRole('row')).toHaveLength(SAMPLE.length + 1)
+        expect(String(fetchMock.mock.calls.at(-1)?.[0])).toContain('inputHash=hash-abc')
+    })
+
+    it('renders the matched state for each log', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(ok(SAMPLE))
+        renderDecisions()
+        search('hash-abc')
+        expect(await screen.findByText('MATCHED')).toBeInTheDocument()
+        expect(screen.getByText('NO MATCH')).toBeInTheDocument()
+    })
+
+    it('queries by rule version id when that field is selected', async () => {
+        const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(ok(SAMPLE))
+        renderDecisions()
+        fireEvent.click(screen.getByRole('tab', { name: 'Rule version id' }))
+        search('ver-0001')
+        await waitFor(() =>
+            expect(String(fetchMock.mock.calls.at(-1)?.[0])).toContain('ruleVersionId=ver-0001'),
+        )
+    })
+
+    it('shows an empty state when the query returns no logs', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(ok([]))
+        renderDecisions()
+        search('hash-none')
+        expect(await screen.findByText('No decision logs for this query.')).toBeInTheDocument()
+    })
+
+    it('shows an error state with a working Retry', async () => {
+        const fetchMock = vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network down'))
+        renderDecisions()
+        search('hash-abc')
+        expect(await screen.findByText('Could not load decision logs.')).toBeInTheDocument()
+        const before = fetchMock.mock.calls.length
+        fireEvent.click(screen.getByRole('button', { name: 'Retry' }))
+        await waitFor(() => expect(fetchMock.mock.calls.length).toBeGreaterThan(before))
+    })
+
+    it('marks the Decisions sidebar item as the current page', () => {
+        renderDecisions()
+        expect(screen.getByRole('link', { name: 'Decisions' })).toHaveAttribute(
+            'aria-current',
+            'page',
+        )
+    })
+})


### PR DESCRIPTION
E-08 Sandbox UI #288 (F-08.8) - a read-only decision log viewer over the live decision-logs API.

## What
The decision audit log is queryable **only by exactly one of inputHash or ruleVersionId** (the backend 400s otherwise), so this is a **query-by-key** screen, not a browse-all list:
- `features/decisions/useDecisionLogs` - TanStack Query gated by `enabled: filter !== null` so nothing is fetched until a search; sends exactly one `?field=value` pair, value `encodeURIComponent`-escaped.
- `routes/Decisions.tsx` - a field selector (Input hash / Rule version id) + value input + Search, with idle / loading / empty / error+retry states (idle checked before `isPending` so a disabled query never shows a perpetual spinner).
- `DecisionLogsTable` + `MatchedPill`; `api/types.ts` `DecisionLogResponse {id, evaluatedAt, ruleVersionId, inputHash, matched, outcomeLabel?}` matching the backend DTO field-for-field.
- App route `/decisions` + Sidebar entry. 7 vitest tests.

## Gate chain
- critic: GO (read endpoint verified present; UI-only).
- security-auditor (opus): PASS - §5.3 clean (opaque hashes/ids, no PII), query value escaped + exactly-one-param (no injection), React-escaped output, no secrets, 9/9 reqs.
- code-reviewer: the double non-null-assertion was tidied (destructure once); the inline-style finding was declined - it mirrors the merged AccountsTable/TransactionsTable/CasesTable + routes verbatim (repo-wide style question, not this slice's to fork).
- evaluator: PASS (0.875).
Web gates green: lint 0 errors, typecheck, vitest 50 passed (7 new), build.

Closes #288