### PR TITLE
style: make three code comments timeless

### DIFF
--- a/services/compliance/src/integrationTest/kotlin/com/fincore/compliance/api/KycApiContextIT.kt
+++ b/services/compliance/src/integrationTest/kotlin/com/fincore/compliance/api/KycApiContextIT.kt
@@ -39,8 +39,7 @@ class KycApiContextIT(
     class TestBeans {
         @Bean fun jwtDecoder(): JwtDecoder = mockk()
 
-        // No in-tree KycProvider yet (sandbox is #239); a fake satisfies the orchestrator's dependency so the
-        // full web context boots.
+        // A fake KycProvider satisfies the orchestrator's dependency so the full web context boots in isolation.
         @Bean fun kycProvider(): KycProvider =
             object : KycProvider {
                 override fun check(request: KycCheckRequest): KycCheckResult = KycCheckResult.Pending("ref-test")

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/application/kyc/KycOrchestrator.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/application/kyc/KycOrchestrator.kt
@@ -14,7 +14,7 @@ import org.springframework.stereotype.Service
  *
  * Concurrent process calls on the same session resolve via the entity's optimistic lock: the loser's
  * OptimisticLockingFailureException propagates. Pending and InsufficientData leave the session in SCREENING (there is
- * no PENDING status); a later re-screen advances it. The provider reference is not persisted in this slice.
+ * no PENDING status); a later re-screen advances it. The provider reference is not persisted.
  */
 @Service
 class KycOrchestrator(

--- a/services/decision/src/main/kotlin/com/fincore/decision/store/api/DecisionRuleController.kt
+++ b/services/decision/src/main/kotlin/com/fincore/decision/store/api/DecisionRuleController.kt
@@ -39,7 +39,7 @@ class DecisionRuleController(
     }
 
     // No Idempotency-Key here by design: versions are append-only and monotonic, so a retried publish creates
-    // a new, immutable version rather than corrupting state. The full idempotency subsystem is a later slice.
+    // a new, immutable version rather than corrupting state.
     @Operation(summary = "Publish a rule version", description = "Validates the DSL document and stores it as the new active version.")
     @PostMapping("/{ruleKey}/versions", consumes = [MediaType.APPLICATION_JSON_VALUE])
     fun publishVersion(


### PR DESCRIPTION
Quality sweep over the merged codebase to bring comments to a maximally senior, timeless form.

## Audit result
The codebase is already clean (every slice passed the per-slice code-reviewer + code-simplifier anti-slop gate). Deterministic scans found: 0 em/en-dash in code, 0 TODO/FIXME/XXX/HACK, 0 'In this commit' phrasing. The only findings were three comments that referenced implementation slices or a closed ticket:
- KycOrchestrator: dropped 'in this slice' (the provider reference is simply not persisted).
- DecisionRuleController: dropped the 'the full idempotency subsystem is a later slice' aside (the by-design rationale stays).
- KycApiContextIT: reworded 'No in-tree KycProvider yet (sandbox is #239)' to a timeless note about the fake isolating the web context.

Comment-only, behaviour-preserving. compliance + decision compile, detekt and spotless green locally. The legitimate why-comments (invariants, tx-boundary notes, MapStruct-limitation and JSONB-normalization rationale, fail-closed/ReDoS reasoning) were deliberately kept - they earn their place.