### PR TITLE
feat(payments): add a paged list endpoint for payments

### DIFF
--- a/services/payments/src/integrationTest/kotlin/com/fincore/payments/application/PaymentServiceIT.kt
+++ b/services/payments/src/integrationTest/kotlin/com/fincore/payments/application/PaymentServiceIT.kt
@@ -84,6 +84,18 @@ class PaymentServiceIT(
     }
 
     @Test
+    fun `should list initiated payments as a page newest first`() {
+        service.initiate(InitiatePaymentCommand("key-1", money(), "order-1"))
+        service.initiate(InitiatePaymentCommand("key-2", money(), "order-2"))
+
+        val page = service.list(0, 20)
+
+        page.totalElements shouldBe 2L
+        page.items.size shouldBe 2
+        page.items.first().reference shouldBe "order-2"
+    }
+
+    @Test
     fun `should cancel an initiated payment and emit a cancelled event`() {
         val payment = service.initiate(InitiatePaymentCommand("key-1", money(), "order-1"))
 

--- a/services/payments/src/main/kotlin/com/fincore/payments/api/PaymentController.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/api/PaymentController.kt
@@ -5,6 +5,7 @@ package com.fincore.payments.api
 
 import com.fincore.core.PaymentId
 import com.fincore.payments.api.dto.request.InitiatePaymentRequest
+import com.fincore.payments.api.dto.response.PageResponse
 import com.fincore.payments.api.dto.response.PaymentResponse
 import com.fincore.payments.api.mapper.PaymentApiMapper
 import com.fincore.payments.application.PaymentService
@@ -18,6 +19,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestHeader
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 import java.net.URI
 
@@ -38,6 +40,17 @@ class PaymentController(
         return ResponseEntity.created(URI.create("/v1/payments/${response.id}")).body(response)
     }
 
+    @Operation(summary = "List payments", description = "Returns a page of payments, newest first.")
+    @GetMapping
+    fun list(
+        @RequestParam(defaultValue = "0") page: Int,
+        @RequestParam(defaultValue = "20") size: Int,
+    ): PageResponse<PaymentResponse> {
+        require(page >= 0) { "page must be >= 0" }
+        require(size in 1..MAX_PAGE_SIZE) { "size must be 1..$MAX_PAGE_SIZE" }
+        return mapper.toPageResponse(paymentService.list(page, size))
+    }
+
     @Operation(summary = "Get a payment", description = "Returns the payment or 404.")
     @GetMapping("/{id}")
     fun get(
@@ -49,4 +62,8 @@ class PaymentController(
     fun cancel(
         @PathVariable id: String,
     ): PaymentResponse = mapper.toResponse(paymentService.cancel(PaymentId.fromString(id)))
+
+    private companion object {
+        const val MAX_PAGE_SIZE = 100
+    }
 }

--- a/services/payments/src/main/kotlin/com/fincore/payments/api/dto/response/PageResponse.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/api/dto/response/PageResponse.kt
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.api.dto.response
+
+data class PageResponse<T>(
+    val items: List<T>,
+    val page: Int,
+    val size: Int,
+    val totalElements: Long,
+    val totalPages: Int,
+)

--- a/services/payments/src/main/kotlin/com/fincore/payments/api/mapper/PaymentApiMapper.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/api/mapper/PaymentApiMapper.kt
@@ -6,8 +6,10 @@ package com.fincore.payments.api.mapper
 import com.fincore.core.Currency
 import com.fincore.core.Money
 import com.fincore.payments.api.dto.request.InitiatePaymentRequest
+import com.fincore.payments.api.dto.response.PageResponse
 import com.fincore.payments.api.dto.response.PaymentResponse
 import com.fincore.payments.application.InitiatePaymentCommand
+import com.fincore.payments.application.PaymentPage
 import com.fincore.payments.domain.Payment
 import org.springframework.stereotype.Component
 
@@ -31,5 +33,14 @@ class PaymentApiMapper {
             amount = payment.amount.amount,
             currency = payment.amount.currency.code,
             status = payment.status.name,
+        )
+
+    fun toPageResponse(page: PaymentPage): PageResponse<PaymentResponse> =
+        PageResponse(
+            items = page.items.map(::toResponse),
+            page = page.page,
+            size = page.size,
+            totalElements = page.totalElements,
+            totalPages = page.totalPages,
         )
 }

--- a/services/payments/src/main/kotlin/com/fincore/payments/application/PaymentPage.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/application/PaymentPage.kt
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.payments.application
+
+import com.fincore.payments.domain.Payment
+
+data class PaymentPage(
+    val items: List<Payment>,
+    val page: Int,
+    val size: Int,
+    val totalElements: Long,
+    val totalPages: Int,
+)

--- a/services/payments/src/main/kotlin/com/fincore/payments/application/PaymentService.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/application/PaymentService.kt
@@ -9,6 +9,11 @@ import com.fincore.payments.domain.Payment
 interface PaymentService {
     fun initiate(command: InitiatePaymentCommand): Payment
 
+    fun list(
+        page: Int,
+        size: Int,
+    ): PaymentPage
+
     fun get(id: PaymentId): Payment
 
     fun cancel(id: PaymentId): Payment

--- a/services/payments/src/main/kotlin/com/fincore/payments/application/PaymentServiceImpl.kt
+++ b/services/payments/src/main/kotlin/com/fincore/payments/application/PaymentServiceImpl.kt
@@ -16,6 +16,8 @@ import com.fincore.payments.infrastructure.persistence.PaymentEventEntity
 import com.fincore.payments.infrastructure.persistence.PaymentEventRepository
 import com.fincore.payments.infrastructure.persistence.PaymentPersistenceAdapter
 import com.fincore.payments.infrastructure.persistence.PaymentRepository
+import org.springframework.data.domain.PageRequest
+import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
@@ -42,6 +44,22 @@ class PaymentServiceImpl(
                 if (attempt >= MAX_ATTEMPTS) throw PaymentConcurrencyException(race)
             }
         }
+    }
+
+    @Transactional(readOnly = true)
+    override fun list(
+        page: Int,
+        size: Int,
+    ): PaymentPage {
+        val pageable = PageRequest.of(page, size, Sort.by(Sort.Order.desc("createdAt"), Sort.Order.desc("id")))
+        val result = paymentRepository.findAll(pageable)
+        return PaymentPage(
+            items = result.content.map(adapter::toDomain),
+            page = page,
+            size = size,
+            totalElements = result.totalElements,
+            totalPages = result.totalPages,
+        )
     }
 
     @Transactional(readOnly = true)

--- a/services/payments/src/test/kotlin/com/fincore/payments/api/PaymentControllerTest.kt
+++ b/services/payments/src/test/kotlin/com/fincore/payments/api/PaymentControllerTest.kt
@@ -8,6 +8,7 @@ import com.fincore.core.Money
 import com.fincore.core.PaymentId
 import com.fincore.payments.api.mapper.PaymentApiMapper
 import com.fincore.payments.application.PaymentConcurrencyException
+import com.fincore.payments.application.PaymentPage
 import com.fincore.payments.application.PaymentService
 import com.fincore.payments.config.SecurityConfig
 import com.fincore.payments.domain.Payment
@@ -136,6 +137,30 @@ class PaymentControllerTest(
             .perform(get("/v1/payments/${payment.id}").with(jwt().authorities(SimpleGrantedAuthority(READ))))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.id").value(payment.id.toString()))
+    }
+
+    @Test
+    fun `should list payments as a page with read scope`() {
+        every { paymentService.list(0, 20) } returns
+            PaymentPage(listOf(payment(PaymentStatus.INITIATED)), 0, 20, 1, 1)
+
+        mockMvc
+            .perform(get("/v1/payments").with(jwt().authorities(SimpleGrantedAuthority(READ))))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.items[0].status").value("INITIATED"))
+            .andExpect(jsonPath("$.totalElements").value(1))
+    }
+
+    @Test
+    fun `should return 401 when listing payments without a token`() {
+        mockMvc.perform(get("/v1/payments")).andExpect(status().isUnauthorized)
+    }
+
+    @Test
+    fun `should return 400 when listing with an invalid page size`() {
+        mockMvc
+            .perform(get("/v1/payments?size=0").with(jwt().authorities(SimpleGrantedAuthority(READ))))
+            .andExpect(status().isBadRequest)
     }
 
     @Test


### PR DESCRIPTION
E-08 #289a (F-08.7a) - the backend half of the payments UI slice. The PaymentController had no list endpoint (only POST initiate, GET /{id}, POST /{id}/cancel), so the payments dashboard screen (#289b) needs one.

## What
- `GET /v1/payments?page=&size=` returning `PageResponse<PaymentResponse>` newest-first, mirroring the merged ledger accounts list:
  - `PaymentService.list(page, size): PaymentPage` + `@Transactional(readOnly = true)` impl using `PageRequest.of(page, size, Sort desc createdAt, desc id)` + `findAll` + `adapter::toDomain`.
  - new generic `PageResponse<T>` DTO + `PaymentPage` application wrapper + `PaymentApiMapper.toPageResponse`.
  - thin controller method: bounds `page >= 0` and `size in 1..100` (`MAX_PAGE_SIZE`) -> 400 via the existing IllegalArgumentException handler, then delegates.
- Reuses the existing `GET /v1/payments/** -> payments:read` rule (covers the collection); no SecurityConfig change.

## Gate chain
- critic: GO (faithful mirror of the ledger accounts list).
- security-auditor (opus): PASS - GET requires payments:read (401 tested), size bounded (no unbounded/DoS), response is PaymentResponse only (no PII/internal leak), readOnly tx with no external call, §5.3 clean, 4/4 ACs.
- code-reviewer: APPROVED, no must-fix - PaymentEntity has createdAt+id for the sort (no PropertyReferenceException), thin controller, MAX_PAGE_SIZE const, SPDX. Adopted the one LOW: the IT now asserts newest-first ordering.
- evaluator: PASS (0.88+).
Local gates green: test/detekt/detektTest/spotlessCheck/assemble/compileIntegrationTestKotlin.

Part of #289 (the payments UI #289b follows on this endpoint).