### PR TITLE
feat(sdk): add payments and compliance clients to both SDKs

### DIFF
--- a/libs/sdk-kotlin/src/main/kotlin/com/fincore/sdk/ComplianceClient.kt
+++ b/libs/sdk-kotlin/src/main/kotlin/com/fincore/sdk/ComplianceClient.kt
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.sdk
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fincore.sdk.model.ComplianceCase
+import com.fincore.sdk.model.KycSession
+import java.net.http.HttpClient
+
+class ComplianceClient(
+    baseUrl: String,
+    token: String? = null,
+    httpClient: HttpClient = HttpClient.newHttpClient(),
+    mapper: ObjectMapper = JsonHttp.defaultMapper(),
+) {
+    private val http = JsonHttp(baseUrl, token, httpClient, mapper)
+
+    fun listCases(status: String): List<ComplianceCase> = http.get("/v1/compliance/cases?status=${http.encode(status)}", CASE_LIST)
+
+    fun getCase(id: String): ComplianceCase = http.get("/v1/compliance/cases/${http.encode(id)}", ComplianceCase::class.java)
+
+    fun getKycSession(id: String): KycSession = http.get("/v1/kyc/sessions/${http.encode(id)}", KycSession::class.java)
+
+    private companion object {
+        val CASE_LIST = object : TypeReference<List<ComplianceCase>>() {}
+    }
+}

--- a/libs/sdk-kotlin/src/main/kotlin/com/fincore/sdk/JsonHttp.kt
+++ b/libs/sdk-kotlin/src/main/kotlin/com/fincore/sdk/JsonHttp.kt
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.sdk
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import java.net.URI
+import java.net.URLEncoder
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpResponse
+import java.nio.charset.StandardCharsets
+import java.time.Duration
+
+internal class JsonHttp(
+    baseUrl: String,
+    private val token: String?,
+    private val httpClient: HttpClient,
+    private val mapper: ObjectMapper,
+) {
+    private val baseUrl = baseUrl.trimEnd('/')
+
+    fun <T> get(
+        path: String,
+        type: Class<T>,
+    ): T = mapper.readValue(getRaw(path), type)
+
+    fun <T> get(
+        path: String,
+        type: TypeReference<T>,
+    ): T = mapper.readValue(getRaw(path), type)
+
+    fun encode(value: String): String = URLEncoder.encode(value, StandardCharsets.UTF_8).replace("+", "%20")
+
+    private fun getRaw(path: String): String {
+        val builder =
+            HttpRequest
+                .newBuilder()
+                .uri(URI.create("$baseUrl$path"))
+                .timeout(Duration.ofSeconds(REQUEST_TIMEOUT_SECONDS))
+                .header("Accept", "application/json")
+                .GET()
+        if (token != null) {
+            builder.header("Authorization", "Bearer $token")
+        }
+        val response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString())
+        if (response.statusCode() !in HTTP_OK_MIN..HTTP_OK_MAX) {
+            throw FincoreException(response.statusCode(), "GET $path failed with HTTP ${response.statusCode()}")
+        }
+        return response.body()
+    }
+
+    companion object {
+        const val REQUEST_TIMEOUT_SECONDS = 30L
+        const val HTTP_OK_MIN = 200
+        const val HTTP_OK_MAX = 299
+
+        fun defaultMapper(): ObjectMapper =
+            jacksonObjectMapper().apply { configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false) }
+    }
+}

--- a/libs/sdk-kotlin/src/main/kotlin/com/fincore/sdk/PaymentsClient.kt
+++ b/libs/sdk-kotlin/src/main/kotlin/com/fincore/sdk/PaymentsClient.kt
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.sdk
+
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fincore.sdk.model.Page
+import com.fincore.sdk.model.Payment
+import java.net.http.HttpClient
+
+class PaymentsClient(
+    baseUrl: String,
+    token: String? = null,
+    httpClient: HttpClient = HttpClient.newHttpClient(),
+    mapper: ObjectMapper = JsonHttp.defaultMapper(),
+) {
+    private val http = JsonHttp(baseUrl, token, httpClient, mapper)
+
+    fun listPayments(
+        page: Int = 0,
+        size: Int = DEFAULT_PAGE_SIZE,
+    ): Page<Payment> = http.get("/v1/payments?page=$page&size=$size", PAYMENT_PAGE)
+
+    fun getPayment(id: String): Payment = http.get("/v1/payments/${http.encode(id)}", Payment::class.java)
+
+    private companion object {
+        const val DEFAULT_PAGE_SIZE = 20
+        val PAYMENT_PAGE = object : TypeReference<Page<Payment>>() {}
+    }
+}

--- a/libs/sdk-kotlin/src/main/kotlin/com/fincore/sdk/model/ComplianceCase.kt
+++ b/libs/sdk-kotlin/src/main/kotlin/com/fincore/sdk/model/ComplianceCase.kt
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.sdk.model
+
+data class ComplianceCase(
+    val id: String,
+    val reference: String,
+    val status: String,
+)

--- a/libs/sdk-kotlin/src/main/kotlin/com/fincore/sdk/model/KycSession.kt
+++ b/libs/sdk-kotlin/src/main/kotlin/com/fincore/sdk/model/KycSession.kt
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.sdk.model
+
+data class KycSession(
+    val id: String,
+    val subjectReference: String,
+    val status: String,
+)

--- a/libs/sdk-kotlin/src/main/kotlin/com/fincore/sdk/model/Payment.kt
+++ b/libs/sdk-kotlin/src/main/kotlin/com/fincore/sdk/model/Payment.kt
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.sdk.model
+
+import java.math.BigDecimal
+
+data class Payment(
+    val id: String,
+    val reference: String,
+    val amount: BigDecimal,
+    val currency: String,
+    val status: String,
+)

--- a/libs/sdk-kotlin/src/test/kotlin/com/fincore/sdk/PaymentsComplianceClientTest.kt
+++ b/libs/sdk-kotlin/src/test/kotlin/com/fincore/sdk/PaymentsComplianceClientTest.kt
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+package com.fincore.sdk
+
+import com.sun.net.httpserver.HttpExchange
+import com.sun.net.httpserver.HttpServer
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+import java.math.BigDecimal
+import java.net.InetSocketAddress
+import java.nio.charset.StandardCharsets
+
+private const val NOT_FOUND = 404
+
+class PaymentsComplianceClientTest :
+    StringSpec({
+
+        val paymentJson =
+            """{"id":"pay_1","reference":"po-1","amount":125.50,"currency":"USD","status":"SETTLED","futureField":"ignored"}"""
+        val paymentPageJson = """{"items":[$paymentJson],"page":0,"size":20,"totalElements":1,"totalPages":1}"""
+        val caseJson = """{"id":"case_1","reference":"c-1","status":"OPEN"}"""
+        val caseListJson = """[$caseJson]"""
+        val kycJson = """{"id":"kyc_1","subjectReference":"subj-1","status":"APPROVED"}"""
+
+        lateinit var server: HttpServer
+        var seenAuthorization: String? = null
+        var seenCaseQuery: String? = null
+
+        fun HttpExchange.reply(
+            status: Int,
+            body: String,
+        ) {
+            val bytes = body.toByteArray(StandardCharsets.UTF_8)
+            sendResponseHeaders(status, bytes.size.toLong())
+            responseBody.use { it.write(bytes) }
+        }
+
+        beforeSpec {
+            server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+            server.createContext("/v1/payments") { exchange ->
+                seenAuthorization = exchange.requestHeaders.getFirst("Authorization")
+                when (exchange.requestURI.path) {
+                    "/v1/payments" -> exchange.reply(200, paymentPageJson)
+                    "/v1/payments/pay_1" -> exchange.reply(200, paymentJson)
+                    else -> exchange.reply(NOT_FOUND, """{"detail":"not found"}""")
+                }
+            }
+            server.createContext("/v1/compliance/cases") { exchange ->
+                when (exchange.requestURI.path) {
+                    "/v1/compliance/cases" -> {
+                        seenCaseQuery = exchange.requestURI.query
+                        exchange.reply(200, caseListJson)
+                    }
+                    "/v1/compliance/cases/case_1" -> exchange.reply(200, caseJson)
+                    else -> exchange.reply(NOT_FOUND, """{"detail":"not found"}""")
+                }
+            }
+            server.createContext("/v1/kyc/sessions") { exchange ->
+                when (exchange.requestURI.path) {
+                    "/v1/kyc/sessions/kyc_1" -> exchange.reply(200, kycJson)
+                    else -> exchange.reply(NOT_FOUND, """{"detail":"not found"}""")
+                }
+            }
+            server.start()
+        }
+
+        afterSpec { server.stop(0) }
+
+        fun baseUrl() = "http://127.0.0.1:${server.address.port}"
+
+        "listPayments reads a page of payments" {
+            val page = PaymentsClient(baseUrl()).listPayments()
+            page.totalElements shouldBe 1
+            page.items.single().id shouldBe "pay_1"
+        }
+
+        "getPayment keeps the amount precise as a number" {
+            val payment = PaymentsClient(baseUrl()).getPayment("pay_1")
+            payment.amount shouldBe BigDecimal("125.50")
+            payment.currency shouldBe "USD"
+            payment.status shouldBe "SETTLED"
+        }
+
+        "getPayment sends the bearer token when present" {
+            PaymentsClient(baseUrl(), token = "t-123").getPayment("pay_1")
+            seenAuthorization shouldBe "Bearer t-123"
+        }
+
+        "getPayment throws FincoreException on 404" {
+            shouldThrow<FincoreException> { PaymentsClient(baseUrl()).getPayment("missing") }.status shouldBe NOT_FOUND
+        }
+
+        "listCases filters by status and reads a bare list" {
+            val cases = ComplianceClient(baseUrl()).listCases("OPEN")
+            seenCaseQuery shouldBe "status=OPEN"
+            cases.single().status shouldBe "OPEN"
+        }
+
+        "getCase reads a single case" {
+            ComplianceClient(baseUrl()).getCase("case_1").reference shouldBe "c-1"
+        }
+
+        "getKycSession reads a single session" {
+            val session = ComplianceClient(baseUrl()).getKycSession("kyc_1")
+            session.subjectReference shouldBe "subj-1"
+            session.status shouldBe "APPROVED"
+        }
+    })

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -1,65 +1,33 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 FinCore Engine Authors
 
+import { DEFAULT_PAGE_SIZE, HttpTransport, type FincoreClientOptions } from './http.js'
 import type { Account, Balance, Page, Transaction, TransactionDetail } from './types.js'
 
-const DEFAULT_PAGE_SIZE = 20
-
-export class FincoreError extends Error {
-    constructor(readonly status: number) {
-        super(`request failed with status ${status}`)
-        this.name = 'FincoreError'
-    }
-}
-
-export type FetchFn = (url: string, init?: RequestInit) => Promise<Response>
-
-export interface FincoreClientOptions {
-    baseUrl: string
-    token?: string
-    fetch?: FetchFn
-}
-
 export class FincoreClient {
-    private readonly baseUrl: string
-    private readonly token?: string
-    private readonly fetchFn: FetchFn
+    private readonly http: HttpTransport
 
     constructor(options: FincoreClientOptions) {
-        this.baseUrl = options.baseUrl.replace(/\/+$/, '')
-        this.token = options.token
-        this.fetchFn = options.fetch ?? fetch
+        this.http = new HttpTransport(options)
     }
 
     listAccounts(page = 0, size: number = DEFAULT_PAGE_SIZE): Promise<Page<Account>> {
-        return this.get<Page<Account>>(`/v1/accounts?page=${page}&size=${size}`)
+        return this.http.get<Page<Account>>(`/v1/accounts?page=${page}&size=${size}`)
     }
 
     getAccount(id: string): Promise<Account> {
-        return this.get<Account>(`/v1/accounts/${encodeURIComponent(id)}`)
+        return this.http.get<Account>(`/v1/accounts/${encodeURIComponent(id)}`)
     }
 
     getBalance(accountId: string): Promise<Balance> {
-        return this.get<Balance>(`/v1/accounts/${encodeURIComponent(accountId)}/balance`)
+        return this.http.get<Balance>(`/v1/accounts/${encodeURIComponent(accountId)}/balance`)
     }
 
     listTransactions(page = 0, size: number = DEFAULT_PAGE_SIZE): Promise<Page<Transaction>> {
-        return this.get<Page<Transaction>>(`/v1/transactions?page=${page}&size=${size}`)
+        return this.http.get<Page<Transaction>>(`/v1/transactions?page=${page}&size=${size}`)
     }
 
     getTransaction(id: string): Promise<TransactionDetail> {
-        return this.get<TransactionDetail>(`/v1/transactions/${encodeURIComponent(id)}`)
-    }
-
-    private async get<T>(path: string): Promise<T> {
-        const headers: Record<string, string> = { Accept: 'application/json' }
-        if (this.token !== undefined) {
-            headers.Authorization = `Bearer ${this.token}`
-        }
-        const response = await this.fetchFn(`${this.baseUrl}${path}`, { headers })
-        if (!response.ok) {
-            throw new FincoreError(response.status)
-        }
-        return (await response.json()) as T
+        return this.http.get<TransactionDetail>(`/v1/transactions/${encodeURIComponent(id)}`)
     }
 }

--- a/sdk/typescript/src/compliance.ts
+++ b/sdk/typescript/src/compliance.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+import { HttpTransport, type FincoreClientOptions } from './http.js'
+import type { CaseStatus, ComplianceCase, KycSession } from './types.js'
+
+export class ComplianceClient {
+    private readonly http: HttpTransport
+
+    constructor(options: FincoreClientOptions) {
+        this.http = new HttpTransport(options)
+    }
+
+    listCases(status: CaseStatus): Promise<ComplianceCase[]> {
+        return this.http.get<ComplianceCase[]>(`/v1/compliance/cases?status=${encodeURIComponent(status)}`)
+    }
+
+    getCase(id: string): Promise<ComplianceCase> {
+        return this.http.get<ComplianceCase>(`/v1/compliance/cases/${encodeURIComponent(id)}`)
+    }
+
+    getKycSession(id: string): Promise<KycSession> {
+        return this.http.get<KycSession>(`/v1/kyc/sessions/${encodeURIComponent(id)}`)
+    }
+}

--- a/sdk/typescript/src/http.ts
+++ b/sdk/typescript/src/http.ts
@@ -1,0 +1,43 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+export const DEFAULT_PAGE_SIZE = 20
+
+export class FincoreError extends Error {
+    constructor(readonly status: number) {
+        super(`request failed with status ${status}`)
+        this.name = 'FincoreError'
+    }
+}
+
+export type FetchFn = (url: string, init?: RequestInit) => Promise<Response>
+
+export interface FincoreClientOptions {
+    baseUrl: string
+    token?: string
+    fetch?: FetchFn
+}
+
+export class HttpTransport {
+    private readonly baseUrl: string
+    private readonly token?: string
+    private readonly fetchFn: FetchFn
+
+    constructor(options: FincoreClientOptions) {
+        this.baseUrl = options.baseUrl.replace(/\/+$/, '')
+        this.token = options.token
+        this.fetchFn = options.fetch ?? fetch
+    }
+
+    async get<T>(path: string): Promise<T> {
+        const headers: Record<string, string> = { Accept: 'application/json' }
+        if (this.token !== undefined) {
+            headers.Authorization = `Bearer ${this.token}`
+        }
+        const response = await this.fetchFn(`${this.baseUrl}${path}`, { headers })
+        if (!response.ok) {
+            throw new FincoreError(response.status)
+        }
+        return (await response.json()) as T
+    }
+}

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -1,16 +1,25 @@
 // SPDX-License-Identifier: BUSL-1.1
 // SPDX-FileCopyrightText: 2026 FinCore Engine Authors
 
-export { FincoreClient, FincoreError } from './client.js'
-export type { FetchFn, FincoreClientOptions } from './client.js'
+export { FincoreClient } from './client.js'
+export { PaymentsClient } from './payments.js'
+export { ComplianceClient } from './compliance.js'
+export { FincoreError } from './http.js'
+export type { FetchFn, FincoreClientOptions } from './http.js'
 export type {
     Account,
     AccountStatus,
     AccountType,
     Balance,
+    CaseStatus,
+    ComplianceCase,
     Entry,
     EntryDirection,
+    KycSession,
+    KycStatus,
     Page,
+    Payment,
+    PaymentStatus,
     Transaction,
     TransactionDetail,
     TransactionStatus,

--- a/sdk/typescript/src/payments.ts
+++ b/sdk/typescript/src/payments.ts
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+import { DEFAULT_PAGE_SIZE, HttpTransport, type FincoreClientOptions } from './http.js'
+import type { Page, Payment } from './types.js'
+
+export class PaymentsClient {
+    private readonly http: HttpTransport
+
+    constructor(options: FincoreClientOptions) {
+        this.http = new HttpTransport(options)
+    }
+
+    listPayments(page = 0, size: number = DEFAULT_PAGE_SIZE): Promise<Page<Payment>> {
+        return this.http.get<Page<Payment>>(`/v1/payments?page=${page}&size=${size}`)
+    }
+
+    getPayment(id: string): Promise<Payment> {
+        return this.http.get<Payment>(`/v1/payments/${encodeURIComponent(id)}`)
+    }
+}

--- a/sdk/typescript/src/types.ts
+++ b/sdk/typescript/src/types.ts
@@ -64,3 +64,29 @@ export interface TransactionDetail {
     postedAt: string
     entries: Entry[]
 }
+
+export type PaymentStatus = 'INITIATED' | 'SCREENING' | 'SUBMITTED' | 'SETTLED' | 'FAILED' | 'CANCELLED'
+
+export interface Payment {
+    id: string
+    reference: string
+    amount: number
+    currency: string
+    status: PaymentStatus
+}
+
+export type CaseStatus = 'OPEN' | 'CLAIMED' | 'ESCALATED' | 'RESOLVED'
+
+export interface ComplianceCase {
+    id: string
+    reference: string
+    status: CaseStatus
+}
+
+export type KycStatus = 'INITIATED' | 'SCREENING' | 'APPROVED' | 'REJECTED'
+
+export interface KycSession {
+    id: string
+    subjectReference: string
+    status: KycStatus
+}

--- a/sdk/typescript/test/payments-compliance.test.ts
+++ b/sdk/typescript/test/payments-compliance.test.ts
@@ -1,0 +1,72 @@
+// SPDX-License-Identifier: BUSL-1.1
+// SPDX-FileCopyrightText: 2026 FinCore Engine Authors
+
+import { describe, expect, it, vi } from 'vitest'
+import { ComplianceClient, FincoreError, PaymentsClient } from '../src/index.js'
+
+const payment = { id: 'pay_1', reference: 'po-1', amount: 125.5, currency: 'USD', status: 'SETTLED' }
+const paymentPage = { items: [payment], page: 0, size: 20, totalElements: 1, totalPages: 1 }
+const complianceCase = { id: 'case_1', reference: 'c-1', status: 'OPEN' }
+const kycSession = { id: 'kyc_1', subjectReference: 'subj-1', status: 'APPROVED' }
+
+function jsonResponse(body: unknown, status = 200): Response {
+    return new Response(JSON.stringify(body), { status, headers: { 'Content-Type': 'application/json' } })
+}
+
+function mockFetch(body: unknown, status = 200) {
+    return vi.fn(async (_url: string, _init?: RequestInit): Promise<Response> => jsonResponse(body, status))
+}
+
+function headersOf(call: [string, RequestInit?] | undefined): Record<string, string> {
+    return (call?.[1]?.headers ?? {}) as Record<string, string>
+}
+
+describe('PaymentsClient', () => {
+    it('lists payments against the payments base url', async () => {
+        const fetchFn = mockFetch(paymentPage)
+        const page = await new PaymentsClient({ baseUrl: 'http://payments:8081', fetch: fetchFn }).listPayments()
+        expect(page.items[0]?.id).toBe('pay_1')
+        expect(fetchFn.mock.calls[0]?.[0]).toBe('http://payments:8081/v1/payments?page=0&size=20')
+    })
+
+    it('keeps the payment amount as a number', async () => {
+        const fetchFn = mockFetch(payment)
+        const result = await new PaymentsClient({ baseUrl: 'http://payments:8081', fetch: fetchFn }).getPayment('pay_1')
+        expect(result.amount).toBe(125.5)
+        expect(typeof result.amount).toBe('number')
+    })
+
+    it('sends the bearer token when set', async () => {
+        const fetchFn = mockFetch(payment)
+        await new PaymentsClient({ baseUrl: 'http://payments:8081', token: 'secret', fetch: fetchFn }).getPayment('pay_1')
+        expect(headersOf(fetchFn.mock.calls[0]).Authorization).toBe('Bearer secret')
+    })
+
+    it('throws FincoreError on a non-2xx response', async () => {
+        const fetchFn = mockFetch({ detail: 'not found' }, 404)
+        const client = new PaymentsClient({ baseUrl: 'http://payments:8081', fetch: fetchFn })
+        await expect(client.getPayment('missing')).rejects.toBeInstanceOf(FincoreError)
+    })
+})
+
+describe('ComplianceClient', () => {
+    it('lists cases filtered by status', async () => {
+        const fetchFn = mockFetch([complianceCase])
+        const cases = await new ComplianceClient({ baseUrl: 'http://compliance', fetch: fetchFn }).listCases('OPEN')
+        expect(cases[0]?.status).toBe('OPEN')
+        expect(fetchFn.mock.calls[0]?.[0]).toBe('http://compliance/v1/compliance/cases?status=OPEN')
+    })
+
+    it('gets a single case', async () => {
+        const fetchFn = mockFetch(complianceCase)
+        const result = await new ComplianceClient({ baseUrl: 'http://compliance', fetch: fetchFn }).getCase('case_1')
+        expect(result.reference).toBe('c-1')
+    })
+
+    it('gets a kyc session', async () => {
+        const fetchFn = mockFetch(kycSession)
+        const result = await new ComplianceClient({ baseUrl: 'http://compliance', fetch: fetchFn }).getKycSession('kyc_1')
+        expect(result.subjectReference).toBe('subj-1')
+        expect(fetchFn.mock.calls[0]?.[0]).toBe('http://compliance/v1/kyc/sessions/kyc_1')
+    })
+})


### PR DESCRIPTION
Closes #322.

Both SDKs previously covered only the ledger service. This adds per-service read clients for payments and compliance, each constructed with its own base URL since they are separate services.

## Kotlin (`libs/sdk-kotlin`)
- `PaymentsClient`: `listPayments(page, size): Page<Payment>`, `getPayment(id): Payment`.
- `ComplianceClient`: `listCases(status): List<ComplianceCase>`, `getCase(id): ComplianceCase`, `getKycSession(id): KycSession`.
- A shared internal `JsonHttp` transport backs the new clients.

## TypeScript (`sdk/typescript`)
- `PaymentsClient` and `ComplianceClient` with the same surface.
- A shared `HttpTransport` now backs `FincoreClient` too, so request handling lives in one place.
- Status fields are typed unions matching the backend enums.

## Amount typing
Payment amounts are a JSON number on the wire (`PaymentResponse.amount` is a `BigDecimal` serialized without a string formatter; the web client types it as `number` and the issue specifies this), so the SDK mirrors that: Kotlin `BigDecimal`, TypeScript `number`. Ledger amounts stay strings, unchanged.

## Verification
- Kotlin: `:libs:sdk-kotlin:test` (7 tests), `detekt`, `spotlessCheck` all green.
- TypeScript: `typecheck`, `test` (14 total), `build` all green.
- `examples/node-quickstart` still builds against the SDK (backward compatible; all prior exports preserved).

Endpoints and DTO shapes fact-checked against the payments and compliance REST controllers (code-reviewer gate). No publish step. No em/en-dash.