### PR TITLE
refactor: trim restating comments and tighten test variable names

### DIFF
--- a/services/compliance/src/main/kotlin/com/fincore/compliance/application/case/OpenCaseCommand.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/application/case/OpenCaseCommand.kt
@@ -3,7 +3,6 @@
 
 package com.fincore.compliance.application.case
 
-/** Command to open a compliance case. [reference] is a generic, opaque case reference (validated by the domain). */
 data class OpenCaseCommand(
     val reference: String,
 )

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/application/kyc/InitiateKycSessionCommand.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/application/kyc/InitiateKycSessionCommand.kt
@@ -3,10 +3,7 @@
 
 package com.fincore.compliance.application.kyc
 
-/**
- * Command to start a KYC session. [subjectReference] is an opaque token (validated by the KycSession domain);
- * [idempotencyKey] is the caller-supplied Idempotency-Key header value used to dedupe a repeated initiation.
- */
+// subjectReference is an opaque token, never raw PII; idempotencyKey dedupes a repeated initiation.
 data class InitiateKycSessionCommand(
     val idempotencyKey: String,
     val subjectReference: String,

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/application/kyc/KycOrchestrator.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/application/kyc/KycOrchestrator.kt
@@ -8,13 +8,10 @@ import com.fincore.core.KycSessionId
 import org.springframework.stereotype.Service
 
 /**
- * Drives an initiated KYC session through screening. NOT transactional: each persisted transition is its own short
- * transaction on [KycService], and the external [KycProvider.check] runs between them, never inside a transaction
- * (CLAUDE.md 8.10). A [KycProviderException] propagates and leaves the session in SCREENING for a future re-attempt.
- *
- * Concurrent process calls on the same session resolve via the entity's optimistic lock: the loser's
- * OptimisticLockingFailureException propagates. Pending and InsufficientData leave the session in SCREENING (there is
- * no PENDING status); a later re-screen advances it. The provider reference is not persisted.
+ * NOT transactional: each persisted transition is its own short transaction on [KycService], and the external
+ * [KycProvider.check] runs between them, never inside a transaction. A [KycProviderException], Pending, or
+ * InsufficientData leaves the session in SCREENING for a later re-screen; concurrent calls resolve via the entity's
+ * optimistic lock.
  */
 @Service
 class KycOrchestrator(

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/kyc/SandboxKycProvider.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/kyc/SandboxKycProvider.kt
@@ -9,11 +9,7 @@ import com.fincore.compliance.application.kyc.KycProvider
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 
-/**
- * Deterministic in-tree sandbox KYC provider, off by default. Encodes no real provider logic; the outcome is keyed on
- * documented case-insensitive markers in the opaque subject reference: "reject" -> Rejected, "pending" -> Pending,
- * "insufficient" -> InsufficientData, otherwise -> Approved. The same reference always yields the same result.
- */
+// In-tree sandbox provider, off by default; the outcome is a deterministic function of markers in the subject reference.
 @Component
 @ConditionalOnProperty(
     prefix = "fincore.compliance.kyc.sandbox",

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/messaging/AmlTransactionConsumer.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/messaging/AmlTransactionConsumer.kt
@@ -11,10 +11,7 @@ import com.fincore.events.LedgerEvents
 import org.springframework.kafka.annotation.KafkaListener
 import org.springframework.stereotype.Component
 
-/**
- * Subscribes to the ledger transaction topic and forwards posted transactions to the AML handler. The topic also
- * carries other Transaction events, so only TransactionPosted is handled; everything else is ignored.
- */
+// The ledger transaction topic carries several event types; only TransactionPosted is forwarded to the AML handler.
 @Component
 class AmlTransactionConsumer(
     private val objectMapper: ObjectMapper,

--- a/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/sanctions/SandboxSanctionsProvider.kt
+++ b/services/compliance/src/main/kotlin/com/fincore/compliance/infrastructure/sanctions/SandboxSanctionsProvider.kt
@@ -9,13 +9,7 @@ import com.fincore.compliance.application.sanctions.SanctionsScreeningResult
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
 import org.springframework.stereotype.Component
 
-/**
- * Deterministic in-tree sandbox sanctions provider, off by default. Encodes no real sanctions list; the outcome is a
- * pure function of documented case-insensitive markers. An "insufficient" marker in the opaque subject reference yields
- * InsufficientData; otherwise the provided attribute keys carrying the "match" marker are the matched dimensions, and a
- * potential hit is reported when at least the requested number of them match. The score is a fixed sandbox confidence,
- * not the m-of-n ratio.
- */
+// In-tree sandbox provider, off by default; a deterministic m-of-n match driven by markers in the request attributes.
 @Component
 @ConditionalOnProperty(
     prefix = "fincore.compliance.sanctions.sandbox",

--- a/services/compliance/src/test/kotlin/com/fincore/compliance/domain/AmlAlertTest.kt
+++ b/services/compliance/src/test/kotlin/com/fincore/compliance/domain/AmlAlertTest.kt
@@ -17,24 +17,24 @@ class AmlAlertTest {
 
     @Test
     fun `should resolve when transitioned from open`() {
-        val a = alert()
-        a.transitionTo(AmlAlertStatus.RESOLVED)
-        a.status shouldBe AmlAlertStatus.RESOLVED
-        a.isTerminal() shouldBe true
+        val alert = alert()
+        alert.transitionTo(AmlAlertStatus.RESOLVED)
+        alert.status shouldBe AmlAlertStatus.RESOLVED
+        alert.isTerminal() shouldBe true
     }
 
     @Test
     fun `should dismiss when transitioned from open`() {
-        val a = alert()
-        a.transitionTo(AmlAlertStatus.DISMISSED)
-        a.status shouldBe AmlAlertStatus.DISMISSED
+        val alert = alert()
+        alert.transitionTo(AmlAlertStatus.DISMISSED)
+        alert.status shouldBe AmlAlertStatus.DISMISSED
     }
 
     @Test
     fun `should reject reopening a resolved alert`() {
-        val a = alert()
-        a.transitionTo(AmlAlertStatus.RESOLVED)
-        shouldThrow<ComplianceDomainException> { a.transitionTo(AmlAlertStatus.OPEN) }
+        val alert = alert()
+        alert.transitionTo(AmlAlertStatus.RESOLVED)
+        shouldThrow<ComplianceDomainException> { alert.transitionTo(AmlAlertStatus.OPEN) }
     }
 
     @Test

--- a/services/compliance/src/test/kotlin/com/fincore/compliance/domain/ComplianceCaseTest.kt
+++ b/services/compliance/src/test/kotlin/com/fincore/compliance/domain/ComplianceCaseTest.kt
@@ -17,28 +17,28 @@ class ComplianceCaseTest {
 
     @Test
     fun `should resolve through claimed when transitioned legally`() {
-        val c = case()
-        c.transitionTo(CaseStatus.CLAIMED)
-        c.transitionTo(CaseStatus.RESOLVED)
-        c.status shouldBe CaseStatus.RESOLVED
-        c.isTerminal() shouldBe true
+        val case = case()
+        case.transitionTo(CaseStatus.CLAIMED)
+        case.transitionTo(CaseStatus.RESOLVED)
+        case.status shouldBe CaseStatus.RESOLVED
+        case.isTerminal() shouldBe true
     }
 
     @Test
     fun `should resolve through escalation when escalated then resolved`() {
-        val c = case()
-        c.transitionTo(CaseStatus.CLAIMED)
-        c.transitionTo(CaseStatus.ESCALATED)
-        c.transitionTo(CaseStatus.RESOLVED)
-        c.status shouldBe CaseStatus.RESOLVED
+        val case = case()
+        case.transitionTo(CaseStatus.CLAIMED)
+        case.transitionTo(CaseStatus.ESCALATED)
+        case.transitionTo(CaseStatus.RESOLVED)
+        case.status shouldBe CaseStatus.RESOLVED
     }
 
     @Test
     fun `should reject claiming a resolved case`() {
-        val c = case()
-        c.transitionTo(CaseStatus.CLAIMED)
-        c.transitionTo(CaseStatus.RESOLVED)
-        shouldThrow<ComplianceDomainException> { c.transitionTo(CaseStatus.CLAIMED) }
+        val case = case()
+        case.transitionTo(CaseStatus.CLAIMED)
+        case.transitionTo(CaseStatus.RESOLVED)
+        shouldThrow<ComplianceDomainException> { case.transitionTo(CaseStatus.CLAIMED) }
     }
 
     @Test

--- a/services/compliance/src/test/kotlin/com/fincore/compliance/domain/KycSessionTest.kt
+++ b/services/compliance/src/test/kotlin/com/fincore/compliance/domain/KycSessionTest.kt
@@ -17,11 +17,11 @@ class KycSessionTest {
 
     @Test
     fun `should advance through screening to approved when transitioned legally`() {
-        val s = session()
-        s.transitionTo(KycStatus.SCREENING)
-        s.transitionTo(KycStatus.APPROVED)
-        s.status shouldBe KycStatus.APPROVED
-        s.isTerminal() shouldBe true
+        val session = session()
+        session.transitionTo(KycStatus.SCREENING)
+        session.transitionTo(KycStatus.APPROVED)
+        session.status shouldBe KycStatus.APPROVED
+        session.isTerminal() shouldBe true
     }
 
     @Test

--- a/services/decision/src/main/kotlin/com/fincore/decision/store/application/BoundedEvaluator.kt
+++ b/services/decision/src/main/kotlin/com/fincore/decision/store/application/BoundedEvaluator.kt
@@ -14,13 +14,8 @@ import org.springframework.stereotype.Component
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 
-/**
- * Runs the pure evaluator under a hard time budget. A watchdog interrupts the calling thread after the
- * budget; the engine matches author patterns against an interruptible view of the input, so a catastrophic
- * backtrack unwinds promptly as a [RegexMatchInterruptedException] instead of hanging. This wraps ONLY the
- * evaluate call: the watchdog is cancelled and the interrupt flag cleared before returning, so a caller can
- * safely proceed (e.g. to persist an audit row) on a clean thread.
- */
+// Watchdog wraps only evaluate: interrupt flag is cleared before returning so the caller can persist an
+// audit row on a clean thread. ReDoS backtrack surfaces as RegexMatchInterruptedException, not a hang.
 @Component
 class BoundedEvaluator(
     private val ruleEvaluator: RuleEvaluator,

--- a/services/decision/src/main/kotlin/com/fincore/decision/store/application/DecisionLogWriter.kt
+++ b/services/decision/src/main/kotlin/com/fincore/decision/store/application/DecisionLogWriter.kt
@@ -12,10 +12,6 @@ import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
 import java.util.UUID
 
-/**
- * Builds and persists the immutable decision_logs audit row for one completed evaluation. A non-matching
- * result has no outcome, so it stores null label and reason codes (the DB CHECK enforces that totality).
- */
 @Component
 class DecisionLogWriter(
     private val decisionLogRepository: DecisionLogRepository,

--- a/services/decision/src/main/kotlin/com/fincore/decision/store/application/InputMapper.kt
+++ b/services/decision/src/main/kotlin/com/fincore/decision/store/application/InputMapper.kt
@@ -14,11 +14,6 @@ import com.fincore.decision.store.exception.InputNotMappableException
 import com.fincore.decision.store.exception.InputTooLargeException
 import org.springframework.stereotype.Component
 
-/**
- * Maps a JSON input object to typed evaluation attributes, enforcing the attribute-count and per-value
- * string-length caps before the input reaches the engine. Shared by the evaluate and replay paths so the
- * caps are defined once.
- */
 @Component
 class InputMapper(
     private val properties: DecisionApiProperties,

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/api/error/ProblemType.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/api/error/ProblemType.kt
@@ -6,19 +6,8 @@ package com.fincore.ledger.api.error
 import org.springframework.http.HttpStatus
 import java.net.URI
 
-/**
- * Catalog of every error condition the ledger API can surface as an RFC 7807 problem.
- *
- * Each constant is a published, stable contract: its [type] URI and [code] are part of the public API and
- * are guarded by integration tests. The `GlobalExceptionHandler` and `IdempotencyFilter` resolve the
- * status, type, title, and code from here instead of deriving strings at runtime, so the contract cannot
- * drift when a human-readable title is edited.
- *
- * @property slug URL-safe identifier; the [type] URI is [BASE_URI] + slug.
- * @property status HTTP status returned for this condition.
- * @property code machine-readable, SCREAMING_SNAKE code consumers branch on without parsing messages.
- * @property title short human-readable summary.
- */
+// type URI and code are stable public API: GlobalExceptionHandler and IdempotencyFilter resolve them
+// from here so the contract cannot drift when a human-readable title changes.
 enum class ProblemType(
     val slug: String,
     val status: HttpStatus,

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/application/EntryCursor.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/application/EntryCursor.kt
@@ -7,7 +7,7 @@ import java.time.Instant
 import java.util.Base64
 import java.util.UUID
 
-// Opaque keyset cursor over (postedAt, id). The wire form is base64url; clients must treat it as opaque.
+// Wire form is base64url; clients must treat it as opaque and never construct it manually.
 data class EntryCursor(
     val postedAt: Instant,
     val id: UUID,

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/AccountBalanceKey.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/AccountBalanceKey.kt
@@ -8,7 +8,6 @@ import jakarta.persistence.Embeddable
 import java.io.Serializable
 import java.util.UUID
 
-// Composite key mirrors the PK (account_id, currency) on ledger.account_balances.
 @Embeddable
 data class AccountBalanceKey(
     @Column(name = "account_id", nullable = false, updatable = false)

--- a/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/EntryKey.kt
+++ b/services/ledger/src/main/kotlin/com/fincore/ledger/infrastructure/persistence/EntryKey.kt
@@ -9,7 +9,6 @@ import java.io.Serializable
 import java.time.Instant
 import java.util.UUID
 
-// Composite key mirrors the partitioned PK (id, created_at) on ledger.entries.
 @Embeddable
 data class EntryKey(
     @Column(name = "id", nullable = false, updatable = false)

--- a/services/ledger/src/test/kotlin/com/fincore/ledger/api/mapper/LedgerApiMapperTest.kt
+++ b/services/ledger/src/test/kotlin/com/fincore/ledger/api/mapper/LedgerApiMapperTest.kt
@@ -63,8 +63,8 @@ class LedgerApiMapperTest {
 
     @Test
     fun `should parse entry account ids and keep signed amounts when mapping a post command`() {
-        val a = AccountId.generate()
-        val b = AccountId.generate()
+        val debitAccount = AccountId.generate()
+        val creditAccount = AccountId.generate()
         val request =
             PostTransactionRequest(
                 reference = "ref-1",
@@ -72,8 +72,8 @@ class LedgerApiMapperTest {
                 currency = "EUR",
                 entries =
                     listOf(
-                        EntryLineRequest(a.toString(), EntryDirection.DEBIT, BigDecimal("100.00")),
-                        EntryLineRequest(b.toString(), EntryDirection.CREDIT, BigDecimal("-100.00")),
+                        EntryLineRequest(debitAccount.toString(), EntryDirection.DEBIT, BigDecimal("100.00")),
+                        EntryLineRequest(creditAccount.toString(), EntryDirection.CREDIT, BigDecimal("-100.00")),
                     ),
             )
 
@@ -83,9 +83,9 @@ class LedgerApiMapperTest {
         command.actor shouldBe "user-1"
         command.correlationId shouldBe "corr-1"
         command.requestHash shouldBe "hash-2"
-        command.entries[0].accountId shouldBe a
+        command.entries[0].accountId shouldBe debitAccount
         command.entries[0].amount.compareTo(BigDecimal("100.00")) shouldBe 0
-        command.entries[1].accountId shouldBe b
+        command.entries[1].accountId shouldBe creditAccount
         command.entries[1].amount.compareTo(BigDecimal("-100.00")) shouldBe 0
     }
 


### PR DESCRIPTION
Full code-quality pass requested by the owner, covering comments, naming, and structure.

## Findings
- **Structure is already correct.** Every service keeps clean hexagonal layers (thin controllers with no `@Transactional`, interface + impl services, DTOs split into request/response, enums under `domain/enum`, repositories in `infrastructure`). Nothing to change.
- **Production naming is already clean.** No cryptic one or two letter names in main code. The only offenders were a few single-letter locals in tests, now renamed (`c`/`s`/`a` to `case`/`session`/`alert`, and `a`/`b` to `debitAccount`/`creditAccount`).

## Comment changes (balanced bar)
- **Cut** docstrings that restated adjacent code, the sandbox provider doc blocks first (the marker-to-result narration the `when` block already shows), plus a handful of restating one-liners.
- **Trimmed** verbose blocks to the non-obvious why.
- **Kept** comments carrying a real invariant: transaction-boundary rules, fail-closed and constant-time security notes, concurrency and optimistic-lock semantics, MapStruct limitations, privacy/opaque-token notes, and the public plug-in port contracts (KycProvider, SanctionsProvider, AmlCopilot, BankProvider and their types), which document the adapter API for OSS adopters and back PROVIDERS.md.

17 files, comments and test names only, no behavior change. Verified: all four services compile; compliance/ledger/decision unit tests green (466 total); spotless and detekt clean. Integration tests run on CI (need Docker).