### PR TITLE
feat(web): add a helm chart for the sandbox dashboard

### DIFF
--- a/.github/workflows/helm-test.yml
+++ b/.github/workflows/helm-test.yml
@@ -27,7 +27,7 @@ jobs:
 
     strategy:
       matrix:
-        chart: [ledger, payments]
+        chart: [ledger, payments, web]
 
     env:
       KUBECONFORM_VERSION: v0.6.7
@@ -57,6 +57,7 @@ jobs:
             | kubeconform -strict -summary -kubernetes-version "$KUBERNETES_VERSION"
 
       - name: Validate the ServiceMonitor renders (operator CRD skipped)
+        if: matrix.chart != 'web'
         run: |
           rendered=$(helm template ${{ matrix.chart }} deploy/helm/${{ matrix.chart }} \
             --set image.tag=test --set serviceMonitor.enabled=true)

--- a/deploy/helm/web/.helmignore
+++ b/deploy/helm/web/.helmignore
@@ -1,0 +1,6 @@
+.DS_Store
+.git/
+.gitignore
+*.tmp
+*.bak
+*.swp

--- a/deploy/helm/web/Chart.yaml
+++ b/deploy/helm/web/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: web
+description: FinCore sandbox dashboard, a static React SPA served by nginx
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+home: https://github.com/tiana-code/fincore-engine
+sources:
+  - https://github.com/tiana-code/fincore-engine
+maintainers:
+  - name: FinCore Engine Authors

--- a/deploy/helm/web/templates/NOTES.txt
+++ b/deploy/helm/web/templates/NOTES.txt
@@ -1,0 +1,11 @@
+The sandbox dashboard has been deployed as release {{ .Release.Name }}.
+
+Service (ClusterIP) reachable in-cluster at:
+  {{ include "web.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}
+
+Open it locally with port-forward:
+  kubectl --namespace {{ .Release.Namespace }} port-forward svc/{{ include "web.fullname" . }} {{ .Values.service.port }}:{{ .Values.service.port }}
+  open http://localhost:{{ .Values.service.port }}/
+
+The SPA reaches the backend via the API base URL baked at image build time; point it at the
+ledger/payments/compliance/decision services for your environment.

--- a/deploy/helm/web/templates/_helpers.tpl
+++ b/deploy/helm/web/templates/_helpers.tpl
@@ -1,0 +1,35 @@
+{{- define "web.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "web.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name (include "web.name" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "web.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "web.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "web.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "web.labels" -}}
+helm.sh/chart: {{ include "web.chart" . }}
+{{ include "web.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "web.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+{{- default (include "web.fullname" .) .Values.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/web/templates/deployment.yaml
+++ b/deploy/helm/web/templates/deployment.yaml
@@ -1,0 +1,65 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "web.fullname" . }}
+  labels:
+    {{- include "web.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "web.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "web.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "web.serviceAccountName" . }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: web
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.liveness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+            initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
+            periodSeconds: {{ .Values.probes.readiness.periodSeconds }}
+            timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}
+            failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          # nginx-unprivileged writes its pid and temp files under these paths; with a
+          # read-only root filesystem they must be writable emptyDir mounts or the pod CrashLoops.
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            - name: nginx-cache
+              mountPath: /var/cache/nginx
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        - name: nginx-cache
+          emptyDir: {}

--- a/deploy/helm/web/templates/hpa.yaml
+++ b/deploy/helm/web/templates/hpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "web.fullname" . }}
+  labels:
+    {{- include "web.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "web.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/deploy/helm/web/templates/service.yaml
+++ b/deploy/helm/web/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "web.fullname" . }}
+  labels:
+    {{- include "web.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "web.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/web/templates/serviceaccount.yaml
+++ b/deploy/helm/web/templates/serviceaccount.yaml
@@ -1,0 +1,8 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "web.serviceAccountName" . }}
+  labels:
+    {{- include "web.labels" . | nindent 4 }}
+{{- end }}

--- a/deploy/helm/web/values.yaml
+++ b/deploy/helm/web/values.yaml
@@ -1,0 +1,61 @@
+replicaCount: 1
+
+nameOverride: ""
+fullnameOverride: ""
+
+image:
+  repository: ghcr.io/tiana-code/fincore-web
+  # Defaults to the chart appVersion when empty.
+  tag: ""
+  pullPolicy: IfNotPresent
+
+imagePullSecrets: []
+
+serviceAccount:
+  create: true
+  name: ""
+
+service:
+  type: ClusterIP
+  port: 8080
+
+resources:
+  requests:
+    cpu: 50m
+    memory: 64Mi
+  limits:
+    cpu: 250m
+    memory: 128Mi
+
+autoscaling:
+  enabled: true
+  minReplicas: 1
+  maxReplicas: 5
+  targetCPUUtilizationPercentage: 70
+
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 101
+  runAsGroup: 101
+  fsGroup: 101
+  seccompProfile:
+    type: RuntimeDefault
+
+securityContext:
+  allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+
+probes:
+  liveness:
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 3
+    failureThreshold: 3
+  readiness:
+    initialDelaySeconds: 3
+    periodSeconds: 5
+    timeoutSeconds: 3
+    failureThreshold: 3


### PR DESCRIPTION
E-08 Sandbox UI #296 (F-08.10b) - Helm chart for the static nginx web container (deferred from #290). The last E-08 slice.

## What
- deploy/helm/web/ mirrors the ledger chart, trimmed for a static SPA: no configmap/secret/servicemonitor (no env/metrics).
- Pod hardening: runAsNonRoot + uid/gid 101 (nginx-unprivileged) + seccomp RuntimeDefault; readOnlyRootFilesystem + drop ALL caps + no privilege escalation; emptyDir mounts for /tmp + /var/cache/nginx (the paths nginx-unprivileged writes under a read-only root - the CrashLoop-avoidance designed in, since lint/template cannot catch it).
- containerPort 8080, liveness+readiness httpGet "/", ClusterIP service, HPA (autoscaling/v2, replicas omitted), image ghcr.io/tiana-code/fincore-web defaulting to the chart appVersion.
- helm-test.yml: web added to the [ledger, payments] matrix (helm lint + helm template | kubeconform); the ServiceMonitor-render step is guarded `if: matrix.chart != 'web'` since a static SPA has no ServiceMonitor.

## Gate chain
- critic: GO - all web.* helpers defined, no leftover configMapRef/secretKeyRef, kubeconform-valid k8s 1.31 schemas, SM guard correct, emptyDir mounts cover the nginx-unprivileged writable paths.
- security-auditor (opus): PASS - pod hardening complete, no secrets, no deploy/push in CI, image pinned (no :latest), ClusterIP, no workflow injection, clean-room clean.
- code-reviewer: APPROVED, no must-fix.
- evaluator: PASS (0.91).
Note: helm is not installed locally; the CI helm-test job (lint + template + kubeconform) is the validation gate. Chart.yaml/values.yaml/workflow validated as YAML; templates mirror the merged ledger go-template structure.

Closes #296
