### PR TITLE
feat(web): package the sandbox dashboard as a static nginx container

### DIFF
--- a/.github/workflows/web-ci.yml
+++ b/.github/workflows/web-ci.yml
@@ -34,3 +34,35 @@ jobs:
       - run: npm run lint
       - run: npm run test
       - run: npm run build
+
+  docker:
+    name: Web image build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build image
+        run: docker build -t fincore-web:ci web
+      - name: Assert nonroot runtime user
+        run: |
+          user=$(docker inspect -f '{{.Config.User}}' fincore-web:ci)
+          echo "runtime user: $user"
+          [ -n "$user" ] && [ "$user" != "root" ] && [ "$user" != "0" ] || { echo "FAIL: runtime user is root/empty ($user)"; exit 1; }
+      - name: Smoke run (serves index and falls back to it for client routes)
+        run: |
+          docker run -d --name web -p 8080:8080 fincore-web:ci
+          for _ in $(seq 1 15); do curl -fsS http://localhost:8080/ >/dev/null 2>&1 && break || sleep 2; done
+          curl -fsS http://localhost:8080/ >/dev/null 2>&1 || { echo "FAIL: container never became ready"; docker logs web; docker rm -f web; exit 1; }
+          curl -fsS http://localhost:8080/ | grep -qi '<!doctype html'
+          curl -fsS http://localhost:8080/payments | grep -qi '<!doctype html'
+          docker rm -f web
+      - name: Trivy image scan (no CRITICAL)
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: image
+          image-ref: fincore-web:ci
+          severity: CRITICAL
+          exit-code: "1"
+          ignore-unfixed: true
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,11 @@ services:
       FINCORE_PAYMENTS_BANK_SANDBOX_ENABLED: "true"
       OTLP_TRACING_ENDPOINT: http://otel-collector:4318/v1/traces
 
+  web:
+    build: ./web
+    ports:
+      - "8082:8080"
+
   # Opt-in telemetry backends. Started only with `docker compose --profile observability up`;
   # the default stack (and the CI compose smoke) never starts these.
   otel-collector:

--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+.git
+coverage
+*.log
+.env
+.env.*

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -9,6 +9,9 @@ COPY . .
 RUN npm run build
 
 FROM nginxinc/nginx-unprivileged:1.27-alpine AS runtime
+USER root
+RUN apk upgrade --no-cache libcrypto3 libssl3
+USER 101
 COPY --from=builder /web/dist /usr/share/nginx/html
 COPY default.conf /etc/nginx/conf.d/default.conf
 EXPOSE 8080

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,14 @@
+# SPDX-License-Identifier: BUSL-1.1
+# SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+FROM node:22-alpine AS builder
+WORKDIR /web
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM nginxinc/nginx-unprivileged:1.27-alpine AS runtime
+COPY --from=builder /web/dist /usr/share/nginx/html
+COPY default.conf /etc/nginx/conf.d/default.conf
+EXPOSE 8080

--- a/web/README.md
+++ b/web/README.md
@@ -16,3 +16,21 @@ npm run build      # typecheck + production bundle
 
 The Overview landing runs on a typed mock-data layer (`src/mock/`). Each screen migrates from mock to the
 REST API as its backend lands.
+
+## Run as a container
+
+The SPA is served as static files by a non-root nginx image (multi-stage build, `web/Dockerfile`).
+
+```bash
+docker build -t fincore-web web            # build the image
+docker run --rm -p 8082:8080 fincore-web   # serve on http://localhost:8082
+```
+
+Or via the umbrella stack (served alongside the backend):
+
+```bash
+docker compose up web
+```
+
+The API base URL is baked at build time from `VITE_API_BASE_URL` (defaults to a relative path); point it at the
+ledger/payments/compliance/decision services as needed.

--- a/web/default.conf
+++ b/web/default.conf
@@ -1,0 +1,25 @@
+server {
+    listen 8080;
+    server_name _;
+    server_tokens off;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    gzip on;
+    gzip_types text/css application/javascript application/json image/svg+xml;
+    gzip_min_length 1024;
+
+    location = /index.html {
+        add_header Cache-Control "no-cache";
+    }
+
+    location ~* \.(?:js|css|woff2?|png|svg|ico)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+}


### PR DESCRIPTION
E-08 Sandbox UI #290 (F-08.10) - container packaging for the dashboard.

## What
- web/Dockerfile - multi-stage: node:22-alpine builds the bundle, nginxinc/nginx-unprivileged:1.27-alpine serves it (non-root uid 101, port 8080). SPDX header.
- web/default.conf - SPA fallback (try_files), server_tokens off, gzip on text assets, Cache-Control no-cache on index.html + immutable on fingerprinted assets.
- web/.dockerignore - excludes node_modules/dist/.git/.env (keeps package-lock + src).
- web-ci.yml - new docker job: builds the image (context web, no push), hard-asserts non-root, smoke-runs and curls / + a client route /payments (SPA fallback), Trivy CRITICAL scan with the DB mirror. No deploy.
- docker-compose.yml - web service (build ./web, 8082:8080, avoids the grafana 3000 mapping).
- web/README.md - container quickstart.

## Scope
Container + compose + CI validation + README. The full Helm chart (deploy/helm/web) is a focused follow-up (#290b), mirroring the #289 split.

## Gate chain
- critic: GO-WITH-CHANGES (port 8082 not 3000 grafana-clash; exact docker build web context; Trivy added; grep -i; single listen - all applied).
- security-auditor (opus): PASS - non-root by construction, no push/deploy, no workflow injection, server_tokens off, .dockerignore excludes .env/.git, Trivy gate, clean-room clean, no secrets.
- code-reviewer: 2 HIGH (CI non-root assert + readiness hard-fail with explicit exit + docker logs) + 2 should-fix (gzip + cache headers) - all adopted.
- evaluator: PASS (0.88).
Docker is not buildable locally (WSL); the CI docker job is the validation gate.

Closes #290
