### PR TITLE
feat(devex): add a node quickstart example using the typescript sdk

### DIFF
--- a/.github/workflows/examples-ci.yml
+++ b/.github/workflows/examples-ci.yml
@@ -1,0 +1,36 @@
+name: Examples CI
+
+on:
+  push:
+    branches: ["main"]
+    paths: ["examples/**", "sdk/typescript/**", ".github/workflows/examples-ci.yml"]
+  pull_request:
+    paths: ["examples/**", "sdk/typescript/**", ".github/workflows/examples-ci.yml"]
+
+concurrency:
+  group: examples-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  node-quickstart:
+    name: node-quickstart typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+      - name: Build the local SDK dependency
+        working-directory: sdk/typescript
+        run: |
+          npm ci
+          npm run build
+      - name: Install and typecheck the example
+        working-directory: examples/node-quickstart
+        run: |
+          npm install
+          npm run typecheck
+          npm run build

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,9 @@
+# Examples
+
+Runnable examples that call a local FinCore Engine sandbox.
+
+| Example | Stack | Shows |
+|---------|-------|-------|
+| [node-quickstart](node-quickstart/) | Node + TypeScript | Listing and fetching ledger accounts through the TypeScript SDK |
+
+Start the sandbox first (`docker compose up -d`, or `scripts/fincore run-demo`), then follow each example's README.

--- a/examples/node-quickstart/.gitignore
+++ b/examples/node-quickstart/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/examples/node-quickstart/README.md
+++ b/examples/node-quickstart/README.md
@@ -1,0 +1,29 @@
+# Node quickstart
+
+Calls the FinCore Engine ledger API through the TypeScript SDK (`@fincore/sdk-typescript`): lists accounts and fetches one.
+
+## Run
+
+1. Start the sandbox stack (from the repo root):
+
+   ```bash
+   docker compose up -d        # or: scripts/fincore run-demo
+   ```
+
+2. Build the local SDK it depends on, then this example:
+
+   ```bash
+   ( cd ../../sdk/typescript && npm install && npm run build )
+   npm install
+   npm run build
+   ```
+
+3. Run it, pointing at your services and supplying a bearer token with `ledger:read`:
+
+   ```bash
+   FINCORE_API_URL=http://localhost:8080 FINCORE_TOKEN=<jwt> npm start
+   ```
+
+`FINCORE_API_URL` defaults to `http://localhost:8080`. The sandbox stack does not run an identity provider, so obtain a token from your own Keycloak (the SDK sends it as a bearer when set).
+
+SPDX-License-Identifier: BUSL-1.1

--- a/examples/node-quickstart/package-lock.json
+++ b/examples/node-quickstart/package-lock.json
@@ -1,0 +1,65 @@
+{
+  "name": "fincore-example-node-quickstart",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "fincore-example-node-quickstart",
+      "version": "0.1.0",
+      "license": "BUSL-1.1",
+      "dependencies": {
+        "@fincore/sdk-typescript": "file:../../sdk/typescript"
+      },
+      "devDependencies": {
+        "@types/node": "^22.10.2",
+        "typescript": "~5.6.3"
+      }
+    },
+    "../../sdk/typescript": {
+      "name": "@fincore/sdk-typescript",
+      "version": "0.1.0",
+      "license": "BUSL-1.1",
+      "devDependencies": {
+        "@types/node": "^22.10.2",
+        "typescript": "~5.6.3",
+        "vitest": "^3.0.5"
+      }
+    },
+    "node_modules/@fincore/sdk-typescript": {
+      "resolved": "../../sdk/typescript",
+      "link": true
+    },
+    "node_modules/@types/node": {
+      "version": "22.19.21",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.21.tgz",
+      "integrity": "sha512-VMeFBSCKQKmm2swI2kW51SFusDqekC6q9trBCvJ/JliDchFSuoYYKN7yVNjPthP1HKZcx3U1gI/wTcEBjEFKTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+      "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/examples/node-quickstart/package.json
+++ b/examples/node-quickstart/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "fincore-example-node-quickstart",
+  "version": "0.1.0",
+  "description": "Node quickstart calling the FinCore Engine REST API via the TypeScript SDK",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "typecheck": "tsc --noEmit",
+    "start": "node dist/index.js"
+  },
+  "license": "BUSL-1.1",
+  "dependencies": {
+    "@fincore/sdk-typescript": "file:../../sdk/typescript"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "typescript": "~5.6.3"
+  }
+}

--- a/examples/node-quickstart/src/index.ts
+++ b/examples/node-quickstart/src/index.ts
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+import { FincoreClient } from '@fincore/sdk-typescript'
+
+const baseUrl = process.env.FINCORE_API_URL ?? 'http://localhost:8080'
+const token = process.env.FINCORE_TOKEN
+
+async function main(): Promise<void> {
+    const client = new FincoreClient({ baseUrl, token })
+
+    const page = await client.listAccounts()
+    console.log(`accounts: ${page.totalElements} total (page ${page.page + 1} of ${page.totalPages})`)
+    for (const account of page.items) {
+        console.log(`  ${account.id}  ${account.type.padEnd(11)} ${account.currency}  ${account.name}`)
+    }
+
+    const first = page.items[0]
+    if (first) {
+        const account = await client.getAccount(first.id)
+        console.log(`fetched ${account.id}: ${account.name} (${account.status})`)
+    }
+}
+
+main().catch((error: unknown) => {
+    console.error(error)
+    process.exitCode = 1
+})

--- a/examples/node-quickstart/tsconfig.json
+++ b/examples/node-quickstart/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022"],
+    "types": ["node"],
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noUncheckedIndexedAccess": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
E-09 DevEx #306 (F-09.7) - the examples directory, starting with one runnable quickstart.

## What
examples/node-quickstart/ - a Node + TypeScript script that dogfoods the new @fincore/sdk-typescript (#305) via a file: dep:
- FincoreClient({ baseUrl: FINCORE_API_URL ?? localhost:8080, token: FINCORE_TOKEN }); listAccounts -> prints a summary + a row per account; getAccount(first) -> prints it.
- Base URL and bearer token come from the environment; nothing is hardcoded.
- package.json is private with no publish script.
- examples/README.md indexes the examples; node-quickstart/README.md documents starting the stack, building the SDK first, and the env vars.
- .github/workflows/examples-ci.yml (node 22) builds the SDK then typechecks + builds the example; it never starts a live stack.

This makes the SDK's value concrete and keeps the SDK honest (a real consumer compiles against it). More runtimes/examples are a natural follow-up.

## Evidence (node v24 local)
Built the SDK, then example npm install (resolves the file: dep) + typecheck + build all green.

## Gate chain
- code-reviewer: APPROVED, no must-fix - SDK API used exactly against source (no invented methods/fields), env-driven, CI builds the SDK before the example.
- security-auditor (opus): PASS, no must-fix - no hardcoded secrets (token from env only), §0 no-publish at package + CI layers, no live stack in CI, lockfile is devDeps + the file: SDK only with no postinstall, token never logged, clean-room clean, SPDX present.
- evaluator: PASS (0.89).
Two LOW advisories declined with reason (node 22 matches the web-ci/sdk-ts-ci convention; npm install vs ci is intentional for the file:-linked dep).

Closes #306
