### PR TITLE
feat(web): add compliance case operator actions to the case board

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -18,3 +18,11 @@ export async function apiFetch<T>(path: string): Promise<T> {
     if (!response.ok) throw new ApiError(response.status)
     return (await response.json()) as T
 }
+
+export async function apiPost<T>(path: string): Promise<T> {
+    const headers: Record<string, string> = { Accept: 'application/json' }
+    if (DEV_BEARER) headers.Authorization = `Bearer ${DEV_BEARER}`
+    const response = await fetch(`${BASE_URL}${path}`, { method: 'POST', headers })
+    if (!response.ok) throw new ApiError(response.status)
+    return (await response.json()) as T
+}

--- a/web/src/features/cases/CasesTable.tsx
+++ b/web/src/features/cases/CasesTable.tsx
@@ -3,8 +3,15 @@
 
 import type { CaseResponse } from '@/api/types'
 import { CaseStatusPill } from './Pills'
+import { type CaseAction, actionsFor } from './useCaseAction'
 
-export function CasesTable({ cases }: { cases: CaseResponse[] }) {
+interface CasesTableProps {
+    cases: CaseResponse[]
+    onAction: (id: string, action: CaseAction) => void
+    pending: boolean
+}
+
+export function CasesTable({ cases, onAction, pending }: CasesTableProps) {
     return (
         <table className="tbl">
             <thead>
@@ -12,6 +19,7 @@ export function CasesTable({ cases }: { cases: CaseResponse[] }) {
                     <th>Case ID</th>
                     <th>Reference</th>
                     <th>Status</th>
+                    <th>Actions</th>
                 </tr>
             </thead>
             <tbody>
@@ -27,6 +35,21 @@ export function CasesTable({ cases }: { cases: CaseResponse[] }) {
                         <td>{kase.reference}</td>
                         <td>
                             <CaseStatusPill status={kase.status} />
+                        </td>
+                        <td>
+                            <div style={{ display: 'flex', gap: 6 }}>
+                                {actionsFor(kase.status).map((action) => (
+                                    <button
+                                        key={action}
+                                        type="button"
+                                        className="btn btn-sm"
+                                        disabled={pending}
+                                        onClick={() => onAction(kase.id, action)}
+                                    >
+                                        {action}
+                                    </button>
+                                ))}
+                            </div>
                         </td>
                     </tr>
                 ))}

--- a/web/src/features/cases/useCaseAction.ts
+++ b/web/src/features/cases/useCaseAction.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { apiPost } from '@/api/client'
+import type { CaseResponse, CaseStatus } from '@/api/types'
+
+export type CaseAction = 'claim' | 'resolve' | 'escalate'
+
+export function actionsFor(status: CaseStatus): CaseAction[] {
+    switch (status) {
+        case 'OPEN':
+            return ['claim']
+        case 'CLAIMED':
+            return ['resolve', 'escalate']
+        case 'ESCALATED':
+            return ['resolve']
+        case 'RESOLVED':
+            return []
+    }
+}
+
+export function useCaseAction() {
+    const queryClient = useQueryClient()
+    return useMutation({
+        mutationFn: ({ id, action }: { id: string; action: CaseAction }) =>
+            apiPost<CaseResponse>(`/v1/compliance/cases/${id}/${action}`),
+        onSuccess: () => queryClient.invalidateQueries({ queryKey: ['cases'] }),
+    })
+}

--- a/web/src/routes/Cases.tsx
+++ b/web/src/routes/Cases.tsx
@@ -6,6 +6,7 @@ import type { CaseStatus } from '@/api/types'
 import { Shell } from '@/components/Shell'
 import { StateMessage } from '@/components/StateMessage'
 import { CasesTable } from '@/features/cases/CasesTable'
+import { useCaseAction } from '@/features/cases/useCaseAction'
 import { useCases } from '@/features/cases/useCases'
 
 const STATUSES: CaseStatus[] = ['OPEN', 'CLAIMED', 'ESCALATED', 'RESOLVED']
@@ -13,6 +14,7 @@ const STATUSES: CaseStatus[] = ['OPEN', 'CLAIMED', 'ESCALATED', 'RESOLVED']
 export function Cases() {
     const [status, setStatus] = useState<CaseStatus>('OPEN')
     const { data, isPending, isError, refetch } = useCases(status)
+    const action = useCaseAction()
 
     return (
         <Shell activeNav="Compliance">
@@ -34,7 +36,10 @@ export function Cases() {
                             role="tab"
                             aria-selected={option === status}
                             className={`btn${option === status ? ' btn-active' : ''}`}
-                            onClick={() => setStatus(option)}
+                            onClick={() => {
+                                action.reset()
+                                setStatus(option)
+                            }}
                         >
                             {option}
                         </button>
@@ -63,9 +68,21 @@ export function Cases() {
                         ) : data.length === 0 ? (
                             <StateMessage icon="inbox" text="No cases in this status." />
                         ) : (
-                            <CasesTable cases={data} />
+                            <CasesTable
+                                cases={data}
+                                pending={action.isPending}
+                                onAction={(id, act) => action.mutate({ id, action: act })}
+                            />
                         )}
                     </div>
+                    {action.isError && (
+                        <div
+                            role="alert"
+                            style={{ padding: '8px 16px', fontSize: 12, color: 'var(--text-err)' }}
+                        >
+                            Could not apply the action. Try again.
+                        </div>
+                    )}
                 </div>
             </div>
         </Shell>

--- a/web/src/test/Cases.test.tsx
+++ b/web/src/test/Cases.test.tsx
@@ -96,4 +96,65 @@ describe('Cases', () => {
             'page',
         )
     })
+
+    it('claims an open case via POST and refetches the list', async () => {
+        const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(ok(SAMPLE))
+        renderCases()
+        await screen.findByText('case-ref-1')
+
+        fireEvent.click(screen.getAllByRole('button', { name: 'claim' })[0])
+
+        await waitFor(() => {
+            const claimCall = fetchMock.mock.calls.find((c) =>
+                String(c[0]).includes('/v1/compliance/cases/case_0001/claim'),
+            )
+            expect(claimCall).toBeTruthy()
+            expect(claimCall?.[1]?.method).toBe('POST')
+        })
+        await waitFor(() => {
+            const listGets = fetchMock.mock.calls.filter(
+                (c) =>
+                    String(c[0]).includes('/v1/compliance/cases?status=') &&
+                    !String(c[0]).includes('/claim'),
+            )
+            expect(listGets.length).toBeGreaterThan(1)
+        })
+    })
+
+    it('clears a prior action error when switching status tabs', async () => {
+        vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+            if (String(input).includes('/claim')) return Promise.reject(new Error('boom'))
+            return Promise.resolve(ok(SAMPLE))
+        })
+        renderCases()
+        await screen.findByText('case-ref-1')
+        fireEvent.click(screen.getAllByRole('button', { name: 'claim' })[0])
+        await screen.findByRole('alert')
+
+        fireEvent.click(screen.getByRole('tab', { name: 'RESOLVED' }))
+        await waitFor(() => expect(screen.queryByRole('alert')).not.toBeInTheDocument())
+    })
+
+    it('shows no action buttons on a resolved case', async () => {
+        vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+            ok([{ id: 'case_0009', reference: 'case-ref-9', status: 'RESOLVED' }]),
+        )
+        renderCases()
+        await screen.findByText('case-ref-9')
+        expect(screen.queryByRole('button', { name: 'claim' })).not.toBeInTheDocument()
+        expect(screen.queryByRole('button', { name: 'resolve' })).not.toBeInTheDocument()
+        expect(screen.queryByRole('button', { name: 'escalate' })).not.toBeInTheDocument()
+    })
+
+    it('surfaces an error when an action fails', async () => {
+        vi.spyOn(globalThis, 'fetch').mockImplementation((input) => {
+            if (String(input).includes('/claim')) return Promise.reject(new Error('boom'))
+            return Promise.resolve(ok(SAMPLE))
+        })
+        renderCases()
+        await screen.findByText('case-ref-1')
+
+        fireEvent.click(screen.getAllByRole('button', { name: 'claim' })[0])
+        expect(await screen.findByRole('alert')).toHaveTextContent('Could not apply the action')
+    })
 })


### PR DESCRIPTION
E-08 Sandbox UI #297 (F-08.9b) - operator write-actions on the compliance case board (follow-up to the read-only board #287). First useMutation / write-path UI slice.

## What
- api/client.ts +apiPost (POST variant of apiFetch: dev-bearer, ApiError, no body - the action endpoints are path-only).
- features/cases/useCaseAction.ts - useMutation posting /v1/compliance/cases/{id}/{action}, invalidating the cases query on success; actionsFor(status) maps each status to its legal transitions only (OPEN=claim, CLAIMED=resolve|escalate, ESCALATED=resolve, RESOLVED=none) - the UI never offers an illegal action.
- CasesTable +Actions column (buttons gated by actionsFor, disabled while pending).
- routes/Cases.tsx wires the mutation, shows a role=alert error banner on failure, and resets the mutation when switching status tabs so a stale error never lingers.
- 5 new vitest tests (claim POST path+method+refetch; no buttons on RESOLVED; failure -> alert; tab-switch clears the error).

## Gate chain
- critic: GO.
- security-auditor (opus): PASS - authz is server-side (compliance:write enforced; client gating is UX-only and the backend still 409s an illegal transition); the action is a fixed union (no URL injection); bearer API (no CSRF); error message leaks nothing; clean-room clean.
- code-reviewer: 1 MEDIUM (useMutation error banner persisted across tab switches) fixed with action.reset() on tab switch + a test; 1 LOW (refetch assertion precision) fixed.
- evaluator: PASS (0.88).
Web gates green: lint 0 errors, typecheck, vitest 60 passed (5 new), build.

Closes #297
