### PR TITLE
feat(devex): add a kotlin sdk module with a typed ledger client

### DIFF
--- a/libs/sdk-kotlin/build.gradle.kts
+++ b/libs/sdk-kotlin/build.gradle.kts
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    `maven-publish`
+}
+
+description = "FinCore Kotlin SDK: a typed HTTP client over the FinCore Engine REST API"
+
+kotlin {
+    jvmToolchain(21)
+}
+
+dependencies {
+    implementation(libs.kotlin.stdlib)
+    implementation(libs.jackson.module.kotlin)
+    implementation(libs.jackson.databind)
+
+    testImplementation(libs.kotest.assertions.core)
+    testImplementation(libs.kotest.runner.junit5)
+}
+
+tasks.test {
+    useJUnitPlatform()
+}
+
+java {
+    withSourcesJar()
+    withJavadocJar()
+}
+
+publishing {
+    publications {
+        create<MavenPublication>("maven") {
+            from(components["java"])
+            groupId = "com.fincore"
+            artifactId = "sdk-kotlin"
+            version = rootProject.version.toString()
+            pom {
+                name.set("FinCore Kotlin SDK")
+                description.set(
+                    "Typed JVM client over the FinCore Engine REST API, depending only on the JDK " +
+                        "HTTP client and Jackson.",
+                )
+                url.set("https://github.com/tiana-code/fincore-engine")
+                licenses {
+                    license {
+                        name.set("Business Source License 1.1")
+                        url.set("https://github.com/tiana-code/fincore-engine/blob/main/LICENSE")
+                    }
+                }
+                developers {
+                    developer {
+                        id.set("tiana-code")
+                        name.set("Tiana")
+                    }
+                }
+                scm {
+                    connection.set("scm:git:https://github.com/tiana-code/fincore-engine.git")
+                    developerConnection.set("scm:git:ssh://git@github.com/tiana-code/fincore-engine.git")
+                    url.set("https://github.com/tiana-code/fincore-engine")
+                }
+            }
+        }
+    }
+}

--- a/libs/sdk-kotlin/src/main/kotlin/com/fincore/sdk/FincoreClient.kt
+++ b/libs/sdk-kotlin/src/main/kotlin/com/fincore/sdk/FincoreClient.kt
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.sdk
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fincore.sdk.model.Account
+import com.fincore.sdk.model.Page
+import java.net.URI
+import java.net.URLEncoder
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.charset.StandardCharsets
+import java.time.Duration
+
+class FincoreClient(
+    baseUrl: String,
+    private val token: String? = null,
+    private val httpClient: HttpClient = HttpClient.newHttpClient(),
+    private val mapper: ObjectMapper = defaultMapper(),
+) {
+    private val baseUrl = baseUrl.trimEnd('/')
+
+    fun listAccounts(
+        page: Int = 0,
+        size: Int = DEFAULT_PAGE_SIZE,
+    ): Page<Account> = mapper.readValue(get("/v1/accounts?page=$page&size=$size"), ACCOUNT_PAGE)
+
+    fun getAccount(id: String): Account =
+        mapper.readValue(get("/v1/accounts/${URLEncoder.encode(id, StandardCharsets.UTF_8)}"), Account::class.java)
+
+    private fun get(path: String): String {
+        val builder =
+            HttpRequest
+                .newBuilder()
+                .uri(URI.create("$baseUrl$path"))
+                .timeout(Duration.ofSeconds(REQUEST_TIMEOUT_SECONDS))
+                .header("Accept", "application/json")
+                .GET()
+        if (token != null) {
+            builder.header("Authorization", "Bearer $token")
+        }
+        val response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString())
+        if (response.statusCode() !in HTTP_OK_MIN..HTTP_OK_MAX) {
+            throw FincoreException(response.statusCode(), "GET $path failed with HTTP ${response.statusCode()}")
+        }
+        return response.body()
+    }
+
+    private companion object {
+        const val DEFAULT_PAGE_SIZE = 20
+        const val REQUEST_TIMEOUT_SECONDS = 30L
+        const val HTTP_OK_MIN = 200
+        const val HTTP_OK_MAX = 299
+        val ACCOUNT_PAGE = object : TypeReference<Page<Account>>() {}
+
+        fun defaultMapper(): ObjectMapper =
+            jacksonObjectMapper().apply { configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false) }
+    }
+}

--- a/libs/sdk-kotlin/src/main/kotlin/com/fincore/sdk/FincoreException.kt
+++ b/libs/sdk-kotlin/src/main/kotlin/com/fincore/sdk/FincoreException.kt
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.sdk
+
+class FincoreException(
+    val status: Int,
+    message: String,
+) : RuntimeException(message)

--- a/libs/sdk-kotlin/src/main/kotlin/com/fincore/sdk/model/Account.kt
+++ b/libs/sdk-kotlin/src/main/kotlin/com/fincore/sdk/model/Account.kt
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.sdk.model
+
+data class Account(
+    val id: String,
+    val name: String,
+    val type: String,
+    val currency: String,
+    val status: String,
+)

--- a/libs/sdk-kotlin/src/main/kotlin/com/fincore/sdk/model/Page.kt
+++ b/libs/sdk-kotlin/src/main/kotlin/com/fincore/sdk/model/Page.kt
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.sdk.model
+
+data class Page<T>(
+    val items: List<T>,
+    val page: Int,
+    val size: Int,
+    val totalElements: Long,
+    val totalPages: Int,
+)

--- a/libs/sdk-kotlin/src/test/kotlin/com/fincore/sdk/FincoreClientTest.kt
+++ b/libs/sdk-kotlin/src/test/kotlin/com/fincore/sdk/FincoreClientTest.kt
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.sdk
+
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import java.net.InetSocketAddress
+import java.nio.charset.StandardCharsets
+
+private const val NOT_FOUND = 404
+
+class FincoreClientTest :
+    StringSpec({
+
+        val accountJson =
+            """{"id":"acc_1","name":"Cash","type":"ASSET","currency":"USD","status":"ACTIVE","futureField":"ignored"}"""
+        val pageJson = """{"items":[$accountJson],"page":0,"size":20,"totalElements":1,"totalPages":1}"""
+
+        lateinit var server: HttpServer
+        var seenAuthorization: String? = null
+
+        fun HttpExchange.reply(
+            status: Int,
+            body: String,
+        ) {
+            val bytes = body.toByteArray(StandardCharsets.UTF_8)
+            sendResponseHeaders(status, bytes.size.toLong())
+            responseBody.use { it.write(bytes) }
+        }
+
+        beforeSpec {
+            server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+            server.createContext("/v1/accounts") { exchange ->
+                seenAuthorization = exchange.requestHeaders.getFirst("Authorization")
+                when (exchange.requestURI.path) {
+                    "/v1/accounts" -> exchange.reply(200, pageJson)
+                    "/v1/accounts/acc_1" -> exchange.reply(200, accountJson)
+                    else -> exchange.reply(NOT_FOUND, """{"detail":"not found"}""")
+                }
+            }
+            server.start()
+        }
+
+        afterSpec { server.stop(0) }
+
+        "lists accounts and decodes the page" {
+            val client = FincoreClient("http://127.0.0.1:${server.address.port}", token = "test-token")
+            val page = client.listAccounts()
+            page.totalElements shouldBe 1
+            page.items.single().id shouldBe "acc_1"
+            page.items.single().type shouldBe "ASSET"
+        }
+
+        "sends the bearer token" {
+            FincoreClient("http://127.0.0.1:${server.address.port}", token = "test-token").listAccounts()
+            seenAuthorization shouldBe "Bearer test-token"
+        }
+
+        "gets a single account" {
+            val client = FincoreClient("http://127.0.0.1:${server.address.port}")
+            client.getAccount("acc_1").name shouldBe "Cash"
+        }
+
+        "raises FincoreException with the status on a non-2xx response" {
+            val client = FincoreClient("http://127.0.0.1:${server.address.port}")
+            val ex = shouldThrow<FincoreException> { client.getAccount("missing") }
+            ex.status shouldBe NOT_FOUND
+        }
+    })

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -27,6 +27,7 @@ include(
     ":libs:fincore-observability",
     ":libs:fincore-test-support",
     ":libs:decision-engine",
+    ":libs:sdk-kotlin",
     ":services:ledger",
     ":services:decision",
     ":services:payments",


### PR DESCRIPTION
E-09 DevEx #304 (F-09.2) - a Kotlin SDK module.

## What
New :libs:sdk-kotlin, a hand-written typed client over the REST API (JDK HttpClient + Jackson only, no coupling to service modules):
- FincoreClient(baseUrl, token?, httpClient, mapper): listAccounts(page,size) -> Page<Account>, getAccount(id) -> Account.
- Bearer auth applied only when a token is set; 30s request timeout; non-2xx -> FincoreException(status); id path-segment URL-encoded; deserializer tolerates unknown fields (forward-compat for new server fields).
- SDK-owned DTOs Account/Page with type/status as String, so the SDK never breaks on a new ledger enum value.
- maven-publish configured with NO remote target (local consumption + POM only, like decision-engine #175) - nothing is pushed to a registry (§0-safe).
- Embedding test: an in-process JDK HttpServer; covers list decode, bearer-sent, 404 -> FincoreException, and unknown-field tolerance.

Hand-written over openapi-generator: no codegen toolchain, fully reviewable, clean dependency footprint. Scope is a deliberate minimal first surface; #310 tracks the remaining read/write operations.

## Evidence
./gradlew :libs:sdk-kotlin:build = BUILD SUCCESSFUL locally (detekt + spotlessCheck + 4 tests + jacoco).

## Gate chain
- critic: GO - no remote publish target anywhere; Account/Page match the ledger DTOs field-by-field; endpoints verified vs AccountController; catalog aliases resolve so full CI == local; embedding test real; clean-room clean.
- security-auditor (opus): PASS - §0 no-publish confirmed, no hardcoded secrets (test-token is a fake fixture, bearer not logged), JDK TLS validates, SPDX on all files, 6/6 ACs.
- evaluator: PASS (0.91). Both optional LOWs (id-encode, FAIL_ON_UNKNOWN=false) applied.

Closes #304
