### PR TITLE
feat(web): demo-data notice on the sandbox overview

### DIFF
--- a/web/src/routes/Overview.tsx
+++ b/web/src/routes/Overview.tsx
@@ -10,21 +10,54 @@ import { TryTheApi } from '@/features/overview/TryTheApi'
 import { getOverview } from '@/mock/overview'
 
 export function Overview() {
-  const data = getOverview()
-  return (
-    <Shell activeNav="Overview" topBar={<OverviewTopBar status={data.status} services={data.services} />}>
-      <div className="flex flex-col gap-[18px] px-6 pb-8 pt-6">
-        <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
-          {data.kpis.map((kpi) => (
-            <Kpi key={kpi.label} datum={kpi} />
-          ))}
-        </div>
-        <div className="grid grid-cols-1 gap-[18px] lg:grid-cols-2">
-          <ActivityFeed activity={data.activity} />
-          <TryTheApi examples={data.apiExamples} />
-        </div>
-        <SystemLinks links={data.systemLinks} />
-      </div>
-    </Shell>
-  )
+    const data = getOverview()
+    return (
+        <Shell
+            activeNav="Overview"
+            topBar={<OverviewTopBar status={data.status} services={data.services} />}
+        >
+            <div className="flex flex-col gap-[18px] px-6 pb-8 pt-6">
+                <div
+                    role="note"
+                    style={{
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: 10,
+                        padding: '10px 14px',
+                        borderRadius: 10,
+                        border: '1px solid var(--amber)',
+                        background: 'var(--surface)',
+                        fontSize: 12.5,
+                        color: 'var(--text-2)',
+                    }}
+                >
+                    <span
+                        style={{
+                            width: 7,
+                            height: 7,
+                            borderRadius: '50%',
+                            background: 'var(--amber)',
+                            flexShrink: 0,
+                        }}
+                    />
+                    <span>
+                        <strong style={{ color: 'var(--text)' }}>Demo overview.</strong> FinCore is
+                        fully functional and serves a live API; the other screens read real data.
+                        The headline metrics and activity feed on this landing page are sample
+                        values for demonstration, not a live feed.
+                    </span>
+                </div>
+                <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-4">
+                    {data.kpis.map((kpi) => (
+                        <Kpi key={kpi.label} datum={kpi} />
+                    ))}
+                </div>
+                <div className="grid grid-cols-1 gap-[18px] lg:grid-cols-2">
+                    <ActivityFeed activity={data.activity} />
+                    <TryTheApi examples={data.apiExamples} />
+                </div>
+                <SystemLinks links={data.systemLinks} />
+            </div>
+        </Shell>
+    )
 }


### PR DESCRIPTION
Adds a visible notice to the overview landing clarifying that FinCore is fully functional and serves a live API, while the headline metrics and activity feed on this landing page are sample values (centralized in web/src/mock/overview.ts), not a live feed. Verified: tsc clean, Overview test passes.