### PR TITLE
feat(sandbox): drive the full payment lifecycle in the compose smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,10 @@ jobs:
     permissions:
       contents: read
 
+    # Shared by `docker compose up` (the payments service) and demo-payment.sh so both sign/verify with the same secret.
+    env:
+      FINCORE_PAYMENTS_WEBHOOK_HMACSECRET: sandbox-webhook-secret
+
     # Step order is load-bearing: smoke -> logs (on failure) -> teardown (always).
     # `docker compose down` removes containers, so logs must be dumped before it.
     steps:
@@ -158,6 +162,9 @@ jobs:
 
       - name: Auth chain proof (token -> protected endpoint -> 200)
         run: bash scripts/demo-auth.sh
+
+      - name: Payment lifecycle demo (initiate -> SUBMITTED -> webhook -> SETTLED)
+        run: bash scripts/demo-payment.sh
 
       - name: Dump container logs on failure
         if: failure()

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -3,8 +3,12 @@
 useDefault = true
 
 [allowlist]
-description = "Sandbox demo Keycloak realm + token-proof script: a documented, intentionally public demo client secret, not a real credential"
+description = "Documented, intentionally public sandbox demo secrets (Keycloak realm + demo scripts + compose webhook secret), not real credentials"
 paths = [
     '''^deploy/keycloak/fincore-realm\.json$''',
     '''^scripts/demo-auth\.sh$''',
+    '''^scripts/demo-payment\.sh$''',
+]
+regexes = [
+    '''sandbox-webhook-secret''',
 ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,7 @@ services:
       SPRING_DATASOURCE_PASSWORD: ${POSTGRES_PASSWORD:-ledger}
       KEYCLOAK_ISSUER_URI: http://keycloak:8080/realms/fincore
       FINCORE_PAYMENTS_BANK_SANDBOX_ENABLED: "true"
+      FINCORE_PAYMENTS_WEBHOOK_HMACSECRET: ${FINCORE_PAYMENTS_WEBHOOK_HMACSECRET:-sandbox-webhook-secret}
       OTLP_TRACING_ENDPOINT: http://otel-collector:4318/v1/traces
 
   web:

--- a/scripts/demo-payment.sh
+++ b/scripts/demo-payment.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: BUSL-1.1
+# SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+set -euo pipefail
+
+KEYCLOAK_URL="${KEYCLOAK_URL:-http://localhost:8085}"
+PAYMENTS_URL="${PAYMENTS_URL:-http://localhost:8081}"
+CLIENT_ID="${FINCORE_DEMO_CLIENT_ID:-fincore-demo}"
+CLIENT_SECRET="${FINCORE_DEMO_CLIENT_SECRET:-fincore-demo-secret}"
+WEBHOOK_SECRET="${FINCORE_PAYMENTS_WEBHOOK_HMACSECRET:-sandbox-webhook-secret}"
+TOKEN_ENDPOINT="$KEYCLOAK_URL/realms/fincore/protocol/openid-connect/token"
+
+uuid() { uuidgen | tr '[:upper:]' '[:lower:]'; }
+extract() { sed -n "s/.*\"$1\":\"\\([^\"]*\\)\".*/\\1/p"; }
+
+status_of() {
+    curl -fsS -H "Authorization: Bearer $token" "$PAYMENTS_URL/v1/payments/$1" | extract status
+}
+
+token=$(
+    curl -fsS -X POST "$TOKEN_ENDPOINT" \
+        -d grant_type=client_credentials -d "client_id=$CLIENT_ID" -d "client_secret=$CLIENT_SECRET" |
+        extract access_token
+)
+[ -n "$token" ] || {
+    echo "FAIL: could not obtain a token"
+    exit 1
+}
+
+created=$(
+    curl -fsS -X POST "$PAYMENTS_URL/v1/payments" \
+        -H "Authorization: Bearer $token" \
+        -H "Idempotency-Key: $(uuid)" \
+        -H "Content-Type: application/json" \
+        --data-binary '{"amount":"100.00","currency":"USD","reference":"demo-e2e"}'
+)
+payment_id=$(printf '%s' "$created" | extract id)
+[ -n "$payment_id" ] || {
+    echo "FAIL: no payment id in response: $created"
+    exit 1
+}
+echo "initiated $payment_id"
+
+submitted=false
+for _ in $(seq 1 30); do
+    status=$(status_of "$payment_id")
+    [ "$status" = "SUBMITTED" ] && {
+        submitted=true
+        break
+    }
+    [ "$status" = "FAILED" ] && {
+        echo "FAIL: payment FAILED during orchestration"
+        exit 1
+    }
+    sleep 1
+done
+[ "$submitted" = true ] || {
+    echo "FAIL: payment did not reach SUBMITTED"
+    exit 1
+}
+echo "submitted $payment_id"
+
+body="{\"deliveryId\":\"$(uuid)\",\"providerReference\":\"sbx-$payment_id\",\"outcome\":\"SETTLED\"}"
+signature=$(printf '%s' "$body" | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" | sed 's/^.*= //')
+[ -n "$signature" ] || {
+    echo "FAIL: could not compute the webhook signature"
+    exit 1
+}
+curl -fsS -X POST "$PAYMENTS_URL/v1/payments/webhooks" \
+    -H "X-Webhook-Signature: $signature" -H "Content-Type: application/json" --data-binary "$body" >/dev/null
+
+settled=false
+for _ in $(seq 1 15); do
+    [ "$(status_of "$payment_id")" = "SETTLED" ] && {
+        settled=true
+        break
+    }
+    sleep 1
+done
+[ "$settled" = true ] || {
+    echo "FAIL: payment did not reach SETTLED after the webhook"
+    exit 1
+}
+echo "payment lifecycle OK: $payment_id INITIATED -> SUBMITTED -> SETTLED"


### PR DESCRIPTION
F-06.5 (#236) - end-to-end payment lifecycle demo, run in the compose smoke. Unblocked by #315 (Keycloak in the sandbox) and #317 (automatic orchestration after initiate).

## What
scripts/demo-payment.sh drives the full journey against the live stack:
1. obtain a client-credentials token from Keycloak (:8085);
2. initiate a payment (POST :8081/v1/payments, bearer + idempotency key, 100.00 USD);
3. poll until it reaches SUBMITTED on its own (this exercises #317's after-commit async orchestration: screening + sandbox-bank submission);
4. deliver an HMAC-signed webhook (X-Webhook-Signature = lowercase hex HMAC-SHA256 over the exact posted body; providerReference reconstructed deterministically as sbx-<id>);
5. poll until the payment settles (SETTLED).

Wires FINCORE_PAYMENTS_WEBHOOK_HMACSECRET into the payments service (compose) and the compose-smoke job; the CI runs the demo after the auth-chain proof. So a regression in orchestration or webhook verification now fails CI - the demo doubles as a regression test (it is exactly what would have caught the #317 defect).

## Source-fidelity
- providerReference: SandboxBankProvider returns Accepted("sbx-${paymentId}") and PaymentApiMapper sets id=payment.id.toString(), so sbx-<response.id> equals what the webhook handler matches via findByProviderReference. No DTO change needed.
- HMAC: openssl dgst -sha256 -hmac == python hmac == the server's Mac/%02x (parity verified); the signed bytes equal the posted bytes (--data-binary).
- screening default (amount>=0 APPROVE) approves 100.00, which is neither the sandbox reject (999.99) nor delay (888.88) amount.

## Gate chain
critic: initially NO-GO - it correctly caught that the branch was stale (reused a pre-existing branch based on main BEFORE #317 merged, so the orchestration code was absent). Fixed by rebranching from current main; #317 verified present. All other items the critic had already verified. code-reviewer: applied uuidgen portability; -d args already quoted; explicit CI env added. security-auditor (opus): PASS (6/6 ACs, HMAC parity exact, secret wiring matches, webhook permitAll, no publish, clean-room). evaluator: PASS (0.91).

Closes #236
