### PR TITLE
feat(devex): expand the kotlin and typescript sdks with ledger reads

### DIFF
--- a/libs/sdk-kotlin/src/main/kotlin/com/fincore/sdk/FincoreClient.kt
+++ b/libs/sdk-kotlin/src/main/kotlin/com/fincore/sdk/FincoreClient.kt
@@ -8,7 +8,10 @@ import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.fincore.sdk.model.Account
+import com.fincore.sdk.model.Balance
 import com.fincore.sdk.model.Page
+import com.fincore.sdk.model.Transaction
+import com.fincore.sdk.model.TransactionDetail
 import java.net.URI
 import java.net.URLEncoder
 import java.net.http.HttpClient
@@ -30,8 +33,19 @@ class FincoreClient(
         size: Int = DEFAULT_PAGE_SIZE,
     ): Page<Account> = mapper.readValue(get("/v1/accounts?page=$page&size=$size"), ACCOUNT_PAGE)
 
-    fun getAccount(id: String): Account =
-        mapper.readValue(get("/v1/accounts/${URLEncoder.encode(id, StandardCharsets.UTF_8)}"), Account::class.java)
+    fun getAccount(id: String): Account = mapper.readValue(get("/v1/accounts/${encode(id)}"), Account::class.java)
+
+    fun getBalance(accountId: String): Balance = mapper.readValue(get("/v1/accounts/${encode(accountId)}/balance"), Balance::class.java)
+
+    fun listTransactions(
+        page: Int = 0,
+        size: Int = DEFAULT_PAGE_SIZE,
+    ): Page<Transaction> = mapper.readValue(get("/v1/transactions?page=$page&size=$size"), TRANSACTION_PAGE)
+
+    fun getTransaction(id: String): TransactionDetail =
+        mapper.readValue(get("/v1/transactions/${encode(id)}"), TransactionDetail::class.java)
+
+    private fun encode(value: String): String = URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20")
 
     private fun get(path: String): String {
         val builder =
@@ -57,6 +71,7 @@ class FincoreClient(
         const val HTTP_OK_MIN = 200
         const val HTTP_OK_MAX = 299
         val ACCOUNT_PAGE = object : TypeReference<Page<Account>>() {}
+        val TRANSACTION_PAGE = object : TypeReference<Page<Transaction>>() {}
 
         fun defaultMapper(): ObjectMapper =
             jacksonObjectMapper().apply { configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false) }

--- a/libs/sdk-kotlin/src/main/kotlin/com/fincore/sdk/model/Balance.kt
+++ b/libs/sdk-kotlin/src/main/kotlin/com/fincore/sdk/model/Balance.kt
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.sdk.model
+
+import java.math.BigDecimal
+
+data class Balance(
+    val accountId: String,
+    val currency: String,
+    val amount: BigDecimal,
+    val lastPostedAt: String?,
+)

--- a/libs/sdk-kotlin/src/main/kotlin/com/fincore/sdk/model/Transaction.kt
+++ b/libs/sdk-kotlin/src/main/kotlin/com/fincore/sdk/model/Transaction.kt
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.sdk.model
+
+data class Transaction(
+    val id: String,
+    val reference: String,
+    val status: String,
+    val postedAt: String,
+)

--- a/libs/sdk-kotlin/src/main/kotlin/com/fincore/sdk/model/TransactionDetail.kt
+++ b/libs/sdk-kotlin/src/main/kotlin/com/fincore/sdk/model/TransactionDetail.kt
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.sdk.model
+
+import java.math.BigDecimal
+
+data class TransactionDetail(
+    val id: String,
+    val reference: String,
+    val description: String?,
+    val status: String,
+    val reversesId: String?,
+    val postedAt: String,
+    val entries: List<Entry>,
+)
+
+data class Entry(
+    val accountId: String,
+    val direction: String,
+    val amount: BigDecimal,
+    val currency: String,
+)

--- a/libs/sdk-kotlin/src/test/kotlin/com/fincore/sdk/FincoreClientTest.kt
+++ b/libs/sdk-kotlin/src/test/kotlin/com/fincore/sdk/FincoreClientTest.kt
@@ -8,6 +8,7 @@ import com.sun.net.httpserver.HttpServer
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
+import java.math.BigDecimal
 import java.net.InetSocketAddress
 import java.nio.charset.StandardCharsets
 
@@ -19,6 +20,13 @@ class FincoreClientTest :
         val accountJson =
             """{"id":"acc_1","name":"Cash","type":"ASSET","currency":"USD","status":"ACTIVE","futureField":"ignored"}"""
         val pageJson = """{"items":[$accountJson],"page":0,"size":20,"totalElements":1,"totalPages":1}"""
+        val balanceJson = """{"accountId":"acc_1","currency":"USD","amount":"100.00","lastPostedAt":"2026-06-19T00:00:00Z"}"""
+        val txJson = """{"id":"tx_1","reference":"r1","status":"POSTED","postedAt":"2026-06-19T00:00:00Z"}"""
+        val txPageJson = """{"items":[$txJson],"page":0,"size":20,"totalElements":1,"totalPages":1}"""
+        val entryJson = """{"accountId":"acc_1","direction":"DEBIT","amount":"100.00","currency":"USD"}"""
+        val txDetailJson =
+            """{"id":"tx_1","reference":"r1","description":null,"status":"POSTED","reversesId":null,""" +
+                """"postedAt":"2026-06-19T00:00:00Z","entries":[$entryJson]}"""
 
         lateinit var server: HttpServer
         var seenAuthorization: String? = null
@@ -39,6 +47,14 @@ class FincoreClientTest :
                 when (exchange.requestURI.path) {
                     "/v1/accounts" -> exchange.reply(200, pageJson)
                     "/v1/accounts/acc_1" -> exchange.reply(200, accountJson)
+                    "/v1/accounts/acc_1/balance" -> exchange.reply(200, balanceJson)
+                    else -> exchange.reply(NOT_FOUND, """{"detail":"not found"}""")
+                }
+            }
+            server.createContext("/v1/transactions") { exchange ->
+                when (exchange.requestURI.path) {
+                    "/v1/transactions" -> exchange.reply(200, txPageJson)
+                    "/v1/transactions/tx_1" -> exchange.reply(200, txDetailJson)
                     else -> exchange.reply(NOT_FOUND, """{"detail":"not found"}""")
                 }
             }
@@ -63,6 +79,29 @@ class FincoreClientTest :
         "gets a single account" {
             val client = FincoreClient("http://127.0.0.1:${server.address.port}")
             client.getAccount("acc_1").name shouldBe "Cash"
+        }
+
+        "gets an account balance and decodes the string amount" {
+            val client = FincoreClient("http://127.0.0.1:${server.address.port}")
+            val balance = client.getBalance("acc_1")
+            balance.amount shouldBe BigDecimal("100.00")
+            balance.currency shouldBe "USD"
+        }
+
+        "lists transactions and decodes the page" {
+            val client = FincoreClient("http://127.0.0.1:${server.address.port}")
+            client
+                .listTransactions()
+                .items
+                .single()
+                .status shouldBe "POSTED"
+        }
+
+        "gets a transaction with its entries" {
+            val client = FincoreClient("http://127.0.0.1:${server.address.port}")
+            val detail = client.getTransaction("tx_1")
+            detail.entries.single().direction shouldBe "DEBIT"
+            detail.entries.single().amount shouldBe BigDecimal("100.00")
         }
 
         "raises FincoreException with the status on a non-2xx response" {

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 FinCore Engine Authors
 
-import type { Account, Page } from './types.js'
+import type { Account, Balance, Page, Transaction, TransactionDetail } from './types.js'
 
 const DEFAULT_PAGE_SIZE = 20
 
@@ -37,6 +37,18 @@ export class FincoreClient {
 
     getAccount(id: string): Promise<Account> {
         return this.get<Account>(`/v1/accounts/${encodeURIComponent(id)}`)
+    }
+
+    getBalance(accountId: string): Promise<Balance> {
+        return this.get<Balance>(`/v1/accounts/${encodeURIComponent(accountId)}/balance`)
+    }
+
+    listTransactions(page = 0, size: number = DEFAULT_PAGE_SIZE): Promise<Page<Transaction>> {
+        return this.get<Page<Transaction>>(`/v1/transactions?page=${page}&size=${size}`)
+    }
+
+    getTransaction(id: string): Promise<TransactionDetail> {
+        return this.get<TransactionDetail>(`/v1/transactions/${encodeURIComponent(id)}`)
     }
 
     private async get<T>(path: string): Promise<T> {

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -3,4 +3,15 @@
 
 export { FincoreClient, FincoreError } from './client.js'
 export type { FetchFn, FincoreClientOptions } from './client.js'
-export type { Account, AccountStatus, AccountType, Page } from './types.js'
+export type {
+    Account,
+    AccountStatus,
+    AccountType,
+    Balance,
+    Entry,
+    EntryDirection,
+    Page,
+    Transaction,
+    TransactionDetail,
+    TransactionStatus,
+} from './types.js'

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -29,3 +29,38 @@ export interface Page<T> {
     totalElements: number
     totalPages: number
 }
+
+export interface Balance {
+    accountId: string
+    currency: string
+    amount: string
+    lastPostedAt: string | null
+}
+
+export type TransactionStatus = 'POSTED' | 'REVERSED'
+
+export interface Transaction {
+    id: string
+    reference: string
+    status: TransactionStatus
+    postedAt: string
+}
+
+export type EntryDirection = 'DEBIT' | 'CREDIT'
+
+export interface Entry {
+    accountId: string
+    direction: EntryDirection
+    amount: string
+    currency: string
+}
+
+export interface TransactionDetail {
+    id: string
+    reference: string
+    description: string | null
+    status: TransactionStatus
+    reversesId: string | null
+    postedAt: string
+    entries: Entry[]
+}

--- a/sdk/typescript/test/client.test.ts
+++ b/sdk/typescript/test/client.test.ts
@@ -45,6 +45,36 @@ describe('FincoreClient', () => {
         expect(fetchFn.mock.calls[0]?.[0]).toBe('http://host/v1/accounts/a%2Fb')
     })
 
+    it('gets an account balance with a string amount', async () => {
+        const balance = { accountId: 'acc_1', currency: 'USD', amount: '100.00', lastPostedAt: null }
+        const fetchFn = mockFetch(balance)
+        const result = await new FincoreClient({ baseUrl: 'http://host', fetch: fetchFn }).getBalance('acc_1')
+        expect(result.amount).toBe('100.00')
+        expect(fetchFn.mock.calls[0]?.[0]).toBe('http://host/v1/accounts/acc_1/balance')
+    })
+
+    it('lists transactions and decodes the page', async () => {
+        const tx = { id: 'tx_1', reference: 'r1', status: 'POSTED', postedAt: '2026-06-19T00:00:00Z' }
+        const body = { items: [tx], page: 0, size: 20, totalElements: 1, totalPages: 1 }
+        const page = await new FincoreClient({ baseUrl: 'http://host', fetch: mockFetch(body) }).listTransactions()
+        expect(page.items[0]?.status).toBe('POSTED')
+    })
+
+    it('gets a transaction with its entries', async () => {
+        const detail = {
+            id: 'tx_1',
+            reference: 'r1',
+            description: null,
+            status: 'POSTED',
+            reversesId: null,
+            postedAt: '2026-06-19T00:00:00Z',
+            entries: [{ accountId: 'acc_1', direction: 'DEBIT', amount: '100.00', currency: 'USD' }],
+        }
+        const result = await new FincoreClient({ baseUrl: 'http://host', fetch: mockFetch(detail) }).getTransaction('tx_1')
+        expect(result.entries[0]?.direction).toBe('DEBIT')
+        expect(result.entries[0]?.amount).toBe('100.00')
+    })
+
     it('throws FincoreError with the status on a non-2xx response', async () => {
         const client = new FincoreClient({ baseUrl: 'http://host', fetch: mockFetch({ detail: 'not found' }, 404) })
         await expect(client.getAccount('missing')).rejects.toBeInstanceOf(FincoreError)


### PR DESCRIPTION
#310 - expand both SDKs over the ledger read surface.

## What
Added to FincoreClient in both libs/sdk-kotlin and sdk/typescript: getBalance, listTransactions (paged), getTransaction (with entries). New DTOs Balance, Transaction, TransactionDetail + Entry, mirroring the server responses field-for-field.
- Ledger money amounts are JSON strings (MoneyAmountSerializer): the Kotlin client decodes them as BigDecimal (Jackson string coercion, asserted in a test); the TypeScript client keeps them as string. Timestamps are strings, matching the ISO wire form.
- Path ids are percent-encoded (RFC 3986).

Payments and compliance run as separate services on their own base URLs, so they get their own clients - tracked in follow-up #322.

## Evidence
Kotlin: ./gradlew :libs:sdk-kotlin:build green (detekt + spotless + test). TypeScript: typecheck + 7 vitest + build green (node v24 local).

## Gate chain
code-reviewer: Needs-Fix(2). #1 (register JavaTimeModule) declined with evidence - the SDK has no java.time fields, models timestamps as String, and the wire is an ISO string (Boot default, confirmed by the merged web types). #2 (URLEncoder + vs %20) applied. The String-vs-union advisory is kept as String, consistent with the existing Account types since #304 and forward-compatible. evaluator: PASS (0.87).

Closes #310