### PR TITLE
docs: fix a broken wiki link and stale SDK scope in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ docker compose up -d
 The web dashboard is served at `http://localhost:8082`, the ledger API at `:8080`, payments at `:8081`, and
 Keycloak at `:8085`.
 
-Full guide: [Getting Started](https://github.com/tiana-code/fincore-engine/wiki/Getting-Started)
+Full documentation: [Wiki](https://github.com/tiana-code/fincore-engine/wiki)
 
 ### Observability profile (optional)
 
@@ -82,8 +82,8 @@ shipping the services' JSON logs into it (a log shipper) is a follow-up - until 
 FinCore Engine ships with the tooling an adopter needs to integrate quickly:
 
 - **Client SDKs** - a [Kotlin SDK](libs/sdk-kotlin) (`com.fincore:sdk-kotlin`) and a [TypeScript SDK](sdk/typescript)
-  (`@fincore/sdk-typescript`) wrap the ledger REST API with typed models, preserving monetary amounts as strings to
-  avoid floating-point drift.
+  (`@fincore/sdk-typescript`) with typed clients for the ledger, payments, and compliance services. Ledger amounts are
+  represented as strings to avoid floating-point drift.
 - **`fincore` CLI** - the [`scripts/fincore`](scripts/fincore) helper scaffolds a sandbox `.env`, checks service
   health, and runs the smoke demo.
 - **Runnable examples** - [`examples/node-quickstart`](examples/node-quickstart) lists and reads accounts through the


### PR DESCRIPTION
Two accuracy fixes found while re-checking the README against the published wiki and the current code.

1. **Broken wiki link.** The quick start pointed at `wiki/Getting-Started`, which is not among the 46 published wiki pages. Repointed to the wiki landing, which exists and carries a quickstart.
2. **Stale SDK description.** The Developer experience section still said the SDKs wrap the *ledger* REST API and keep *all* monetary amounts as strings. After the payments and compliance clients merged (#322), that is inaccurate: the SDKs now cover ledger, payments, and compliance, and payment amounts are JSON numbers. Reworded to match.

Verified: all six remaining `wiki/*` links in the README resolve to published pages; no em/en-dash.